### PR TITLE
Add support for nightly indexing (resolves #50)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,4 @@ gem 'dotenv-rails', groups: [:development, :test]
 
 gem 'activejob-traffic_control', '>= 0.1.3'
 gem 'sidekiq'
+gem 'sidekiq-cron'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
       faraday
       multi_json
     erubis (2.7.0)
+    et-orbi (1.0.4)
+      tzinfo
     execjs (2.7.0)
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
@@ -194,6 +196,8 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    rufus-scheduler (3.4.2)
+      et-orbi (~> 1.0)
     sass (3.4.22)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -213,6 +217,9 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (~> 3.3, >= 3.3.3)
+    sidekiq-cron (0.6.0)
+      rufus-scheduler (>= 3.3.0)
+      sidekiq (>= 4.2.1)
     spawnling (2.1.6)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
@@ -281,6 +288,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   searchkick
   sidekiq
+  sidekiq-cron
   spawnling (~> 2.1)
   therubyracer
   turbolinks

--- a/README.md
+++ b/README.md
@@ -51,15 +51,18 @@ Follow the instructions in the searchkick docs for setting up Elasticsearch loca
 Indexing is performed in the background by Sidekiq. You can run Sidekiq as follows:
 
 ```bash
-bundle exec sidekiq -q searchkick -q default -c 32
+bundle exec sidekiq -C config/sidekiq.yml
 ```
-
-Where `q` denotes the queues we pull from (`searchkick` is the one that matters)
-and `-c` denotes the number of threads. You can of course modify this
-value for yourself.
 
 Note that with about 32 concurrent workers, it should take roughly 8 hours to
 fully reindex.
+
+It's also worth noting that we run a background job every ten seconds to
+handle batch reindexing. This is important because it optimizes queries using
+ActiveRecord's `includes` functionality. Refer to the Study model's
+`search_import` scope for more details.
+
+Scheduled jobs can be configured in `./config/schedule.yml`.
 
 A full reindex can be performed by running:
 

--- a/app/models/reindexes_study.rb
+++ b/app/models/reindexes_study.rb
@@ -3,6 +3,6 @@ class ReindexesStudy < ActiveRecord::Base
   after_save :reindex_study
   belongs_to :study, :foreign_key => 'nct_id'
   def reindex_study
-    study.reindex_async
+    study.enqueue_reindex_job
   end
 end

--- a/app/workers/aact_sync.rb
+++ b/app/workers/aact_sync.rb
@@ -1,0 +1,7 @@
+class AactSync
+  include Sidekiq::Worker
+
+  def perform(opts)
+    Study.enqueue_reindex_job(Study.where('updated_at > ?', opts.fetch('days_ago', 1).to_i.days.ago))
+  end
+end

--- a/app/workers/process_queue_job.rb
+++ b/app/workers/process_queue_job.rb
@@ -1,0 +1,5 @@
+class ProcessQueueJob < Searchkick::ProcessQueueJob
+  def perform(opts)
+    Searchkick::ProcessQueueJob.perform_later(class_name: opts["class_name"])
+  end
+end

--- a/config/initializers/searchkick.rb
+++ b/config/initializers/searchkick.rb
@@ -6,7 +6,6 @@ class Searchkick::BulkReindexJob
   concurrency 8
 end
 
-
 module Searchkick
   class Index
     # monkey-patch full_reindex_async because of bad primary key assumptions

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,5 @@
+schedule_file = "config/schedule.yml"
+
+if File.exists?(schedule_file) && Sidekiq.server?
+  Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,0 +1,11 @@
+aact_sync:
+  cron: "0 0 * * *"
+  class: "AactSync"
+  queue: default
+
+searchkick_study_queue:
+  cron: "*/10 * * * * *" # every 30 seconds
+  class: "ProcessQueueJob"
+  queue: searchkick
+  args:
+    class_name: "Study"


### PR DESCRIPTION
* Adds sidekiq cron functionality
* Improves reindexing by implementing a batch background indexer.
  This makes queries against all tables in in batches of ids,
  using fewer queries and less time in total for all queries.
* Add tooling for synchronizing with AACT over N previous days
* Add sidekiq cron worker to reindex nightly over the last day