### PR TITLE
494 bug fix google oauth

### DIFF
--- a/app/graphql/mutations/sign_in.rb
+++ b/app/graphql/mutations/sign_in.rb
@@ -14,7 +14,6 @@ module Mutations
         kid = header ? JSON.parse(header)["kid"] : nil
         return { jwt: nil, user: nil, errors: ["Oauth token missing kid"] } if !kid
         payload, header = decode_jwt(o_auth_token, kid)
-        password = Devise.friendly_token(8)
         provider = payload["iss"]
         user = User.find_or_create_from_payload(payload)
       else

--- a/app/graphql/mutations/sign_in.rb
+++ b/app/graphql/mutations/sign_in.rb
@@ -8,7 +8,7 @@ module Mutations
     argument :o_auth_token, String, required:false
 
   def resolve(email:, password:, o_auth_token: nil)
-      if o_auth_token && !o_auth_token.nil?
+      if o_auth_token && !o_auth_token.empty?
         return { jwt: nil, user: nil, errors: ["Oauth token not three segments"] } if !o_auth_token.split(".").size.eql? 3
         header = Base64.decode64 (o_auth_token.split(".")[0])
         kid = header ? JSON.parse(header)["kid"] : nil
@@ -18,7 +18,7 @@ module Mutations
         provider = payload["iss"]
         user = User.find_or_create_from_payload(payload)
       else
-        user = User.find_by(email:email) unless user
+        user = User.find_by(email:email)
         return nil unless user
         return nil unless user.valid_password?(password)
       end

--- a/app/graphql/mutations/sign_in.rb
+++ b/app/graphql/mutations/sign_in.rb
@@ -8,7 +8,7 @@ module Mutations
     argument :o_auth_token, String, required:false
 
   def resolve(email:, password:, o_auth_token: nil)
-      if o_auth_token && !o_auth_token.empty?
+      if o_auth_token && !o_auth_token.nil?
         return { jwt: nil, user: nil, errors: ["Oauth token not three segments"] } if !o_auth_token.split(".").size.eql? 3
         header = Base64.decode64 (o_auth_token.split(".")[0])
         kid = header ? JSON.parse(header)["kid"] : nil
@@ -17,11 +17,11 @@ module Mutations
         password = Devise.friendly_token(8)
         provider = payload["iss"]
         user = User.find_or_create_from_payload(payload)
+      else
+        user = User.find_by(email:email) unless user
+        return nil unless user
+        return nil unless user.valid_password?(password)
       end
-      user = User.find_by(email:email) unless user
-      return nil unless user
-
-      return nil unless user.valid_password?(password) || o_auth_token
 
       hmac_secret = Rails.application.secrets.secret_key_base
       exp_secs = ENV["JWT_EXPIRATION_TIME_SECS"] || 86_400


### PR DESCRIPTION
Fix where you could bypass authorization without correct password. Sign in now has two ways you can go. One is if you pass a o_auth_token that is not empty(currently empty always from front end unless oauth picked) you go through the google oauth. If you pass an empty string oauthtoken or no oauthtoken you go through the password path.