### PR TITLE
166 wiki history ui

### DIFF
--- a/front/app/components/Edits/Edit.tsx
+++ b/front/app/components/Edits/Edit.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { Row, Col } from 'react-bootstrap';
+import {
+  WikiPageEditFragment,
+} from 'types/WikiPageEditFragment';
+import EditBlurb from "./EditBlurb";
+import ExpandedEdit from "./ExpandedEdit";
+
+interface EditProps {
+  edit: WikiPageEditFragment;
+}
+
+interface EditState {
+  expanded: boolean
+}
+
+class Edit extends React.Component<EditProps, EditState> {
+
+  state = {
+    expanded: false
+  }
+
+  setExpanded = (expanded) => this.setState({ ...this.state, expanded })
+
+  render() {
+    const { edit } = this.props;
+    const { expanded } = this.state;
+    return (
+      <tr key={edit.id} style={{ padding: '10px' }}>
+        <td>
+          <EditBlurb edit={edit} expanded={expanded} setExpanded={this.setExpanded} />
+          {expanded && (
+            <Row style={{ padding: '10px', marginBottom: '10px' }}>
+              <Col md={12}>
+                <ExpandedEdit edit={edit} />
+              </Col>
+            </Row>
+          )}
+        </td>
+      </tr>
+    )
+  }
+}
+
+export default Edit;

--- a/front/app/components/Edits/Edit.tsx
+++ b/front/app/components/Edits/Edit.tsx
@@ -1,26 +1,23 @@
-import * as React from "react";
+import * as React from 'react';
 import { Row, Col } from 'react-bootstrap';
-import {
-  WikiPageEditFragment,
-} from 'types/WikiPageEditFragment';
-import EditBlurb from "./EditBlurb";
-import ExpandedEdit from "./ExpandedEdit";
+import { WikiPageEditFragment } from 'types/WikiPageEditFragment';
+import EditBlurb from './EditBlurb';
+import ExpandedEdit from './ExpandedEdit';
 
 interface EditProps {
   edit: WikiPageEditFragment;
 }
 
 interface EditState {
-  expanded: boolean
+  expanded: boolean;
 }
 
 class Edit extends React.Component<EditProps, EditState> {
-
   state = {
-    expanded: false
-  }
+    expanded: false,
+  };
 
-  setExpanded = (expanded) => this.setState({ ...this.state, expanded })
+  setExpanded = expanded => this.setState({ ...this.state, expanded });
 
   render() {
     const { edit } = this.props;
@@ -28,7 +25,11 @@ class Edit extends React.Component<EditProps, EditState> {
     return (
       <tr key={edit.id} style={{ padding: '10px' }}>
         <td>
-          <EditBlurb edit={edit} expanded={expanded} setExpanded={this.setExpanded} />
+          <EditBlurb
+            edit={edit}
+            expanded={expanded}
+            setExpanded={this.setExpanded}
+          />
           {expanded && (
             <Row style={{ padding: '10px', marginBottom: '10px' }}>
               <Col md={12}>
@@ -38,7 +39,7 @@ class Edit extends React.Component<EditProps, EditState> {
           )}
         </td>
       </tr>
-    )
+    );
   }
 }
 

--- a/front/app/components/Edits/EditBlurb.tsx
+++ b/front/app/components/Edits/EditBlurb.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import { Row, Col, Table, Button } from 'react-bootstrap';
+import {
+  WikiPageEditFragment,
+  WikiPageEditFragment_user
+} from 'types/WikiPageEditFragment';
+
+interface EditBlurbProps {
+  edit: WikiPageEditFragment;
+  expanded: boolean;
+  setExpanded: any;
+}
+
+class EditBlurb extends React.Component<EditBlurbProps> {
+
+  getUserIdentity() {
+    const { edit: { user } } = this.props;
+    if (!user) {
+      return 'Anonymous';
+    }
+    if (user.firstName) {
+      return `${user.firstName} ${user.lastName && user.lastName[0]}`;
+    }
+    return user.email;
+  }
+
+  getBlurb() {
+    const { edit: { changeSet: { bodyChanged, frontMatterChanged } } } = this.props;
+    if (bodyChanged && frontMatterChanged) {
+      return "made the first edit."
+    }
+    if (frontMatterChanged) {
+      return "made a crowd data change.";
+    }
+    return "updated the wiki."
+  }
+
+  render() {
+    const { edit, expanded, setExpanded } = this.props;
+    return (
+      <Row style={{ marginBottom: '10px', padding: '10px' }}>
+        <Col md={8}>
+          <span className="diff-actor">
+            {this.getUserIdentity()}
+          </span>
+          <span>
+            {' ' + this.getBlurb()}
+          </span>
+        </Col>
+        <Col md={2}>
+          <small>
+            {new Date(edit.createdAt).toLocaleDateString('en-US')}
+          </small>
+        </Col>
+        <Col md={2} className="text-right">
+          {expanded && (<Button onClick={() => setExpanded(false)}>View Less</Button>)}
+          {!expanded && (<Button onClick={() => setExpanded(true)}>View More</Button>)}
+        </Col>
+      </Row>
+    )
+  }
+}
+
+export default EditBlurb;

