### PR TITLE
Fix date format

### DIFF
--- a/app/graphql/types/date_time_type.rb
+++ b/app/graphql/types/date_time_type.rb
@@ -9,13 +9,13 @@ module Types
     # @param value [DateTime]
     # @return [String]
     def self.coerce_result(value, _ctx)
-      value&.to_datetime&.utc&.iso8601
+      value&.to_datetime&.utc&.to_s(:month_day_year)
     end
 
     # @param str_value [String]
     # @return [DateTime]
     def self.coerce_input(str_value, _ctx)
-      DateTime.iso8601(str_value)
+      DateTime.parse(str_value)
     rescue ArgumentError
       # Invalid input
       nil

--- a/app/graphql/types/date_time_type.rb
+++ b/app/graphql/types/date_time_type.rb
@@ -9,16 +9,22 @@ module Types
     # @param value [DateTime]
     # @return [String]
     def self.coerce_result(value, _ctx)
+      # Format as mm/dd/yyyy
       value&.to_datetime&.utc&.to_s(:month_day_year)
     end
 
     # @param str_value [String]
     # @return [DateTime]
     def self.coerce_input(str_value, _ctx)
-      DateTime.parse(str_value)
+      # Try parse mm/dd/yyyy first
+      DateTime.strptime(date, Time::DATE_FORMATS[:month_day_year])
     rescue ArgumentError
-      # Invalid input
-      nil
+      begin
+        DateTime.parse(str_value)
+      rescue ArgumentError
+        # Invalid input
+        nil
+      end
     end
   end
 end

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:month_day_year] = '%m/%d/%Y'


### PR DESCRIPTION
This is just a stopgap for #184, because right now apollo-client has no way to serialize custom scalars. I had hoped to find a client alternative to https://github.com/apollographql/graphql-tools/blob/master/docs/source/scalars.md#date-as-a-scalar, but there is none.

Ideally they will implement it before we need to make a better solution, but I'm not holding my breath because the issue has been open since 2016 (see: https://github.com/apollographql/apollo-client/issues/585, further discussion at: https://github.com/apollographql/apollo-feature-requests/issues/2).

If not, there are some unofficial alternatives to look into such as https://github.com/cult-of-coders/apollo-client-transformers.