### PR TITLE
RTM resolves issue #415 and #414 

### DIFF
--- a/front/app/containers/App/App.tsx
+++ b/front/app/containers/App/App.tsx
@@ -49,15 +49,10 @@ class App extends React.PureComponent<AppProps> {
             <Route exact path="/" component={LandingPage} />
             <Route exact path="/about" component={AboutPage} />
             <Route exact path="/version" component={ReleaseNotes} />
-            {/* <Redirect exact from="/search/" to="/search/default" /> */}
             <Route
               path="/search/"
               component={SearchPage}
             />
-            {/* <Route
-              path="/search/:siteviewUrl/:searchId"
-              component={SearchPage}
-            /> */}
             <Route path="/search/:siteviewUrl" component={SearchPage} />
             <Route
               path="/study/:nctId/review/:reviewId/edit"

--- a/front/app/containers/BulkEditPage/BulkEditPage.tsx
+++ b/front/app/containers/BulkEditPage/BulkEditPage.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { match } from 'react-router';
+import { History } from 'history';
 import { WorkflowsViewFragment } from 'types/WorkflowsViewFragment';
 import { WorkflowConfigFragment } from 'types/WorkflowConfigFragment';
 import { displayFields } from 'utils/siteViewHelpers';
@@ -170,6 +171,7 @@ const groupBucketsByLabel = ({ data, labels }) =>
 
 interface BulkEditProps {
   match: match<{ searchId?: string }>;
+  history:History;
 }
 interface BulkEditState {
   undoHistory: any[];
@@ -197,10 +199,8 @@ class BulkEditPage extends React.PureComponent<BulkEditProps, BulkEditState> {
           workflow.suggestedLabelsFilter.values,
           workflow.allSuggestedLabels.map(name => ({ name, rank: null }))
         ).map(prop('name'));
-    const hash = path(['match', 'params', 'searchId'], this.props) as
-      | string
-      | null;
 
+        const hash = new URLSearchParams(this.props.history.location.search).getAll("hash").toString() as |string |null;
     return (
       <Query query={SearchPageParamsQuery} variables={{ hash }}>
         {queryParams => {

--- a/front/app/containers/SearchPage/SearchPage.tsx
+++ b/front/app/containers/SearchPage/SearchPage.tsx
@@ -484,7 +484,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
   renderSearch = () => {
     const hash = this.getHashFromLocation();
     const { currentSiteView } = this.props;
-    console.log("Hash", hash, currentSiteView)
     return (
       <ParamsQueryComponent
         key={`${hash}+${JSON.stringify(this.state?.params)}`}
@@ -591,7 +590,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
 
   getHashFromLocation(): string | null {
     let hash = new URLSearchParams(this.props.history.location.search).getAll("hash")
-    // console.log("Correct Hash", hash)
     return hash.toString();
   }
 
@@ -613,15 +611,11 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     const variables = { ...this.state.params, ...params };
     const { data } = await this.props.mutate({ variables });
     const siteViewUrl = new URLSearchParams(this.props.history.location.search).getAll("sv").toString() || 'default';
-    // console.log("SV", siteViewUrl)
     if (data?.provisionSearchHash?.searchHash?.short) {
       console.log("pushing")
       this.props.history.push(
         `/search?hash=${data!.provisionSearchHash!.searchHash!.short}&sv=${siteViewUrl}`
       );
-      // this.props.history.push(
-      //   `/search/${siteViewUrl}/${data!.provisionSearchHash!.searchHash!.short}`
-      // );
     }
   };
 
@@ -677,7 +671,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
             href={
               `/search?hash=${hash}&sv=${presearchButton.target}`
             }>
-            {/* href={`/search/${presearchButton.target}/${hash}`}> */}
             {presearchButton.name}
           </Button>
         )}

--- a/front/app/containers/WorkflowPage/WorkflowPage.tsx
+++ b/front/app/containers/WorkflowPage/WorkflowPage.tsx
@@ -185,6 +185,8 @@ class WorkflowPage extends React.Component<
   };
 
   render() {
+    const hash = new URLSearchParams(this.props.history.location.search).getAll("hash").toString() as |string |null;
+
     return (
       <WorkflowsViewProvider>
         {workflowsView => (
@@ -260,7 +262,7 @@ class WorkflowPage extends React.Component<
                                     <SuggestedLabels
                                       nctId={this.props.match.params.nctId}
                                       searchHash={
-                                        this.props.match.params.searchId || null
+                                        hash
                                       }
                                       onSelect={this.handleSelect(
                                         (data &&


### PR DESCRIPTION
Both WorkflowPage and BulkEditPage previously read the hash from math.params, but with new routing no longer the case. This makes necessary updates to correctly read hash.