### PR TITLE
RTM Additional fix for issue #372

### DIFF
--- a/front/app/containers/AggDropDown/AggDropDown.tsx
+++ b/front/app/containers/AggDropDown/AggDropDown.tsx
@@ -408,6 +408,12 @@ class AggDropDown extends React.Component<AggDropDownProps, AggDropDownState> {
 
   findFields = () => {
     const { agg, site, currentSiteView } = this.props;
+    if (this.props.presearch== true){
+      return find(propEq('name', agg), [
+        ...(currentSiteView?.search?.presearch?.aggs?.fields || []),
+        ...(currentSiteView?.search?.presearch?.crowdAggs?.fields || []),
+      ]) as SiteViewFragment_search_aggs_fields | null;
+    }
     return find(propEq('name', agg), [
       ...(currentSiteView?.search?.aggs?.fields || []),
       ...(currentSiteView?.search?.crowdAggs?.fields || []),
@@ -608,18 +614,19 @@ class AggDropDown extends React.Component<AggDropDownProps, AggDropDownState> {
   componentDidMount() {
     let fields = this.props.currentSiteView.search.aggs.fields;
     const field = this.findFields();
-    if (field?.order && field.order.sortKind == 'key') {
-      this.setState({
-        sortKind: 0,
-        desc: field.order.desc,
-      });
-    } else if (field?.order && field.order.sortKind == 'count') {
-      this.setState({
-        sortKind: 1,
-        desc: field.order.desc,
-      });
+    console.log("Presearch", this.props.presearch ,field)
+      if (field?.order && field.order.sortKind == 'key') {
+        this.setState({
+          sortKind: 0,
+          desc: field.order.desc,
+        });
+      } else if (field?.order && field.order.sortKind == 'count') {
+        this.setState({
+          sortKind: 1,
+          desc: field.order.desc,
+        });
+      }
     }
-  }
 
   render() {
     const { agg, presearch } = this.props;


### PR DESCRIPTION
Presearch crowd aggs previously were not getting it's default sort options from the right place. 

The first picture is of the configuration I set for presearch followed by facet bar. I included both so you can see I have essentially configured them to be opposites to show they are now independent as was intended. 

_Preseach Config_
![Screen Shot 2020-04-21 at 5 14 21 PM](https://user-images.githubusercontent.com/17464571/79919409-f5a8e680-83f3-11ea-8f78-5c6041121312.png)

_FacetBar Config_
![Screen Shot 2020-04-21 at 5 15 26 PM](https://user-images.githubusercontent.com/17464571/79919417-f8a3d700-83f3-11ea-8930-03e7e600d506.png)

Lastly, this image shows the presearch correctly displaying configured default sort options with the _tags_ open in the facet bar to demonstrate they are different. 

![Screen Shot 2020-04-21 at 5 15 46 PM](https://user-images.githubusercontent.com/17464571/79919580-4587ad80-83f4-11ea-9c19-0dd1f4705127.png)
