### PR TITLE
RTM Missing themeProvider component: issue #484

### DIFF
--- a/front/app/containers/FacilitiesPage/FacilityCard.tsx
+++ b/front/app/containers/FacilitiesPage/FacilityCard.tsx
@@ -253,7 +253,7 @@ class FacilityCard extends React.PureComponent<any> {
   renderContactList = contacts => {
     return (
       <div>
-        <FacilitySubHead>Contact Info:</FacilitySubHead>
+        <ThemedFacilitySubHead>Contact Info:</ThemedFacilitySubHead>
         <div
           style={{
             display: 'flex',


### PR DESCRIPTION
A component was missing withTheme Provider causing some studies (specifical ones with facility contact Info) to crash when expanding facilities card


![Screen Shot 2020-04-23 at 1 02 34 PM](https://user-images.githubusercontent.com/17464571/80133411-ccf32f00-8562-11ea-9cc3-38e5fc10c441.png)
