### PR TITLE
add buttons to maximize and minimize all edits on history page

### DIFF
--- a/front/app/components/Edits/Edit.tsx
+++ b/front/app/components/Edits/Edit.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Row, Col } from 'react-bootstrap';
 import { WikiPageEditFragment } from 'types/WikiPageEditFragment';
+import ExpansionContext from 'containers/WikiPage/ExpansionContext';
 import EditBlurb from './EditBlurb';
 import ExpandedEdit from './ExpandedEdit';
 
@@ -8,35 +9,36 @@ interface EditProps {
   edit: WikiPageEditFragment;
 }
 
-interface EditState {
-  expanded: boolean;
-}
-
-class Edit extends React.Component<EditProps, EditState> {
-  state = {
-    expanded: false,
-  };
-
-  setExpanded = expanded => this.setState({ ...this.state, expanded });
-
+class Edit extends React.Component<EditProps> {
   render() {
     const { edit } = this.props;
-    const { expanded } = this.state;
+
     return (
       <tr key={edit.id} style={{ padding: '10px' }}>
         <td>
-          <EditBlurb
-            edit={edit}
-            expanded={expanded}
-            setExpanded={this.setExpanded}
-          />
-          {expanded && (
-            <Row style={{ padding: '10px', marginBottom: '10px' }}>
-              <Col md={12}>
-                <ExpandedEdit edit={edit} />
-              </Col>
-            </Row>
-          )}
+          <ExpansionContext.Consumer>
+            {({ historyExpanded, toggleEditVisibility }) => {
+              const expanded = historyExpanded[edit.id];
+              const nodes = [
+                <EditBlurb
+                  edit={edit}
+                  expanded={expanded}
+                  setExpanded={toggleEditVisibility(edit.id)}
+                />,
+              ];
+
+              if (expanded) {
+                nodes.push(
+                  <Row style={{ padding: '10px', marginBottom: '10px' }}>
+                    <Col md={12}>
+                      <ExpandedEdit edit={edit} />
+                    </Col>
+                  </Row>
+                );
+              }
+              return nodes;
+            }}
+          </ExpansionContext.Consumer>
         </td>
       </tr>
     );

--- a/front/app/components/Edits/Edits.tsx
+++ b/front/app/components/Edits/Edits.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
-import {
-  WikiPageEditFragment,
-} from 'types/WikiPageEditFragment';
-import StyleWrapper from "./StyleWrapper";
-import Edit from "./Edit";
-
+import { WikiPageEditFragment } from 'types/WikiPageEditFragment';
+import StyleWrapper from './StyleWrapper';
+import Edit from './Edit';
 
 interface EditsProps {
   edits: WikiPageEditFragment[];
@@ -12,7 +9,7 @@ interface EditsProps {
 
 class Edits extends React.Component<EditsProps> {
   render() {
-    const { edits } = this.props
+    const { edits } = this.props;
     return (
       <StyleWrapper striped bordered>
         <tbody>

--- a/front/app/containers/WikiPage/ExpansionContext.tsx
+++ b/front/app/containers/WikiPage/ExpansionContext.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+interface ExpansionContextType {
+  historyExpanded?: any;
+  toggleEditVisibility?: any;
+}
+
+const context: ExpansionContextType = {
+  historyExpanded: {},
+  toggleEditVisibility: () => {},
+};
+
+const ExpansionContext = React.createContext(context);
+
+export default ExpansionContext;


### PR DESCRIPTION
* Move management of "expanded" vs "not expanded" view of an edit to `WikiPage` container, inside of an `ExpansionContext`
* Add ability to maximize all history via a button rendered in the wiki page container
* Add ability to minimize all history via a button rendered in the wiki page container
* Utilize the expansion context to provide a view of whether a given edit should or should not render details.

<img width="1140" alt="Screen Shot 2020-04-22 at 6 26 15 PM" src="https://user-images.githubusercontent.com/232917/80039973-0d9d6a80-84c7-11ea-86de-5134007461dc.png">
<img width="1138" alt="Screen Shot 2020-04-22 at 6 26 03 PM" src="https://user-images.githubusercontent.com/232917/80039974-0d9d6a80-84c7-11ea-8c70-bea8d759f1ec.png">
<img width="1149" alt="Screen Shot 2020-04-22 at 6 25 50 PM" src="https://user-images.githubusercontent.com/232917/80039976-0d9d6a80-84c7-11ea-8922-b176c0caa033.png">
