### PR TITLE
Ensure an initial edit is created for wiki pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,3 +107,5 @@ gem "http_logger", "~> 0.6.0"
 gem "factory_bot", "~> 5.1", group: :test
 
 gem "faker", "~> 2.11", group: :test
+
+gem "database_cleaner-active_record", "~> 1.8", :group => :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,10 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.5)
     dalli (2.7.9)
+    database_cleaner (1.8.4)
+    database_cleaner-active_record (1.8.0)
+      activerecord
+      database_cleaner (~> 1.8.0)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -403,6 +407,7 @@ DEPENDENCIES
   bootstrap-sass
   coffee-rails (~> 4.2.0)
   composite_primary_keys
+  database_cleaner-active_record (~> 1.8)
   devise
   diffy
   dotenv-rails

--- a/app/graphql/mutations/update_wiki_content.rb
+++ b/app/graphql/mutations/update_wiki_content.rb
@@ -7,6 +7,8 @@ module Mutations
     argument :content, String, "Markdown version of the text", required: true
 
     def resolve(nct_id:, content:)
+      return nil unless current_user
+
       wiki_page = WikiPage.find_or_initialize_by(nct_id: nct_id)
       wiki_page.content = content
       wiki_page.updater = current_user

--- a/app/graphql/mutations/upsert_wiki_label.rb
+++ b/app/graphql/mutations/upsert_wiki_label.rb
@@ -8,6 +8,8 @@ module Mutations
     argument :value, String, "Label value", required: true
 
     def resolve(nct_id:, key:, value:)
+      return nil unless current_user
+
       serializable do
         wiki_page = WikiPage.find_or_initialize_by(nct_id: nct_id)
         front_matter = wiki_page.front_matter

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -44,14 +44,17 @@ class WikiPage < ApplicationRecord
     }
   end
 
+  def should_create_edit?
+    WikiPageEdit.where(wiki_page: self).count == 0 || text_was != text
+  end
+
   def create_edit
-    return if text_was == text
+    return unless should_create_edit?
     raise "Cannot update WikiPage with updater not specified" if @updater.blank?
 
     diff = Diffy::Diff.new(text_was, text)
