### PR TITLE
fix diff comment bug in new history view

### DIFF
--- a/app/graphql/types/diff_type.rb
+++ b/app/graphql/types/diff_type.rb
@@ -5,6 +5,6 @@ module Types
     value "INS", "Inserted line"
     value "DEL", "Deleted line"
     value "UNCHANGED", "Unchanged line"
-    value "COMMENT", "A comment line"
+    value "DIFFCOMMENT", "A comment line"
   end
 end

--- a/app/graphql/types/wiki_page_edit_type.rb
+++ b/app/graphql/types/wiki_page_edit_type.rb
@@ -33,7 +33,7 @@ module Types
           body_changed ||= !in_front_matter
         end
         {
-          status: status,
+          status: status.gsub(/-/, ""),
           content: tag.text,
           front_matter: in_front_matter,
           body: !in_front_matter,


### PR DESCRIPTION
* Added `DIFFCOMMENT` to GraphQL Enum
* Replace `diff-comment` status with `DIFFCOMMENT` status during preparation of data in GraphQL backend

Since Diffy uses the native `diff` command on a given deployment to work, I'm wondering if this didn't get caught earlier because of differences in the `diff` binary as deployed vs. on my Mac.

Another thing worth noting: I parsed all of our existing diff html entries using Nokogiri, and it took me about 20 seconds to parse all existing records, so I think that answers that in terms of performance for individual entries.