--- a/front/app/components/Edits/Edits.tsx
+++ b/front/app/components/Edits/Edits.tsx
@@ -1,57 +1,23 @@
 import * as React from 'react';
-import styled from 'styled-components';
-import { WikiPageQuery } from 'types/WikiPageQuery';
-import { Row, Col, Table } from 'react-bootstrap';
 import {
   WikiPageEditFragment,
-  WikiPageEditFragment_user,
 } from 'types/WikiPageEditFragment';
-import { gql } from 'apollo-boost';
 import StyleWrapper from "./StyleWrapper";
+import Edit from "./Edit";
+
 
 interface EditsProps {
   edits: WikiPageEditFragment[];
 }
 
-class Edits extends React.PureComponent<EditsProps> {
-  getName = (user: WikiPageEditFragment_user | null) => {
-    if (!user) return 'Anonymous';
-    if (user.firstName) {
-      return `${user.firstName} ${user.lastName && user.lastName[0]}`;
-    }
-    return user.email;
-  };
-
+class Edits extends React.Component<EditsProps> {
   render() {
+    const { edits } = this.props
     return (
       <StyleWrapper striped bordered>
         <tbody>
-          {this.props.edits.map(edit => (
-            <tr key={edit.id} style={{ padding: '10px' }}>
-              <td>
-                <Row style={{ marginBottom: '10px', padding: '10px' }}>
-                  <Col md={6}>
-                    <b>{this.getName(edit.user)}</b>
-                    <br />
-                  </Col>
-                  <Col md={4}>{edit.comment}</Col>
-                  <Col md={2} className="text-right">
-                    <small>
-                      {new Date(edit.createdAt).toLocaleDateString('en-US')}
-                    </small>
-                  </Col>
-                </Row>
-                <Row style={{ padding: '10px', marginBottom: '10px' }}>
-                  <Col md={12}>
-                    <div
-                      dangerouslySetInnerHTML={{
-                        __html: edit.diffHtml || '<p></p>',
-                      }}
-                    />
-                  </Col>
-                </Row>
-              </td>
-            </tr>
+          {edits.map((edit, i) => (
+            <Edit key={i} edit={edit} />
           ))}
         </tbody>
       </StyleWrapper>

--- a/front/app/components/Edits/Edits.tsx
+++ b/front/app/components/Edits/Edits.tsx
@@ -7,88 +7,13 @@ import {
   WikiPageEditFragment_user,
 } from 'types/WikiPageEditFragment';
 import { gql } from 'apollo-boost';
+import StyleWrapper from "./StyleWrapper";
 
 interface EditsProps {
   edits: WikiPageEditFragment[];
 }
 
-// these are the styles provided by diffy, btw
-const StyleWrapper = styled(Table)`
-  .diff {
-    overflow: auto;
-  }
-  .diff ul {
-    background: none;
-    overflow: auto;
-    font-size: 13px;
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: table;
-    width: 100%;
-  }
-  .diff del,
-  .diff ins {
-    display: block;
-    text-decoration: none;
-  }
-  .diff li {
-    padding: 0;
-    display: table-row;
-    margin: 0;
-    height: 1em;
-  }
-  .diff li.ins {
-    background: #dfd;
-    color: #080;
-  }
-  .diff li.del {
-    background: #fee;
-    color: #b00;
-  }
-  .diff li:hover {
-    background: #ffc;
-  }
-  /* try 'whitespace:pre;' if you don't want lines to wrap */
-  .diff del,
-  .diff ins,
-  .diff span {
-    white-space: pre-wrap;
-    font-family: courier;
-  }
-  .diff del strong {
-    font-weight: normal;
-    background: #fcc;
-  }
-  .diff ins strong {
-    font-weight: normal;
-    background: #9f9;
-  }
-  .diff li.diff-comment {
-    display: none;
-  }
-  .diff li.diff-block-info {
-    background: none repeat scroll 0 0 gray;
-  }
-`;
-
 class Edits extends React.PureComponent<EditsProps> {
-  static fragment = gql`
-    fragment WikiPageEditFragment on WikiPageEdit {
-      user {
-        id
-        firstName
-        lastName
-        email
-      }
-      createdAt
-      id
-      comment
-      diff
-      diffHtml
-    }
-  `;
-
   getName = (user: WikiPageEditFragment_user | null) => {
     if (!user) return 'Anonymous';
     if (user.firstName) {

--- a/front/app/components/Edits/ExpandedEdit/ExpandedAsRawDiff.tsx
+++ b/front/app/components/Edits/ExpandedEdit/ExpandedAsRawDiff.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+import {
+  WikiPageEditFragment,
+} from 'types/WikiPageEditFragment';
+
+interface EditProps {
+  edit: WikiPageEditFragment;
+}
+
+class ExpandedAsRawDiff extends React.Component<EditProps> {
+  render() {
+    const { edit } = this.props;
+    return (
+      <div
+        dangerouslySetInnerHTML={{
+          __html: edit.diffHtml || '<p></p>',
+        }}
+      />
+    )
+  }
+}
+
+export default ExpandedAsRawDiff;

--- a/front/app/components/Edits/ExpandedEdit/ExpandedEdit.tsx
+++ b/front/app/components/Edits/ExpandedEdit/ExpandedEdit.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import {
+  WikiPageEditFragment,
+} from 'types/WikiPageEditFragment';
+import ExpandedAsRawDiff from "./ExpandedAsRawDiff";
+import FrontMatterExpandedEdit from "./FrontMatterExpandedEdit";
+import WikiExpandedEdit from "./WikiExpandedEdit";
+
+interface EditProps {
+  edit: WikiPageEditFragment;
+}
+
+class ExpandedEdit extends React.Component<EditProps> {
+  render() {
+    const { edit } = this.props
+    const { changeSet: { bodyChanged, frontMatterChanged } } = edit;
+
+    console.log(edit.changeSet);
+
+    if (bodyChanged && frontMatterChanged) {
+      return <ExpandedAsRawDiff edit={edit} />;
+    }
+    if (frontMatterChanged) {
+      return <FrontMatterExpandedEdit edit={edit} />;
+    }
+
+    return <WikiExpandedEdit edit={edit} />;
+  }
+}
+
+export default ExpandedEdit;

--- a/front/app/components/Edits/ExpandedEdit/ExpandedEdit.tsx
+++ b/front/app/components/Edits/ExpandedEdit/ExpandedEdit.tsx
@@ -1,10 +1,8 @@
-import * as React from "react";
-import {
-  WikiPageEditFragment,
-} from 'types/WikiPageEditFragment';
-import ExpandedAsRawDiff from "./ExpandedAsRawDiff";
-import FrontMatterExpandedEdit from "./FrontMatterExpandedEdit";
-import WikiExpandedEdit from "./WikiExpandedEdit";
+import * as React from 'react';
+import { WikiPageEditFragment } from 'types/WikiPageEditFragment';
+import ExpandedAsRawDiff from './ExpandedAsRawDiff';
+import FrontMatterExpandedEdit from './FrontMatterExpandedEdit';
+import WikiExpandedEdit from './WikiExpandedEdit';
 
 interface EditProps {
   edit: WikiPageEditFragment;
@@ -12,8 +10,10 @@ interface EditProps {
 
 class ExpandedEdit extends React.Component<EditProps> {
   render() {
-    const { edit } = this.props
-    const { changeSet: { bodyChanged, frontMatterChanged } } = edit;
+    const { edit } = this.props;
+    const {
+      changeSet: { bodyChanged, frontMatterChanged },
+    } = edit;
 
     console.log(edit.changeSet);
 

--- a/front/app/components/Edits/ExpandedEdit/FrontMatterExpandedEdit.tsx
+++ b/front/app/components/Edits/ExpandedEdit/FrontMatterExpandedEdit.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-
+import { Row, Col, Table } from 'react-bootstrap';
 import { WikiPageEditFragment } from 'types/WikiPageEditFragment';
+import DeleteSiteMutation from 'mutations/DeleteSiteMutations';
 
 interface EditProps {
   edit: WikiPageEditFragment;
@@ -8,7 +9,52 @@ interface EditProps {
 
 class FrontMatterExpandedEdit extends React.Component<EditProps> {
   render() {
-    return null;
+    const {
+      edit: {
+        changeSet: { editLines },
+      },
+    } = this.props;
+    const fmLines = editLines.filter(({ frontMatter }) => frontMatter);
+    const inserts = fmLines.filter(({ status }) => status === 'INS');
+    const deletes = fmLines.filter(({ status }) => status === 'DEL');
+
+    const nodes: any[] = [];
+    // this only accommodates a single diff right now!
+    if (deletes.length > 0) {
+      const [fieldName, former] = deletes[0].content.split(/:(.+)/);
+      nodes.push(
+        <tr className="del">
+          <td>-</td>
+          <td>{fieldName}</td>
+          <td>{former}</td>
+        </tr>
+      );
+    }
+    if (inserts.length > 0) {
+      const [fieldName, current] = inserts[0].content.split(/:(.+)/);
+      nodes.push(
+        <tr className="ins">
+          <td>+</td>
+          <td>{fieldName}</td>
+          <td>{current}</td>
+        </tr>
+      );
+    }
+
+    return (
+      <Row>
+        <Col md={12}>
+          <Table className="crowd-diff">
+            <thead>
+              <th></th>
+              <th>Field</th>
+              <th>Value</th>
+            </thead>
+            <tbody>{nodes}</tbody>
+          </Table>
+        </Col>
+      </Row>
+    );
   }
 }
 

--- a/front/app/components/Edits/ExpandedEdit/FrontMatterExpandedEdit.tsx
+++ b/front/app/components/Edits/ExpandedEdit/FrontMatterExpandedEdit.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import {
+  WikiPageEditFragment,
+} from 'types/WikiPageEditFragment';
+
+interface EditProps {
+  edit: WikiPageEditFragment;
+}
+
+
+class FrontMatterExpandedEdit extends React.Component<EditProps> {
+  render() {
+    return null;
+  }
+}
+
+export default FrontMatterExpandedEdit;

--- a/front/app/components/Edits/ExpandedEdit/FrontMatterExpandedEdit.tsx
+++ b/front/app/components/Edits/ExpandedEdit/FrontMatterExpandedEdit.tsx
@@ -1,13 +1,10 @@
-import * as React from "react";
+import * as React from 'react';
 
-import {
-  WikiPageEditFragment,
-} from 'types/WikiPageEditFragment';
+import { WikiPageEditFragment } from 'types/WikiPageEditFragment';
 
 interface EditProps {
   edit: WikiPageEditFragment;
 }
-
 
 class FrontMatterExpandedEdit extends React.Component<EditProps> {
   render() {

--- a/front/app/components/Edits/ExpandedEdit/WikiExpandedEdit.tsx
+++ b/front/app/components/Edits/ExpandedEdit/WikiExpandedEdit.tsx
@@ -1,0 +1,122 @@
+import * as React from "react";
+import * as FontAwesome from "react-fontawesome";
+import { Row, Col } from 'react-bootstrap';
+
+import {
+  WikiPageEditFragment,
+} from 'types/WikiPageEditFragment';
+
+interface EditProps {
+  edit: WikiPageEditFragment;
+}
+
+interface EditState {
+  lineVisible: any;
+}
+
+class WikiExpandedEdit extends React.Component<EditProps, EditState> {
+  state = {
+    lineVisible: {}
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      lineVisible: this.prepareSpans()
+    }
+  }
+
+  /**
+   * Only show a line on either side for context
+   * by default for line-by-line change.
+   */
+  prepareSpans = () => {
+    const { edit } = this.props;
+    let lastWasChange = false;
+    const lineVisible = {};
+    edit.changeSet.editLines.forEach((line, i) => {
+      if (line.status !== "UNCHANGED") {
+        lineVisible[i - 1] = true;
+        lineVisible[i] = true;
+        lastWasChange = true;
+      } else if (lastWasChange) {
+        lineVisible[i] = true;
+        lastWasChange = false;
+      } else {
+        lineVisible[i] = false;
+      }
+    });
+    return lineVisible;
+  }
+
+  expandSpans = (start, end) => () => {
+    const lineVisibleUpdate = {};
+    for (let i = start; i <= end; i++) {
+      lineVisibleUpdate[i] = true;
+    }
+    this.setState({ lineVisible: { ...this.state.lineVisible, ...lineVisibleUpdate } });
+  }
+
+  render() {
+    const { edit: { changeSet: { editLines } } } = this.props;
+    const { lineVisible } = this.state
+    const nodes: any[] = [];
+    const actions: any[] = [];
+    let firstInvisible: number | null = null;
+    editLines.forEach((line, i) => {
+      if (line.frontMatter || line.content === "---") {
+        // skip front matter
+        return;
+      }
+      if (lineVisible[i]) {
+        if (firstInvisible !== null && i > firstInvisible) {
+          actions.push(
+            <li key={i - 1}>
+              <button className="diff-expander" onClick={this.expandSpans(firstInvisible, i - 1)}>
+                <FontAwesome name="arrows" />
+              </button>
+            </li>
+          );
+          nodes.push(<li key={i - 1} />)
+          firstInvisible = null;
+        }
+        actions.push(<li key={i} className={line.status.toLowerCase()} />)
+        nodes.push(<li key={i} className={line.status.toLowerCase()}>{line.content}</li>);
+      } else {
+        firstInvisible = firstInvisible || i;
+      }
+    });
+    if (firstInvisible !== null) {
+      actions.push(
+        <li key={editLines.length + 1}>
+          <button className="diff-expander" onClick={this.expandSpans(firstInvisible, editLines.length)}>
+            <FontAwesome name="arrows" />
+          </button>
+        </li >
+      );
+      nodes.push(
+        <li key={editLines.length + 1} />
+      )
+    }
+    return (
+      <Row>
+        <Col md={1}>
+          <div className="diff">
+            <ul>
+              {actions}
+            </ul>
+          </div>
+        </Col>
+        <Col md={11}>
+          <div className="diff">
+            <ul className="diff-lines">
+              {nodes}
+            </ul>
+          </div>
+        </Col>
+      </Row>
+    )
+  }
+}
+
+export default WikiExpandedEdit;

--- a/front/app/components/Edits/ExpandedEdit/index.tsx
+++ b/front/app/components/Edits/ExpandedEdit/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./ExpandedEdit";

--- a/front/app/components/Edits/StyleWrapper.tsx
+++ b/front/app/components/Edits/StyleWrapper.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from 'react';
 import styled from 'styled-components';
 import { Table } from 'react-bootstrap';
 
@@ -36,7 +36,8 @@ const StyleWrapper = styled(Table)`
     background: #fee;
     color: #b00;
   }
-  .diff li:hover {
+  .diff li:hover,
+  .diff li.hovered {
     background: #ffc;
   }
   /* try 'whitespace:pre;' if you don't want lines to wrap */
@@ -64,14 +65,24 @@ const StyleWrapper = styled(Table)`
     font-weight: bold;
   }
   .diff .fa {
-    font: normal normal normal 14px/1 FontAwesome;
+    font: normal normal normal 12px/1 FontAwesome;
   }
   .diff-lines li {
     white-space: pre-wrap;
     font-family: courier;
   }
   .diff li {
-    height: 18px;
+    height: 21px;
+    min-height: 21px;
+    max-height: 21px;
+  }
+  .diff-action-column {
+    font-size: 11px;
+    text-align: right;
+    padding-right: 0;
+  }
+  .diff-column {
+    padding-left: 0;
   }
 `;
 

--- a/front/app/components/Edits/StyleWrapper.tsx
+++ b/front/app/components/Edits/StyleWrapper.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+import styled from 'styled-components';
+import { Table } from 'react-bootstrap';
+
+// these are the styles provided by diffy, btw
+const StyleWrapper = styled(Table)`
+  .diff {
+    overflow: auto;
+  }
+  .diff ul {
+    background: none;
+    overflow: auto;
+    font-size: 13px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: table;
+    width: 100%;
+  }
+  .diff del,
+  .diff ins {
+    display: block;
+    text-decoration: none;
+  }
+  .diff li {
+    padding: 0;
+    display: table-row;
+    margin: 0;
+    height: 1em;
+  }
+  .diff li.ins {
+    background: #dfd;
+    color: #080;
+  }
+  .diff li.del {
+    background: #fee;
+    color: #b00;
+  }
+  .diff li:hover {
+    background: #ffc;
+  }
+  /* try 'whitespace:pre;' if you don't want lines to wrap */
+  .diff del,
+  .diff ins,
+  .diff span {
+    white-space: pre-wrap;
+    font-family: courier;
+  }
+  .diff del strong {
+    font-weight: normal;
+    background: #fcc;
+  }
+  .diff ins strong {
+    font-weight: normal;
+    background: #9f9;
+  }
+  .diff li.diff-comment {
+    display: none;
+  }
+  .diff li.diff-block-info {
+    background: none repeat scroll 0 0 gray;
+  }
+`;
+
+export default StyleWrapper;

--- a/front/app/components/Edits/StyleWrapper.tsx
+++ b/front/app/components/Edits/StyleWrapper.tsx
@@ -60,6 +60,19 @@ const StyleWrapper = styled(Table)`
   .diff li.diff-block-info {
     background: none repeat scroll 0 0 gray;
   }
+  .diff-actor {
+    font-weight: bold;
+  }
+  .diff .fa {
+    font: normal normal normal 14px/1 FontAwesome;
+  }
+  .diff-lines li {
+    white-space: pre-wrap;
+    font-family: courier;
+  }
+  .diff li {
+    height: 18px;
+  }
 `;
 
 export default StyleWrapper;

--- a/front/app/components/Edits/StyleWrapper.tsx
+++ b/front/app/components/Edits/StyleWrapper.tsx
@@ -28,16 +28,19 @@ const StyleWrapper = styled(Table)`
     margin: 0;
     height: 1em;
   }
-  .diff li.ins {
+  .diff li.ins,
+  .crowd-diff .ins td {
     background: #dfd;
     color: #080;
   }
-  .diff li.del {
+  .diff li.del,
+  .crowd-diff .del td {
     background: #fee;
     color: #b00;
   }
   .diff li:hover,
-  .diff li.hovered {
+  .diff li.hovered,
+  .crowd-diff tr:hover td {
     background: #ffc;
   }
   /* try 'whitespace:pre;' if you don't want lines to wrap */

--- a/front/app/components/Edits/WikiPageEditFragment.tsx
+++ b/front/app/components/Edits/WikiPageEditFragment.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import gql from "graphql-tag";
+import WikiPage from "containers/WikiPage";
+
+const WikiPageEditFragment = gql`
+  fragment WikiPageEditFragment on WikiPageEdit {
+    user {
+      id
+      firstName
+      lastName
+      email
+    }
+    createdAt
+    id
+    comment
+    diff
+    diffHtml
+    changeSet {
+      bodyChanged
+      frontMatterChanged
+      editLines {
+        status
+        content
+        frontMatter
+        body
+      }
+    }
+  }
+`;
+
+export default WikiPageEditFragment;

--- a/front/app/components/Edits/index.ts
+++ b/front/app/components/Edits/index.ts
@@ -1,1 +1,2 @@
-export { default } from './Edits';
+export { default } from "./Edits";
+export { default as WikiPageEditFragment } from "./WikiPageEditFragment";

--- a/front/app/containers/CrowdPage/CrowdPage.tsx
+++ b/front/app/containers/CrowdPage/CrowdPage.tsx
@@ -9,7 +9,7 @@ import Helmet from 'react-helmet';
 
 import LoadingPane from 'components/LoadingPane';
 import Error from 'components/Error';
-import Edits from 'components/Edits';
+import Edits, { WikiPageEditFragment } from 'components/Edits';
 import StudySummary from 'components/StudySummary';
 import ButtonCell from './ButtonCell';
 
@@ -23,7 +23,6 @@ import {
 } from 'types/CrowdPageDeleteWikiLabelMutation';
 import { CrowdPageQuery, CrowdPageQueryVariables } from 'types/CrowdPageQuery';
 
-import { WikiPageEditFragment } from 'types/WikiPageEditFragment';
 import WikiPage from 'containers/WikiPage';
 import {
   keys,
@@ -102,7 +101,7 @@ export const UPSERT_LABEL_MUTATION = gql`
   }
 
   ${FRAGMENT}
-  ${Edits.fragment}
+  ${WikiPageEditFragment}
 `;
 
 export const DELETE_LABEL_MUTATION = gql`
@@ -119,7 +118,7 @@ export const DELETE_LABEL_MUTATION = gql`
   }
 
   ${FRAGMENT}
-  ${Edits.fragment}
+  ${WikiPageEditFragment}
 `;
 
 const TableWrapper = styled(Table)`
@@ -131,7 +130,7 @@ const TableWrapper = styled(Table)`
 export class UpsertMutationComponent extends Mutation<
   CrowdPageUpsertWikiLabelMutation,
   CrowdPageUpsertWikiLabelMutationVariables
-> {}
+  > { }
 
 export type UpsertMutationFn = MutationFn<
   CrowdPageUpsertWikiLabelMutation,
@@ -141,14 +140,14 @@ export type UpsertMutationFn = MutationFn<
 export class DeleteMutationComponent extends Mutation<
   CrowdPageDeleteWikiLabelMutation,
   CrowdPageDeleteWikiLabelMutationVariables
-> {}
+  > { }
 
 export type DeleteMutationFn = MutationFn<
   CrowdPageDeleteWikiLabelMutation,
   CrowdPageDeleteWikiLabelMutationVariables
 >;
 
-class QueryComponent extends Query<CrowdPageQuery, CrowdPageQueryVariables> {}
+class QueryComponent extends Query<CrowdPageQuery, CrowdPageQueryVariables> { }
 
 class Crowd extends React.Component<CrowdProps, CrowdState> {
   state: CrowdState = {

--- a/front/app/containers/TagsPage/TagsPage.tsx
+++ b/front/app/containers/TagsPage/TagsPage.tsx
@@ -18,7 +18,7 @@ import {
 } from 'types/TagsPageDeleteWikiTagMutation';
 import WikiPage from 'containers/WikiPage';
 import { contains, reject, equals, lensPath } from 'ramda';
-import Edits from 'components/Edits';
+import Edits, { WikiPageEditFragment } from 'components/Edits';
 import CurrentUser from 'containers/CurrentUser';
 import { UserFragment } from 'types/UserFragment';
 import { SiteStudyBasicGenericSectionFragment } from 'types/SiteStudyBasicGenericSectionFragment';
@@ -86,7 +86,7 @@ const DELETE_TAG_MUTATION = gql`
   }
 
   ${FRAGMENT}
-  ${Edits.fragment}
+  ${WikiPageEditFragment}
 `;
 
 const ADD_TAG_MUTATION = gql`
@@ -103,13 +103,13 @@ const ADD_TAG_MUTATION = gql`
   }
 
   ${FRAGMENT}
-  ${Edits.fragment}
+  ${WikiPageEditFragment}
 `;
 
 class AddTagMutationComponent extends Mutation<
   TagsPageAddWikiTagMutation,
   TagsPageAddWikiTagMutationVariables
-> {}
+  > { }
 
 type AddTagMutationFn = MutationFn<
   TagsPageAddWikiTagMutation,
@@ -119,14 +119,14 @@ type AddTagMutationFn = MutationFn<
 class DeleteTagMutationComponent extends Mutation<
   TagsPageDeleteWikiTagMutation,
   TagsPageDeleteWikiTagMutationVariables
-> {}
+  > { }
 
 type DeleteTagMutationFn = MutationFn<
   TagsPageDeleteWikiTagMutation,
   TagsPageDeleteWikiTagMutationVariables
 >;
 
-class QueryComponent extends Query<TagsPageQuery, TagsPageQueryVariables> {}
+class QueryComponent extends Query<TagsPageQuery, TagsPageQueryVariables> { }
 
 class TagsPage extends React.Component<TagsPageProps, TagsPageState> {
   static fragment = FRAGMENT;

--- a/front/app/containers/WikiPage/WikiPage.tsx
+++ b/front/app/containers/WikiPage/WikiPage.tsx
@@ -16,7 +16,7 @@ import * as FontAwesome from 'react-fontawesome';
 
 import LoadingPane from 'components/LoadingPane';
 import Error from 'components/Error';
-import Edits from 'components/Edits';
+import Edits, { WikiPageEditFragment } from 'components/Edits';
 import { trimPath } from 'utils/helpers';
 import CurrentUser from 'containers/CurrentUser';
 import { UserFragment } from 'types/UserFragment';
@@ -49,7 +49,7 @@ const FRAGMENT = gql`
     meta
   }
 
-  ${Edits.fragment}
+  ${WikiPageEditFragment}
 `;
 
 const QUERY = gql`
@@ -88,11 +88,11 @@ const Toolbar = styled.div`
   padding: 10px;
 `;
 
-class QueryComponent extends Query<WikiPageQuery, WikiPageQueryVariables> {}
+class QueryComponent extends Query<WikiPageQuery, WikiPageQueryVariables> { }
 class UpdateContentMutation extends Mutation<
   WikiPageUpdateContentMutation,
   WikiPageUpdateContentMutationVariables
-> {}
+  > { }
 
 class WikiPage extends React.Component<WikiPageProps, WikiPageState> {
   state: WikiPageState = {
@@ -118,20 +118,20 @@ class WikiPage extends React.Component<WikiPageProps, WikiPageState> {
     this.props.onLoaded && this.props.onLoaded();
   };
 
-  handleHistory = (hash:string, siteViewUrl:string) => {
+  handleHistory = (hash: string, siteViewUrl: string) => {
     this.props.history.push(`${trimPath(this.props.match.url)}/wiki/history?hash=${hash}&sv=${siteViewUrl}`);
   };
 
-  handleEdit = (hash:string, siteViewUrl:string) => {
-    console.log("this.props",this.props.match)
+  handleEdit = (hash: string, siteViewUrl: string) => {
+    console.log("this.props", this.props.match)
     this.props.history.push(`${trimPath(this.props.match.url)}/wiki/edit?hash=${hash}&sv=${siteViewUrl}`);
   };
 
-  handleView = (hash:string, siteViewUrl:string) => {
+  handleView = (hash: string, siteViewUrl: string) => {
     this.props.history.push(`${trimPath(this.props.match.url)}?hash=${hash}&sv=${siteViewUrl}`);
   };
 
-  handlePreview = (hash:string, siteViewUrl:string) => {
+  handlePreview = (hash: string, siteViewUrl: string) => {
     if (this.state.editorState === 'plain') {
       const text = this.getEditorText() || '';
       this.setState({
@@ -199,13 +199,13 @@ class WikiPage extends React.Component<WikiPageProps, WikiPageState> {
     );
   };
 
-  renderEditButton = (isAuthenticated: boolean, hash:string, siteViewUrl:string) => {
+  renderEditButton = (isAuthenticated: boolean, hash: string, siteViewUrl: string) => {
     if (!isAuthenticated) return null;
 
     return (
       <Button
         type="button"
-        onClick={()=>this.handleEdit(hash, siteViewUrl)}
+        onClick={() => this.handleEdit(hash, siteViewUrl)}
         style={{ marginLeft: '10px' }}>
         Edit <FontAwesome name="edit" />
       </Button>
@@ -232,7 +232,7 @@ class WikiPage extends React.Component<WikiPageProps, WikiPageState> {
     );
   };
 
-  renderToolbar = (data: WikiPageQuery, user: UserFragment | null, hash:string, siteViewUrl:string) => {
+  renderToolbar = (data: WikiPageQuery, user: UserFragment | null, hash: string, siteViewUrl: string) => {
     const isAuthenticated = user !== null;
     return (
       <Toolbar>
@@ -244,7 +244,7 @@ class WikiPage extends React.Component<WikiPageProps, WikiPageState> {
                 {this.renderMarkdownButton()}{' '}
                 <Button
                   type="button"
-                  onClick={()=>this.handlePreview(hash, siteViewUrl)}
+                  onClick={() => this.handlePreview(hash, siteViewUrl)}
                   style={{ marginLeft: '10px' }}>
                   Preview <FontAwesome name="photo" />
                 </Button>
@@ -259,7 +259,7 @@ class WikiPage extends React.Component<WikiPageProps, WikiPageState> {
                 {this.renderEditButton(isAuthenticated, hash, siteViewUrl)}{' '}
                 <Button
                   type="button"
-                  onClick={()=>this.handleView(hash,siteViewUrl)}
+                  onClick={() => this.handleView(hash, siteViewUrl)}
                   style={{ marginLeft: '10px' }}>
                   View <FontAwesome name="photo" />
                 </Button>
@@ -270,7 +270,7 @@ class WikiPage extends React.Component<WikiPageProps, WikiPageState> {
           <Route
             render={() => (
               <>
-                <Button type="button" onClick={()=>this.handleHistory(hash, siteViewUrl)}>
+                <Button type="button" onClick={() => this.handleHistory(hash, siteViewUrl)}>
                   History <FontAwesome name="history" />
                 </Button>
                 {this.renderEditButton(isAuthenticated, hash, siteViewUrl)}


### PR DESCRIPTION
Related to #166 .

Display a blurb for a given change, with a more configurable UI for crowd annotation changes vs. wiki changes.

## Blurb view
![image](https://user-images.githubusercontent.com/232917/79166368-fcf84080-7db2-11ea-8f24-18a04c733d8f.png)

## Crowd Annotation Changes
![image](https://user-images.githubusercontent.com/232917/79166397-11d4d400-7db3-11ea-987b-ab40e199d964.png)

## Wiki Change, Unexpanded
<img width="1098" alt="Screen Shot 2020-04-13 at 6 18 18 PM" src="https://user-images.githubusercontent.com/232917/79166457-39c43780-7db3-11ea-9ffe-70c4c3db6dd6.png">

## Wiki Change, Expanded
<img width="1102" alt="Screen Shot 2020-04-13 at 6 18 26 PM" src="https://user-images.githubusercontent.com/232917/79166476-4052af00-7db3-11ea-9e6c-a0491cb5e1e8.png">