-    WikiPageEdit.create(
+    wiki_page_edits << WikiPageEdit.new(
       user: @updater,
-      wiki_page_id: id,
       diff: diff.to_s,
       diff_html: diff.to_s(:html_simple),
     )

--- a/spec/factories/wiki_page.rb
+++ b/spec/factories/wiki_page.rb
@@ -3,5 +3,13 @@
 FactoryBot.define do
   factory :wiki_page do
     study
+
+    transient do
+      updater { nil }
+    end
+
+    before(:create) do |page|
+      page.updater ||= FactoryBot.create(:user)
+    end
   end
 end

--- a/spec/fixtures/files/graphql/wiki_page_mutations/update_wiki_content.gql
+++ b/spec/fixtures/files/graphql/wiki_page_mutations/update_wiki_content.gql
@@ -1,0 +1,39 @@
+mutation WikiPageUpdateContentMutation($nctId: String!, $content: String!) {
+  updateWikiContent(input: { nctId: $nctId, content: $content }) {
+    wikiPage {
+      ...WikiPageFragment
+      __typename
+    }
+    errors
+    __typename
+  }
+}
+fragment WikiPageFragment on WikiPage {
+  content
+  edits {
+    ...WikiPageEditFragment
+    __typename
+  }
+  nctId
+  meta
+  __typename
+}
+fragment WikiPageEditFragment on WikiPageEdit {
+  user {
+    id
+    firstName
+    lastName
+    email
+    __typename
+  }
+  changeSet {
+    frontMatterChanged
+    bodyChanged
+  }
+  createdAt
+  id
+  comment
+  diff
+  diffHtml
+  __typename
+}

--- a/spec/fixtures/files/graphql/wiki_page_mutations/upsert_wiki_label.gql
+++ b/spec/fixtures/files/graphql/wiki_page_mutations/upsert_wiki_label.gql
@@ -1,0 +1,42 @@
+mutation CrowdPageUpsertWikiLabelMutation(
+  $nctId: String!
+  $key: String!
+  $value: String!
+) {
+  upsertWikiLabel(input: { nctId: $nctId, key: $key, value: $value }) {
+    wikiPage {
+      ...CrowdPageFragment
+      edits {
+        ...WikiPageEditFragment
+        __typename
+      }
+      __typename
+    }
+    errors
+    __typename
+  }
+}
+fragment CrowdPageFragment on WikiPage {
+  nctId
+  meta
+  __typename
+}
+fragment WikiPageEditFragment on WikiPageEdit {
+  user {
+    id
+    firstName
+    lastName
+    email
+    __typename
+  }
+  createdAt
+  id
+  comment
+  diff
+  diffHtml
+  changeSet {
+    frontMatterChanged
+    bodyChanged
+  }
+  __typename
+}

--- a/spec/graphql/update_wiki_content_spec.rb
+++ b/spec/graphql/update_wiki_content_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+describe "updateWikiContent" do
+  let(:study) { Study.order(Arel.sql("RANDOM()")).first }
+  let(:query) { file_fixture("graphql/wiki_page_mutations/update_wiki_content.gql").read }
+  let(:variables) { { nctId: study.nct_id, content: "here is some more wiki content" } }
+  let(:context) { {} }
+
+  subject { ClinwikiSchema.execute(query, variables: variables, context: context).to_h }
+
+  describe "without a logged in user" do
+    it { expect { subject }.not_to(change { WikiPage.count }) }
+    it { expect { subject }.not_to(change { WikiPageEdit.count }) }
+    it "should return nil" do
+      expect(subject.dig("data", "updateWikiContent")).to be_nil
+    end
+  end
+
+  describe "with a logged in user" do
+    let!(:user) { create :user }
+    let(:context) { { current_user: user } }
+    describe "if the wiki page already exists" do
+      let!(:wiki_page) { create :wiki_page, study: study }
+
+      before do
+        fm = wiki_page.front_matter
+        fm["foo"] = "bar"
+        wiki_page.front_matter = fm
+        wiki_page.save
+      end
+
+      it "should not return an error" do
+        expect(subject.dig("data", "updateWikiContent", "errors")).to be_nil
+      end
+
+      it { expect { subject }.to(change { WikiPage.find(wiki_page.id).content }) }
+      it { expect { subject }.not_to(change { wiki_page.reload.front_matter }) }
+      it { expect { subject }.not_to(change { WikiPage.count }) }
+      it { expect { subject }.to(change { WikiPageEdit.count }) }
+
+      it "updates the body, and not the front matter" do
+        expect(subject.dig("data", "updateWikiContent", "wikiPage", "edits", 0, "changeSet", "frontMatterChanged")).to be_falsey
+        expect(subject.dig("data", "updateWikiContent", "wikiPage", "edits", 0, "changeSet", "bodyChanged")).to be_truthy
+      end
+    end
+
+    describe "if the wiki page is new" do
+      it { expect { subject }.to(change { WikiPageEdit.count }) }
+      it { expect { subject }.to(change { WikiPage.count }) }
+      it "should create a wiki page with the correct content" do
+        subject
+        expect(WikiPage.last.content).to eql "here is some more wiki content"
+        expect(subject.dig("data", "updateWikiContent", "wikiPage", "edits", 0, "changeSet", "frontMatterChanged")).to be_truthy
+        expect(subject.dig("data", "updateWikiContent", "wikiPage", "edits", 0, "changeSet", "bodyChanged")).to be_truthy
+      end
+      it "doesn't modify front matter, just initializes it" do
+        subject
+        expect(WikiPage.last.front_matter).to be_empty
+      end
+    end
+  end
+end

--- a/spec/graphql/upsert_wiki_label_spec.rb
+++ b/spec/graphql/upsert_wiki_label_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe "upsertWikiLabel" do
+  let(:study) { Study.order(Arel.sql("RANDOM()")).first }
+  let(:query) { file_fixture("graphql/wiki_page_mutations/upsert_wiki_label.gql").read }
+  let(:variables) { { nctId: study.nct_id, key: "some key", value: "some value" } }
+  let(:context) { {} }
+
+  subject { ClinwikiSchema.execute(query, variables: variables, context: context).to_h }
+
+  describe "without a logged in user" do
+    it { expect { subject }.not_to(change { WikiPage.count }) }
+    it { expect { subject }.not_to(change { WikiPageEdit.count }) }
+    it "should return nil" do
+      expect(subject.dig("data", "upsertWikiLabel")).to be_nil
+    end
+  end
+
+  describe "with a logged in user" do
+    let!(:user) { create :user }
+    let(:context) { { current_user: user } }
+    describe "if the wiki page already exists" do
+      let!(:wiki_page) { create :wiki_page, study: study }
+      describe "if a value is already set for the crowd data" do
+        before do
+          fm = wiki_page.front_matter
+          fm["some key"] = "some other value"
+          wiki_page.front_matter = fm
+          wiki_page.save
+        end
+        it { expect(subject.dig("errors")).to be_nil }
+        it { expect { subject }.not_to(change { WikiPage.count }) }
+        it { expect { subject }.to(change { WikiPageEdit.count }) }
+        it "should change the front matter value" do
+          subject
+          expect(wiki_page.reload.front_matter["some key"]).to eql("some value")
+          expect(subject.dig(
+                   "data", "upsertWikiLabel", "wikiPage", "edits", 0, "changeSet", "frontMatterChanged"
+                 )).to be_truthy
+          expect(subject.dig(
+                   "data", "upsertWikiLabel", "wikiPage", "edits", 0, "changeSet", "bodyChanged"
+                 )).to be_falsey
+        end
+      end
+    end
+
+    describe "if the wiki page is new" do
+      it { expect { subject }.to(change { WikiPage.count }) }
+      it { expect { subject }.to(change { WikiPageEdit.count }) }
+      it "should set the front matter value" do
+        subject
+        expect(WikiPage.last.front_matter["some key"]).to eql("some value")
+        expect(subject.dig(
+                 "data", "upsertWikiLabel", "wikiPage", "edits", 0, "changeSet", "frontMatterChanged"
+               )).to be_truthy
+        expect(subject.dig(
+                 "data", "upsertWikiLabel", "wikiPage", "edits", 0, "changeSet", "bodyChanged"
+               )).to be_truthy
+      end
+      it "does not modify the content of the wiki page" do
+        subject
+        expect(WikiPage.last.content).to eql(WikiPage.new(study: study).default_content)
+      end
+    end
+  end
+end

--- a/spec/graphql/wiki_page_edit_history_spec.rb
+++ b/spec/graphql/wiki_page_edit_history_spec.rb
@@ -25,9 +25,9 @@ describe "Wiki Page Edit History" do
     wiki_page.save
   end
 
-  it "shows the initial wiki page creation as both changed" do
-    expect(edits.last["changeSet"]["bodyChanged"]).to eql true
-    expect(edits.last["changeSet"]["frontMatterChanged"]).to eql true
+  it "shows the initial wiki page creation as neither changed" do
+    expect(edits.last["changeSet"]["bodyChanged"]).to eql false
+    expect(edits.last["changeSet"]["frontMatterChanged"]).to eql false
   end
 
   it "shows changes to content as only content changed" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,7 +31,6 @@ RSpec.configure do |config|
   # If you"re not using ActiveRecord, or you"d prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,6 +54,17 @@ RSpec.configure do |config|
     FactoryBot.find_definitions
   end
 
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.clean_with(:truncation, except: Study.connection.tables)
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
+
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
   #   # These two settings work together to allow you to limit a spec run


### PR DESCRIPTION
* Utilize ActiveRecord-idiomatic approach for solving associations for two models that are being instantiated at the same time (this was the source of the bug; we've been creating edits with `nil` `wiki_page_id`s)
* Introduce `database_cleaning` gem for improved isolation of tests (we'll need to think about how to figure out what to do with performance, but the default transaction configuration was starting to break more advanced tests)
* Add a couple of graphql tests to validate the core mutations working with `WikiPage` objects are  being changed properly, with the correct values for edit history

Resolves #241 