### PR TITLE
misc bug-fixes post double wiki edit merge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,4 +91,23 @@ white-listed for CORS requests. This means you can configure a site with the sub
 
 # Testing
 
-ClinWiki doesn't currently have any automated tests (feel free to contribute some). Instead we have a manual checklist maintained in the Wiki that we will run though after features are merged to staging. [See it here](https://github.com/clinwiki-org/clinwiki/wiki/Testing-Guide)
+ClinWiki is working on increasing unit test coverage.
+
+We have a manual checklist maintained in the Wiki that
+we will run though after features are merged to staging.
+[See it here](https://github.com/clinwiki-org/clinwiki/wiki/Testing-Guide)
+
+## Running Ruby Tests
+
+```bash
+# ensure your test database exists.
+# you should only need to run this once.
+# you'll want to re-migrate the test database
+# when new migrations appear
+RAILS_ENV=test bundle exec rake db:create db:migrate
+
+bundle exec rspec spec
+```
+
+The test database is automatically configured
+in `config/environments/test.rb'

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -11,7 +11,7 @@ class WikiPage < ApplicationRecord
   def default_content
     <<~CONTENT
       ## Lay Summary
-      #{study.brief_summary.description.gsub(/^\s+/, '')}
+      #{study&.brief_summary&.description&.gsub(/^\s+/, '')}
 
       ## Pros
       * Add a pro here

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,10 @@
 # rubocop:disable all
 Rails.application.configure do
+
+  # automatically set the database to `clinwiki_test` instead of clinwiki
+  # you can keep this up to date by setting RAILS_ENV="test" before running db:migrate
+  ENV["DATABASE_URL"] = ENV["DATABASE_URL"].gsub(/clinwiki$/, "clinwiki_test")
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's

--- a/front/app/components/Edits/EditBlurb.tsx
+++ b/front/app/components/Edits/EditBlurb.tsx
@@ -1,8 +1,8 @@
-import * as React from "react";
+import * as React from 'react';
 import { Row, Col, Table, Button } from 'react-bootstrap';
 import {
   WikiPageEditFragment,
-  WikiPageEditFragment_user
+  WikiPageEditFragment_user,
 } from 'types/WikiPageEditFragment';
 
 interface EditBlurbProps {
@@ -12,9 +12,10 @@ interface EditBlurbProps {
 }
 
 class EditBlurb extends React.Component<EditBlurbProps> {
-
   getUserIdentity() {
-    const { edit: { user } } = this.props;
+    const {
+      edit: { user },
+    } = this.props;
     if (!user) {
       return 'Anonymous';
     }
@@ -25,14 +26,21 @@ class EditBlurb extends React.Component<EditBlurbProps> {
   }
 
   getBlurb() {
-    const { edit: { changeSet: { bodyChanged, frontMatterChanged } } } = this.props;
-    if (bodyChanged && frontMatterChanged) {
-      return "made the first edit."
+    const {
+      edit: {
+        changeSet: { bodyChanged, frontMatterChanged },
+      },
+    } = this.props;
+    if (!bodyChanged && !frontMatterChanged) {
+      return 'made the first edit.';
     }
     if (frontMatterChanged) {
-      return "made a crowd data change.";
+      return 'made a crowd data change.';
     }
-    return "updated the wiki."
+    if (bodyChanged) {
+      return 'updated the wiki.';
+    }
+    return 'made a change.';
   }
 
   render() {
@@ -40,24 +48,22 @@ class EditBlurb extends React.Component<EditBlurbProps> {
     return (
       <Row style={{ marginBottom: '10px', padding: '10px' }}>
         <Col md={8}>
-          <span className="diff-actor">
-            {this.getUserIdentity()}
-          </span>
-          <span>
-            {' ' + this.getBlurb()}
-          </span>
+          <span className="diff-actor">{this.getUserIdentity()}</span>
+          <span>{' ' + this.getBlurb()}</span>
         </Col>
         <Col md={2}>
-          <small>
-            {new Date(edit.createdAt).toLocaleDateString('en-US')}
-          </small>
+          <small>{new Date(edit.createdAt).toLocaleDateString('en-US')}</small>
         </Col>
         <Col md={2} className="text-right">
-          {expanded && (<Button onClick={() => setExpanded(false)}>View Less</Button>)}
-          {!expanded && (<Button onClick={() => setExpanded(true)}>View More</Button>)}
+          {expanded && (
+            <Button onClick={() => setExpanded(false)}>View Less</Button>
+          )}
+          {!expanded && (
+            <Button onClick={() => setExpanded(true)}>View More</Button>
+          )}
         </Col>
       </Row>
-    )
+    );
   }
 }
 

--- a/front/app/components/Edits/ExpandedEdit/ExpandedEdit.tsx
+++ b/front/app/components/Edits/ExpandedEdit/ExpandedEdit.tsx
@@ -15,16 +15,14 @@ class ExpandedEdit extends React.Component<EditProps> {
       changeSet: { bodyChanged, frontMatterChanged },
     } = edit;
 
-    console.log(edit.changeSet);
-
-    if (bodyChanged && frontMatterChanged) {
-      return <ExpandedAsRawDiff edit={edit} />;
-    }
     if (frontMatterChanged) {
       return <FrontMatterExpandedEdit edit={edit} />;
     }
+    if (bodyChanged && !frontMatterChanged) {
+      return <WikiExpandedEdit edit={edit} />;
+    }
 
-    return <WikiExpandedEdit edit={edit} />;
+    return <ExpandedAsRawDiff edit={edit} />;
   }
 }
 

--- a/front/app/components/Edits/ExpandedEdit/FrontMatterExpandedEdit.tsx
+++ b/front/app/components/Edits/ExpandedEdit/FrontMatterExpandedEdit.tsx
@@ -14,7 +14,9 @@ class FrontMatterExpandedEdit extends React.Component<EditProps> {
         changeSet: { editLines },
       },
     } = this.props;
-    const fmLines = editLines.filter(({ frontMatter }) => frontMatter);
+    const fmLines = editLines.filter(
+      ({ frontMatter, content }) => frontMatter && content !== '---'
+    );
     const inserts = fmLines.filter(({ status }) => status === 'INS');
     const deletes = fmLines.filter(({ status }) => status === 'DEL');
 
@@ -23,7 +25,7 @@ class FrontMatterExpandedEdit extends React.Component<EditProps> {
     if (deletes.length > 0) {
       const [fieldName, former] = deletes[0].content.split(/:(.+)/);
       nodes.push(
-        <tr className="del">
+        <tr className="del" key={`${fieldName}-delete`}>
           <td>-</td>
           <td>{fieldName}</td>
           <td>{former}</td>
@@ -33,7 +35,7 @@ class FrontMatterExpandedEdit extends React.Component<EditProps> {
     if (inserts.length > 0) {
       const [fieldName, current] = inserts[0].content.split(/:(.+)/);
       nodes.push(
-        <tr className="ins">
+        <tr className="ins" key={`${fieldName}-insert`}>
           <td>+</td>
           <td>{fieldName}</td>
           <td>{current}</td>
@@ -46,9 +48,11 @@ class FrontMatterExpandedEdit extends React.Component<EditProps> {
         <Col md={12}>
           <Table className="crowd-diff">
             <thead>
-              <th></th>
-              <th>Field</th>
-              <th>Value</th>
+              <tr>
+                <th></th>
+                <th>Field</th>
+                <th>Value</th>
+              </tr>
             </thead>
             <tbody>{nodes}</tbody>
           </Table>

--- a/front/app/components/Edits/ExpandedEdit/WikiExpandedEdit.tsx
+++ b/front/app/components/Edits/ExpandedEdit/WikiExpandedEdit.tsx
@@ -65,10 +65,7 @@ class WikiExpandedEdit extends React.Component<EditProps, EditState> {
     className: `${className}${
       this.state.hoveredLine === key ? ' hovered' : ''
     }`,
-    onMouseEnter: () => {
-      console.log(key);
-      this.setState({ ...this.state, hoveredLine: key });
-    },
+    onMouseEnter: () => this.setState({ ...this.state, hoveredLine: key }),
     onMouseLeave: () => this.setState({ ...this.state, hoveredLine: null }),
   });
 

--- a/front/app/types/CrowdPageDeleteWikiLabelMutation.ts
+++ b/front/app/types/CrowdPageDeleteWikiLabelMutation.ts
@@ -1,6 +1,8 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
+import { Diff } from "./globalTypes";
+
 // ====================================================
 // GraphQL mutation operation: CrowdPageDeleteWikiLabelMutation
 // ====================================================
@@ -25,6 +27,33 @@ export interface CrowdPageDeleteWikiLabelMutation_deleteWikiLabel_wikiPage_edits
   email: string;
 }
 
+export interface CrowdPageDeleteWikiLabelMutation_deleteWikiLabel_wikiPage_edits_changeSet_editLines {
+  __typename: "WikiPageEditLine";
+  /**
+   * The type of diff line.
+   */
+  status: Diff;
+  /**
+   * The content of the line.
+   */
+  content: string;
+  /**
+   * Whether the line is in the front matter.
+   */
+  frontMatter: boolean;
+  /**
+   * Whether the line is in the body.
+   */
+  body: boolean;
+}
+
+export interface CrowdPageDeleteWikiLabelMutation_deleteWikiLabel_wikiPage_edits_changeSet {
+  __typename: "WikiPageEdits";
+  bodyChanged: boolean;
+  frontMatterChanged: boolean;
+  editLines: CrowdPageDeleteWikiLabelMutation_deleteWikiLabel_wikiPage_edits_changeSet_editLines[];
+}
+
 export interface CrowdPageDeleteWikiLabelMutation_deleteWikiLabel_wikiPage_edits {
   __typename: "WikiPageEdit";
   user: CrowdPageDeleteWikiLabelMutation_deleteWikiLabel_wikiPage_edits_user | null;
@@ -33,6 +62,7 @@ export interface CrowdPageDeleteWikiLabelMutation_deleteWikiLabel_wikiPage_edits
   comment: string | null;
   diff: string | null;
   diffHtml: string | null;
+  changeSet: CrowdPageDeleteWikiLabelMutation_deleteWikiLabel_wikiPage_edits_changeSet;
 }
 
 export interface CrowdPageDeleteWikiLabelMutation_deleteWikiLabel_wikiPage {

--- a/front/app/types/CrowdPageUpsertWikiLabelMutation.ts
+++ b/front/app/types/CrowdPageUpsertWikiLabelMutation.ts
@@ -1,6 +1,8 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
+import { Diff } from "./globalTypes";
+
 // ====================================================
 // GraphQL mutation operation: CrowdPageUpsertWikiLabelMutation
 // ====================================================
@@ -25,6 +27,33 @@ export interface CrowdPageUpsertWikiLabelMutation_upsertWikiLabel_wikiPage_edits
   email: string;
 }
 
+export interface CrowdPageUpsertWikiLabelMutation_upsertWikiLabel_wikiPage_edits_changeSet_editLines {
+  __typename: "WikiPageEditLine";
+  /**
+   * The type of diff line.
+   */
+  status: Diff;
+  /**
+   * The content of the line.
+   */
+  content: string;
+  /**
+   * Whether the line is in the front matter.
+   */
+  frontMatter: boolean;
+  /**
+   * Whether the line is in the body.
+   */
+  body: boolean;
+}
+
+export interface CrowdPageUpsertWikiLabelMutation_upsertWikiLabel_wikiPage_edits_changeSet {
+  __typename: "WikiPageEdits";
+  bodyChanged: boolean;
+  frontMatterChanged: boolean;
+  editLines: CrowdPageUpsertWikiLabelMutation_upsertWikiLabel_wikiPage_edits_changeSet_editLines[];
+}
+
 export interface CrowdPageUpsertWikiLabelMutation_upsertWikiLabel_wikiPage_edits {
   __typename: "WikiPageEdit";
   user: CrowdPageUpsertWikiLabelMutation_upsertWikiLabel_wikiPage_edits_user | null;
@@ -33,6 +62,7 @@ export interface CrowdPageUpsertWikiLabelMutation_upsertWikiLabel_wikiPage_edits
   comment: string | null;
   diff: string | null;
   diffHtml: string | null;
+  changeSet: CrowdPageUpsertWikiLabelMutation_upsertWikiLabel_wikiPage_edits_changeSet;
 }
 
 export interface CrowdPageUpsertWikiLabelMutation_upsertWikiLabel_wikiPage {

--- a/front/app/types/StudyPagePrefetchQuery.ts
+++ b/front/app/types/StudyPagePrefetchQuery.ts
@@ -1,6 +1,8 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
+import { Diff } from "./globalTypes";
+
 // ====================================================
 // GraphQL query operation: StudyPagePrefetchQuery
 // ====================================================
@@ -25,6 +27,33 @@ export interface StudyPagePrefetchQuery_study_wikiPage_edits_user {
   email: string;
 }
 
+export interface StudyPagePrefetchQuery_study_wikiPage_edits_changeSet_editLines {
+  __typename: "WikiPageEditLine";
+  /**
+   * The type of diff line.
+   */
+  status: Diff;
+  /**
+   * The content of the line.
+   */
+  content: string;
+  /**
+   * Whether the line is in the front matter.
+   */
+  frontMatter: boolean;
+  /**
+   * Whether the line is in the body.
+   */
+  body: boolean;
+}
+
+export interface StudyPagePrefetchQuery_study_wikiPage_edits_changeSet {
+  __typename: "WikiPageEdits";
+  bodyChanged: boolean;
+  frontMatterChanged: boolean;
+  editLines: StudyPagePrefetchQuery_study_wikiPage_edits_changeSet_editLines[];
+}
+
 export interface StudyPagePrefetchQuery_study_wikiPage_edits {
   __typename: "WikiPageEdit";
   user: StudyPagePrefetchQuery_study_wikiPage_edits_user | null;
@@ -33,6 +62,7 @@ export interface StudyPagePrefetchQuery_study_wikiPage_edits {
   comment: string | null;
   diff: string | null;
   diffHtml: string | null;
+  changeSet: StudyPagePrefetchQuery_study_wikiPage_edits_changeSet;
 }
 
 export interface StudyPagePrefetchQuery_study_wikiPage {

--- a/front/app/types/TagsPageAddWikiTagMutation.ts
+++ b/front/app/types/TagsPageAddWikiTagMutation.ts
@@ -1,6 +1,8 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
+import { Diff } from "./globalTypes";
+
 // ====================================================
 // GraphQL mutation operation: TagsPageAddWikiTagMutation
 // ====================================================
@@ -25,6 +27,33 @@ export interface TagsPageAddWikiTagMutation_upsertWikiTag_wikiPage_edits_user {
   email: string;
 }
 
+export interface TagsPageAddWikiTagMutation_upsertWikiTag_wikiPage_edits_changeSet_editLines {
+  __typename: "WikiPageEditLine";
+  /**
+   * The type of diff line.
+   */
+  status: Diff;
+  /**
+   * The content of the line.
+   */
+  content: string;
+  /**
+   * Whether the line is in the front matter.
+   */
+  frontMatter: boolean;
+  /**
+   * Whether the line is in the body.
+   */
+  body: boolean;
+}
+
+export interface TagsPageAddWikiTagMutation_upsertWikiTag_wikiPage_edits_changeSet {
+  __typename: "WikiPageEdits";
+  bodyChanged: boolean;
+  frontMatterChanged: boolean;
+  editLines: TagsPageAddWikiTagMutation_upsertWikiTag_wikiPage_edits_changeSet_editLines[];
+}
+
 export interface TagsPageAddWikiTagMutation_upsertWikiTag_wikiPage_edits {
   __typename: "WikiPageEdit";
   user: TagsPageAddWikiTagMutation_upsertWikiTag_wikiPage_edits_user | null;
@@ -33,6 +62,7 @@ export interface TagsPageAddWikiTagMutation_upsertWikiTag_wikiPage_edits {
   comment: string | null;
   diff: string | null;
   diffHtml: string | null;
+  changeSet: TagsPageAddWikiTagMutation_upsertWikiTag_wikiPage_edits_changeSet;
 }
 
 export interface TagsPageAddWikiTagMutation_upsertWikiTag_wikiPage {

--- a/front/app/types/TagsPageDeleteWikiTagMutation.ts
+++ b/front/app/types/TagsPageDeleteWikiTagMutation.ts
@@ -1,6 +1,8 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
+import { Diff } from "./globalTypes";
+
 // ====================================================
 // GraphQL mutation operation: TagsPageDeleteWikiTagMutation
 // ====================================================
@@ -25,6 +27,33 @@ export interface TagsPageDeleteWikiTagMutation_deleteWikiTag_wikiPage_edits_user
   email: string;
 }
 
+export interface TagsPageDeleteWikiTagMutation_deleteWikiTag_wikiPage_edits_changeSet_editLines {
+  __typename: "WikiPageEditLine";
+  /**
+   * The type of diff line.
+   */
+  status: Diff;
+  /**
+   * The content of the line.
+   */
+  content: string;
+  /**
+   * Whether the line is in the front matter.
+   */
+  frontMatter: boolean;
+  /**
+   * Whether the line is in the body.
+   */
+  body: boolean;
+}
+
+export interface TagsPageDeleteWikiTagMutation_deleteWikiTag_wikiPage_edits_changeSet {
+  __typename: "WikiPageEdits";
+  bodyChanged: boolean;
+  frontMatterChanged: boolean;
+  editLines: TagsPageDeleteWikiTagMutation_deleteWikiTag_wikiPage_edits_changeSet_editLines[];
+}
+
 export interface TagsPageDeleteWikiTagMutation_deleteWikiTag_wikiPage_edits {
   __typename: "WikiPageEdit";
   user: TagsPageDeleteWikiTagMutation_deleteWikiTag_wikiPage_edits_user | null;
@@ -33,6 +62,7 @@ export interface TagsPageDeleteWikiTagMutation_deleteWikiTag_wikiPage_edits {
   comment: string | null;
   diff: string | null;
   diffHtml: string | null;
+  changeSet: TagsPageDeleteWikiTagMutation_deleteWikiTag_wikiPage_edits_changeSet;
 }
 
 export interface TagsPageDeleteWikiTagMutation_deleteWikiTag_wikiPage {

--- a/front/app/types/WikiPageEditFragment.ts
+++ b/front/app/types/WikiPageEditFragment.ts
@@ -1,6 +1,8 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
+import { Diff } from "./globalTypes";
+
 // ====================================================
 // GraphQL fragment: WikiPageEditFragment
 // ====================================================
@@ -25,6 +27,33 @@ export interface WikiPageEditFragment_user {
   email: string;
 }
 
+export interface WikiPageEditFragment_changeSet_editLines {
+  __typename: "WikiPageEditLine";
+  /**
+   * The type of diff line.
+   */
+  status: Diff;
+  /**
+   * The content of the line.
+   */
+  content: string;
+  /**
+   * Whether the line is in the front matter.
+   */
+  frontMatter: boolean;
+  /**
+   * Whether the line is in the body.
+   */
+  body: boolean;
+}
+
+export interface WikiPageEditFragment_changeSet {
+  __typename: "WikiPageEdits";
+  bodyChanged: boolean;
+  frontMatterChanged: boolean;
+  editLines: WikiPageEditFragment_changeSet_editLines[];
+}
+
 export interface WikiPageEditFragment {
   __typename: "WikiPageEdit";
   user: WikiPageEditFragment_user | null;
@@ -33,4 +62,5 @@ export interface WikiPageEditFragment {
   comment: string | null;
   diff: string | null;
   diffHtml: string | null;
+  changeSet: WikiPageEditFragment_changeSet;
 }

--- a/front/app/types/WikiPageFragment.ts
+++ b/front/app/types/WikiPageFragment.ts
@@ -1,6 +1,8 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
+import { Diff } from "./globalTypes";
+
 // ====================================================
 // GraphQL fragment: WikiPageFragment
 // ====================================================
@@ -25,6 +27,33 @@ export interface WikiPageFragment_edits_user {
   email: string;
 }
 
+export interface WikiPageFragment_edits_changeSet_editLines {
+  __typename: "WikiPageEditLine";
+  /**
+   * The type of diff line.
+   */
+  status: Diff;
+  /**
+   * The content of the line.
+   */
+  content: string;
+  /**
+   * Whether the line is in the front matter.
+   */
+  frontMatter: boolean;
+  /**
+   * Whether the line is in the body.
+   */
+  body: boolean;
+}
+
+export interface WikiPageFragment_edits_changeSet {
+  __typename: "WikiPageEdits";
+  bodyChanged: boolean;
+  frontMatterChanged: boolean;
+  editLines: WikiPageFragment_edits_changeSet_editLines[];
+}
+
 export interface WikiPageFragment_edits {
   __typename: "WikiPageEdit";
   user: WikiPageFragment_edits_user | null;
@@ -33,6 +62,7 @@ export interface WikiPageFragment_edits {
   comment: string | null;
   diff: string | null;
   diffHtml: string | null;
+  changeSet: WikiPageFragment_edits_changeSet;
 }
 
 export interface WikiPageFragment {

--- a/front/app/types/WikiPageQuery.ts
+++ b/front/app/types/WikiPageQuery.ts
@@ -1,6 +1,8 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
+import { Diff } from "./globalTypes";
+
 // ====================================================
 // GraphQL query operation: WikiPageQuery
 // ====================================================
@@ -25,6 +27,33 @@ export interface WikiPageQuery_study_wikiPage_edits_user {
   email: string;
 }
 
+export interface WikiPageQuery_study_wikiPage_edits_changeSet_editLines {
+  __typename: "WikiPageEditLine";
+  /**
+   * The type of diff line.
+   */
+  status: Diff;
+  /**
+   * The content of the line.
+   */
+  content: string;
+  /**
+   * Whether the line is in the front matter.
+   */
+  frontMatter: boolean;
+  /**
+   * Whether the line is in the body.
+   */
+  body: boolean;
+}
+
+export interface WikiPageQuery_study_wikiPage_edits_changeSet {
+  __typename: "WikiPageEdits";
+  bodyChanged: boolean;
+  frontMatterChanged: boolean;
+  editLines: WikiPageQuery_study_wikiPage_edits_changeSet_editLines[];
+}
+
 export interface WikiPageQuery_study_wikiPage_edits {
   __typename: "WikiPageEdit";
   user: WikiPageQuery_study_wikiPage_edits_user | null;
@@ -33,6 +62,7 @@ export interface WikiPageQuery_study_wikiPage_edits {
   comment: string | null;
   diff: string | null;
   diffHtml: string | null;
+  changeSet: WikiPageQuery_study_wikiPage_edits_changeSet;
 }
 
 export interface WikiPageQuery_study_wikiPage {

--- a/front/app/types/WikiPageUpdateContentMutation.ts
+++ b/front/app/types/WikiPageUpdateContentMutation.ts
@@ -1,6 +1,8 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
+import { Diff } from "./globalTypes";
+
 // ====================================================
 // GraphQL mutation operation: WikiPageUpdateContentMutation
 // ====================================================
@@ -25,6 +27,33 @@ export interface WikiPageUpdateContentMutation_updateWikiContent_wikiPage_edits_
   email: string;
 }
 
+export interface WikiPageUpdateContentMutation_updateWikiContent_wikiPage_edits_changeSet_editLines {
+  __typename: "WikiPageEditLine";
+  /**
+   * The type of diff line.
+   */
+  status: Diff;
+  /**
+   * The content of the line.
+   */
+  content: string;
+  /**
+   * Whether the line is in the front matter.
+   */
+  frontMatter: boolean;
+  /**
+   * Whether the line is in the body.
+   */
+  body: boolean;
+}
+
+export interface WikiPageUpdateContentMutation_updateWikiContent_wikiPage_edits_changeSet {
+  __typename: "WikiPageEdits";
+  bodyChanged: boolean;
+  frontMatterChanged: boolean;
+  editLines: WikiPageUpdateContentMutation_updateWikiContent_wikiPage_edits_changeSet_editLines[];
+}
+
 export interface WikiPageUpdateContentMutation_updateWikiContent_wikiPage_edits {
   __typename: "WikiPageEdit";
   user: WikiPageUpdateContentMutation_updateWikiContent_wikiPage_edits_user | null;
@@ -33,6 +62,7 @@ export interface WikiPageUpdateContentMutation_updateWikiContent_wikiPage_edits 
   comment: string | null;
   diff: string | null;
   diffHtml: string | null;
+  changeSet: WikiPageUpdateContentMutation_updateWikiContent_wikiPage_edits_changeSet;
 }
 
 export interface WikiPageUpdateContentMutation_updateWikiContent_wikiPage {

--- a/front/app/types/globalTypes.ts
+++ b/front/app/types/globalTypes.ts
@@ -5,10 +5,17 @@
 // START Enums and Input Objects
 //==============================================================
 
+export enum Diff {
+  DEL = "DEL",
+  INS = "INS",
+  UNCHANGED = "UNCHANGED",
+}
+
 export enum FieldDisplay {
   DATE = "DATE",
   DATE_RANGE = "DATE_RANGE",
   NUMBER_RANGE = "NUMBER_RANGE",
+  RANGE = "RANGE",
   STAR = "STAR",
   STRING = "STRING",
 }


### PR DESCRIPTION
It looks like merging the fix for creating a wiki edit on the first edit may have broken some things about the new wiki edit UI.

I also noticed that running tests now truncates your dev database. Whoops! I've fixed that in this PR.

There also appear to be some miscellaneous types that needed re-adding.