### PR TITLE
cast front matter to specific types for better queryability

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "gitblame.commitUrl": "https://github.com/clinwiki-org/clinwiki/commit/${hash}"
+  "gitblame.commitUrl": "https://github.com/clinwiki-org/clinwiki/commit/${hash}",
+  "ruby.specCommand": "docker exec -it clinwiki bundle exec rspec"
 }

--- a/Gemfile
+++ b/Gemfile
@@ -95,3 +95,5 @@ gem "faraday"
 
 gem "activerecord-import", "~> 1.0"
 gem "composite_primary_keys"
+
+gem "timeliness", "~> 0.4.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,6 +343,7 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
+    timeliness (0.4.4)
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -423,6 +424,7 @@ DEPENDENCIES
   sidekiq-cron
   solargraph
   spawnling (~> 2.1)
+  timeliness (~> 0.4.4)
   turbolinks
   uglifier (>= 1.3.0)
   web-console

--- a/app/helpers/front_matter_helper.rb
+++ b/app/helpers/front_matter_helper.rb
@@ -49,10 +49,28 @@ module FrontMatterHelper
       front_matter_keys: front_matter.keys,
     }
     front_matter.each do |key, val|
-      result["fm_#{key}"] = val.is_a?(String) ? val.split("|") : val
+      result["fm_#{key}"] = cast(val)
     end
 
     result
+  end
+
+  def cast(val)
+    begin
+      return Integer(val)
+    rescue ArgumentError
+    end
+
+    begin
+      return Float(val)
+    rescue ArgumentError
+    end
+
+    parsed_time = Timeliness.parse(val)
+    return parsed_time unless parsed_time.nil?
+
+    # default to string, which we split against pipe separator
+    return val.split("|")
   end
 
   def combined_markdown(content, front_matter = {})

--- a/spec/helpers/front_matter_helper_spec.rb
+++ b/spec/helpers/front_matter_helper_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+describe FrontMatterHelper do
+
+  let(:helper) { Class.new do; include FrontMatterHelper; end.new }
+
+  describe "#cast" do
+
+    it "splits pipe-separated strings" do
+      expect(helper.cast("a")).to eql(["a"])
+      expect(helper.cast("a|b")).to eql(["a", "b"])
+    end
+
+    it "identifies integers" do
+      expect(helper.cast("1")).to eql(1)
+    end
+
+    it "identifies floats" do
+      expect(helper.cast("123.45")).to eql(123.45)
+    end
+
+    it "identifies common date formats" do
+      expect(helper.cast("2019-01-01")).to eql(Date.new(2019, 1, 1).to_time)
+      expect(helper.cast("05 May 2020")).to eql(Date.new(2020, 5, 5).to_time)
+      expect(helper.cast("9/9/99")).to eql(Date.new(1999, 9, 9).to_time)
+    end
+
+  end
+
+end


### PR DESCRIPTION
Elasticsearch seems to do a pretty good job inferring types for fields, even with a dynamic schema.

This change introduces a heuristic for determining whether a given front matter field is a particular non-string type (float, int, datetime), and then makes sure that the value is indexed as that scalar.

I was able to test this behavior, and it looks pretty good. I'm also able to implement range queries that respect date and integer values.

This introduces the [timeliness](https://github.com/adzap/timeliness) gem for fast parsing of strings into dates.