### PR TITLE
Site view graphql

### DIFF
--- a/app/graphql/mutations/copy_site_view.rb
+++ b/app/graphql/mutations/copy_site_view.rb
@@ -1,0 +1,38 @@
+module Mutations
+  class CopySiteView < BaseMutation
+    field :site_view, Types::SiteViewType, null: true
+    field :errors, [String], null: true
+
+    argument :name, String, required: true
+    argument :url, String, required: false
+    argument :description, String, required: false
+    argument :default, Boolean, required: true
+    argument :site_id, Integer, required: true
+    argument :site_view_id, Integer, required: true
+
+    def resolve(args)
+      site = Site.find_by(id: args[:site_id])
+      if site.nil?
+        return   { site_view: nil, errors: ["Site not found"] }
+      end
+      original_view = site.site_views.find_by(id: args[:site_view_id] )
+      view = site.site_views.new(name:args[:name], default: args[:default], url: args[:url], description: args[:description], updates:original_view.updates)
+      if view.save
+        { site_view: view, errors: nil }
+      else
+        { site_view: nil, errors: view.errors.full_messages }
+      end
+    end
+
+    def authorized?(args)
+      site = Site.find_by(id: args[:site_id])
+      return false if site.blank?
+
+      current_user.present? && (
+        current_user.has_role?(:admin) ||
+        current_user.has_role?(:site_owner, site) ||
+        current_user.has_role?(:site_editor, site)
+      )
+    end
+  end
+end

--- a/app/graphql/mutations/copy_site_view.rb
+++ b/app/graphql/mutations/copy_site_view.rb
@@ -16,7 +16,8 @@ module Mutations
         return   { site_view: nil, errors: ["Site not found"] }
       end
       original_view = site.site_views.find_by(id: args[:site_view_id] )
-      view = site.site_views.new(name:args[:name], default: args[:default], url: args[:url], description: args[:description], updates:original_view.updates)
+      view = site.site_views.new(updates:original_view.updates)
+      view.attributes = args.slice(:name,:url,:description,:default)
       if view.save
         { site_view: view, errors: nil }
       else

--- a/app/graphql/mutations/update_site_view.rb
+++ b/app/graphql/mutations/update_site_view.rb
@@ -12,7 +12,7 @@ module Mutations
 
     def resolve(args)
       view = site_view(args[:id])
-      view.attributes = {name:args[:name], default: args[:default], url: args[:url], description: args[:description]}
+      view.attributes = args.slice(:name,:url,:description,:default)
       mutations = args[:mutations].clone.map do |mutation|
         begin
           mutation[:payload] = JSON.parse(mutation[:payload])

--- a/app/models/site_view.rb
+++ b/app/models/site_view.rb
@@ -8,6 +8,9 @@ class SiteView < ApplicationRecord # rubocop:disable Metrics/ClassLength
     end
   end
 
+  validates :url, uniqueness: { scope: :site }
+
+
   class << self
     def default
       new(id: 0, updates: [])


### PR DESCRIPTION
Added endpoint to copy site view updates to a new site view. Also fixed issue with default being false in updates endpoint cause database errors because can not be null. 
The validates url uniqueness prevents the same site from have siteviews with the same path