### PR TITLE
Agg bucket and crowd agg bucket option to return all skipping visible…

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -14,6 +14,7 @@ module Types
       argument :params, type: SearchInputType, required: false
       argument :url, type: String, required: false
       argument :config_type, String, required: false
+      argument :return_all, Boolean, required:false
     end
 
     field :autocomplete, SearchResultSetType, null: false do
@@ -28,6 +29,7 @@ module Types
       argument :params, type: SearchInputType, required: true
       argument :url, type: String, required: false
       argument :config_type, String, required: false
+      argument :return_all, Boolean, required:false
     end
 
     field :crowd_agg_facets, SearchResultSetType, null: false do
@@ -74,19 +76,19 @@ module Types
       search_service.search
     end
 
-    def agg_buckets(search_hash: nil, params: nil, url: nil, config_type: nil)
+    def agg_buckets(search_hash: nil, params: nil, url: nil, config_type: nil, return_all: nil)
       params = fetch_and_merge_search_params(search_hash: search_hash, params: params)
       search_service = SearchService.new(params)
       Hashie::Mash.new(
-        aggs: search_service.agg_buckets_for_field(field: params[:agg], current_site: context[:current_site],url: url, config_type: config_type),
+        aggs: search_service.agg_buckets_for_field(field: params[:agg], current_site: context[:current_site],url: url, config_type: config_type, return_all: return_all),
       )
     end
 
-    def crowd_agg_buckets(search_hash: nil, params: nil, url: nil,config_type: nil)
+    def crowd_agg_buckets(search_hash: nil, params: nil, url: nil,config_type: nil, return_all: nil)
       params = fetch_and_merge_search_params(search_hash: search_hash, params: params)
       search_service = SearchService.new(params)
       Hashie::Mash.new(
-        aggs: search_service.agg_buckets_for_field(field: params[:agg], current_site: context[:current_site], is_crowd_agg: true, url: url, config_type: config_type),
+        aggs: search_service.agg_buckets_for_field(field: params[:agg], current_site: context[:current_site], is_crowd_agg: true, url: url, config_type: config_type,return_all: return_all),
       )
     end
 


### PR DESCRIPTION
… options. Used in config to see all the options to be able to choose from. Previously if the current site based on domain had changes to the default visible options the list would get shorter, this should still show the whole list incase the user wants to add another visible option once they already have one