### PR TITLE
Fix workflow and bulk update facet display of missing values 

### DIFF
--- a/front/app/containers/BulkEditPage/BulkEditView.tsx
+++ b/front/app/containers/BulkEditPage/BulkEditView.tsx
@@ -5,6 +5,7 @@ import Toast from 'components/Toast';
 import { ButtonToolbar, Button, Checkbox, Panel, Col } from 'react-bootstrap';
 import { checkServerIdentity } from 'tls';
 import MultiCrumb from 'components/MultiCrumb';
+import { bucketKeyStringIsMissing } from 'utils/aggs/bucketKeyIsMissing';
 interface Undo {
   description: string;
   action: () => void;
@@ -122,6 +123,9 @@ class BulkEditView extends React.Component<BulkEditProps, BulkEditState> {
                     const isToRemove =
                       groupedByLabel.toRemove[label] &&
                       groupedByLabel.toRemove[label].includes(value);
+                    const checkboxName = bucketKeyStringIsMissing(value)
+                      ? 'Allow Missing'
+                      : value;
                     return (
                       <Checkbox
                         key={`${label}-${value}`}
@@ -134,7 +138,7 @@ class BulkEditView extends React.Component<BulkEditProps, BulkEditState> {
                         onChange={() =>
                           this.handleSelect(label, value, isToAdd)
                         }>
-                        {value}
+                        {checkboxName}
                       </Checkbox>
                     );
                   })}

--- a/front/app/containers/BulkEditPage/BulkEditView.tsx
+++ b/front/app/containers/BulkEditPage/BulkEditView.tsx
@@ -123,9 +123,10 @@ class BulkEditView extends React.Component<BulkEditProps, BulkEditState> {
                     const isToRemove =
                       groupedByLabel.toRemove[label] &&
                       groupedByLabel.toRemove[label].includes(value);
-                    const checkboxName = bucketKeyStringIsMissing(value)
-                      ? 'Allow Missing'
-                      : value;
+                    if (bucketKeyStringIsMissing(value)) {
+                      // don't allow bulk adding missing value to matching pages
+                      return null;
+                    }
                     return (
                       <Checkbox
                         key={`${label}-${value}`}
@@ -138,7 +139,7 @@ class BulkEditView extends React.Component<BulkEditProps, BulkEditState> {
                         onChange={() =>
                           this.handleSelect(label, value, isToAdd)
                         }>
-                        {checkboxName}
+                        {value}
                       </Checkbox>
                     );
                   })}

--- a/front/app/containers/WorkflowPage/SuggestedLabels.tsx
+++ b/front/app/containers/WorkflowPage/SuggestedLabels.tsx
@@ -3,23 +3,14 @@ import styled from 'styled-components';
 import { Query } from 'react-apollo';
 import { gql } from 'apollo-boost';
 import PREFETCH_QUERY from '../StudyPage';
-import {
-  Checkbox,
-  Col,
-} from 'react-bootstrap';
+import { Checkbox, Col } from 'react-bootstrap';
 import {
   SuggestedLabelsQuery,
   SuggestedLabelsQueryVariables,
   SuggestedLabelsQuery_crowdAggFacets_aggs,
 } from 'types/SuggestedLabelsQuery';
-import {
-  pipe,
-  pathOr,
-  map,
-  filter,
-  fromPairs,
-  keys,
-} from 'ramda';
+import { pipe, pathOr, map, filter, fromPairs, keys } from 'ramda';
+import { bucketKeyStringIsMissing } from 'utils/aggs/bucketKeyIsMissing';
 import CollapsiblePanel from 'components/CollapsiblePanel';
 import { SearchParams, SearchQuery } from 'containers/SearchPage/shared';
 import { WorkSearch } from './WorkSearch';
@@ -138,20 +129,24 @@ class SuggestedLabels extends React.PureComponent<
   }
 
   renderAgg = (key: string, values: [string, boolean][]) => {
+    if (bucketKeyStringIsMissing(key)) {
+      // don't suggest the "missing" label
+      return null;
+    }
     return (
       <StyledPanel key={key} header={key} dropdown>
-          {/* <Col xs={4}> */}
-            {values.map(([value, checked]) => (
-              <Checkbox
-                key={value}
-                checked={checked}
-                disabled={this.props.disabled}
-                onChange={this.handleSelect(key, value)}>
-                {value}
-              </Checkbox>
-            ))}
-          {/* </Col> */}
-          {/* <Col xs={4}>
+        {/* <Col xs={4}> */}
+        {values.map(([value, checked]) => (
+          <Checkbox
+            key={value}
+            checked={checked}
+            disabled={this.props.disabled}
+            onChange={this.handleSelect(key, value)}>
+            {value}
+          </Checkbox>
+        ))}
+        {/* </Col> */}
+        {/* <Col xs={4}>
             <div>
               <WorkSearch nctid={this.props.nctId} />
             </div>

--- a/front/app/utils/aggs/bucketKeyIsMissing.ts
+++ b/front/app/utils/aggs/bucketKeyIsMissing.ts
@@ -4,13 +4,21 @@ import {
 } from 'utils/constants';
 import { AggBucket } from 'containers/SearchPage/Types';
 
-function bucketKeyIsMissing(bucket: AggBucket): boolean {
-  const { key, keyAsString } = bucket;
+export function bucketKeyStringIsMissing(key: string): boolean {
+  return key == STRING_MISSING_IDENTIFIER || key === DATE_MISSING_IDENTIFIER;
+}
+
+export function bucketKeyAsStringIsMissing(keyAsString: string): boolean {
   return (
-    key == STRING_MISSING_IDENTIFIER ||
     keyAsString === STRING_MISSING_IDENTIFIER ||
-    key === DATE_MISSING_IDENTIFIER ||
     keyAsString === DATE_MISSING_IDENTIFIER
+  );
+}
+
+function bucketKeyIsMissing(bucket: AggBucket): boolean {
+  return (
+    bucketKeyStringIsMissing(bucket.key) ||
+    bucketKeyStringIsMissing(bucket.keyAsString || '')
   );
 }
 export default bucketKeyIsMissing;


### PR DESCRIPTION
* Fix a bug where you couldn't select "allow missing" for pre-search view site config
* Don't show missing value as an option for a bulk label
* Don't show the missing value as a suggested label in workflow (I had a hard time getting this to display on my local instance, so I just found where it was in the code)

(resolves #441)