### PR TITLE
Public user type for user query, only first and last name

### DIFF
--- a/app/graphql/types/public_user_type.rb
+++ b/app/graphql/types/public_user_type.rb
@@ -1,0 +1,7 @@
+module Types
+  class PublicUserType < BaseObject
+    field :id, Int, "Id", null: false
+    field :first_name, String, "First name", null: true
+    field :last_name, String, "Last name", null: true
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -60,7 +60,7 @@ module Types
     field :search_params, SearchParamsType, "Search params from hash", null: true do
       argument :hash, type: String, required: false
     end
-    field :user, UserType, "Public Profile User", null:false do
+    field :user, PublicUserType, "Public Profile User", null:false do
       argument :user_id, type: Integer, required: true
     end
 


### PR DESCRIPTION
Public user type to restrict data the query can get back for public profiles