### PR TITLE
RTM Resolves issue #420: Better handles serach query string 

### DIFF
--- a/front/app/containers/SearchPage/SearchPage.tsx
+++ b/front/app/containers/SearchPage/SearchPage.tsx
@@ -583,23 +583,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
   showingCards = () => this.props.currentSiteView.search.results.type == 'card';
 
   componentDidMount() {
-    let searchTerm = new URLSearchParams(this.props.location?.search || "")
-    if (searchTerm.has('q')) {
-      let q = { key: 'AND', children: [{ children: [], key: searchTerm.getAll('q').toString() }] };
-      this.setState(
-        {
-          params: {
-            q: q,
-            aggFilters: [],
-            crowdAggFilters: [],
-            sorts: [],
-            page: 0,
-            pageSize: defaultPageSize,
-          },
-        },
-        () => this.updateSearchParams(this.state.params)
-      );
-    } 
     if (this.showingCards()) {
       window.addEventListener('scroll', this.handleScroll);
     } else {
@@ -627,6 +610,20 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
 
   updateStateFromHash(searchParams) {
     const params: SearchParams = this.searchParamsFromQuery(searchParams);
+    let searchTerm = new URLSearchParams(this.props.location?.search || "")
+    
+    if (searchTerm.has('q')) {
+      let q = { key: 'AND', children: [{ children: [], key: searchTerm.getAll('q').toString() }] };
+      this.setState(
+        {
+          params: {
+            ...params,
+            q: q
+          },
+        },
+        () => this.updateSearchParams(this.state.params)
+      );
+    } 
     this.setState({
       params: {
         ...params,


### PR DESCRIPTION
Previously terms coming from the url query string would override any preselected options in the site view. 

Moved the previously written functions into the updateStateFromHash to update the params with the query alongside when it updates the params from ParamsQueryComponent

In following Screenshot I have configured my siteview to have the mesh term _coronavirus infections_
![Screen Shot 2020-04-17 at 10 50 10 AM](https://user-images.githubusercontent.com/17464571/79588241-3eca0500-8099-11ea-890b-b13e125799f3.png)

This is the view with no query string


![Screen Shot 2020-04-17 at 10 51 37 AM](https://user-images.githubusercontent.com/17464571/79588380-7173fd80-8099-11ea-89d5-d9f46ec475a4.png)

The screen recording shows when adding a query string to url it it will add the query string to the breadcrumbs once the new hash loads 
![Screen Recording 2020-04-17 at 10 57 36 AM](https://user-images.githubusercontent.com/17464571/79589518-24912680-809b-11ea-9ead-75b9c4112ffe.gif)

