### PR TITLE
RTM Resolves issue where crowdAggs would error out Range Filter 

### DIFF
--- a/front/app/containers/SearchPage/components/AggFilterInputUpdater.tsx
+++ b/front/app/containers/SearchPage/components/AggFilterInputUpdater.tsx
@@ -139,7 +139,10 @@ abstract class AbstractAggFilterInputUpdater {
     if (this.input.gte) {
       const thisField: any = find(propEq('name', this.agg))(
         thisSiteView.search.aggs.fields
-      );
+      ) || find(propEq('name', this.agg))(
+        thisSiteView.search.crowdAggs.fields
+      ) ;
+      if(thisField.display){
       switch (thisField.display) {
         case 'DATE_RANGE':
           return this.isDateAgg()
@@ -153,6 +156,8 @@ abstract class AbstractAggFilterInputUpdater {
           return this.input.gte;
       }
     }
+    return this.input.gte
+    }
   }
 
   getMaxString(thisSiteView): string | undefined {
@@ -160,7 +165,9 @@ abstract class AbstractAggFilterInputUpdater {
     if (this.input.lte) {
       const thisField: any = find(propEq('name', this.agg))(
         thisSiteView.search.aggs.fields
-      );
+      ) || find(propEq('name', this.agg))(
+        thisSiteView.search.crowdAggs.fields
+      ) ;
       switch (thisField.display) {
         case 'DATE_RANGE':
           return this.isDateAgg()


### PR DESCRIPTION
First picture shows we have the crowdAgg _tags_ to be displayed as number range 
![Screen Shot 2020-04-14 at 3 12 17 PM](https://user-images.githubusercontent.com/17464571/79269669-726f1a00-7e62-11ea-99e2-b25b287b609d.png)

Shows number range with a min value selected, no error 
![Screen Shot 2020-04-14 at 3 12 46 PM](https://user-images.githubusercontent.com/17464571/79269805-9d596e00-7e62-11ea-96fe-899b1c9bafd2.png)
