### PR TITLE
Workflow missing value bugfixes

### DIFF
--- a/front/app/components/StyledComponents/index.ts
+++ b/front/app/components/StyledComponents/index.ts
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 import withTheme from '../../containers/ThemeProvider';
 
-const StyledButton = styled.div`
+// keep this as a button!
+const StyledButton = styled.button`
   padding: 10px 15px;
   background: ${props => props.theme.button};
   display: inline-block;
@@ -24,19 +25,17 @@ const StyledButton = styled.div`
 
 export const ThemedButton = withTheme(StyledButton);
 
-const LinkContainer = 
-styled.div`
- position: absolute;
- bottom: 30px;
- a {
-   color: ${props => props.theme.authPage.signInLinks};
-   margin-right: 15px;
- } 
- a:hover {
-   color: ${props => props.theme.authPage.signInLinksHover}
- }
- `
-;
+const LinkContainer = styled.div`
+  position: absolute;
+  bottom: 30px;
+  a {
+    color: ${props => props.theme.authPage.signInLinks};
+    margin-right: 15px;
+  }
+  a:hover {
+    color: ${props => props.theme.authPage.signInLinksHover};
+  }
+`;
 
 export const ThemedLinkContainer = withTheme(LinkContainer);
 

--- a/front/app/containers/AggDropDown/Buckets.tsx
+++ b/front/app/containers/AggDropDown/Buckets.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { pipe, filter, map } from 'ramda';
+import { pipe, filter, map, defaultTo } from 'ramda';
 import { SiteViewFragment_search_aggs_fields } from 'types/SiteViewFragment';
 import { FieldDisplay } from 'types/globalTypes';
 import { SiteFragment } from 'types/SiteFragment';
@@ -36,7 +36,7 @@ class Buckets extends React.Component<BucketsProps> {
             checked={updater.isSelected(bucket.key)}
             onChange={() => updater.toggleFilter(bucket.key)}>
             <Bucket
-              value={bucket.key}
+              value={defaultTo(bucket.key)(bucket.keyAsString)}
               display={display}
               docCount={bucket.docCount}
             />

--- a/front/app/containers/LoginPage/SignInPage.tsx
+++ b/front/app/containers/LoginPage/SignInPage.tsx
@@ -137,7 +137,6 @@ class SignInPage extends React.Component<SignInPageProps, SignInPageState> {
                 <form
                   onSubmit={e => {
                     e.preventDefault();
-                    console.log('here');
                     this.handleSignIn(signIn);
                   }}>
                   <StyledFormControl

--- a/front/app/containers/LoginPage/SignInPage.tsx
+++ b/front/app/containers/LoginPage/SignInPage.tsx
@@ -6,7 +6,7 @@ import { gql } from 'apollo-boost';
 import { SignInMutation, SignInMutationVariables } from 'types/SignInMutation';
 import StyledFormControl from './StyledFormControl';
 import StyledContainer from './StyledContainer';
-import {ThemedButton} from '../../components/StyledComponents';
+import { ThemedButton } from '../../components/StyledComponents';
 import { Link } from 'react-router-dom';
 import { History, Location } from 'history';
 import { setLocalJwt } from 'utils/localStorage';
@@ -16,12 +16,12 @@ import { omit } from 'ramda';
 import StyledWrapper from './StyledWrapper';
 import { GoogleLogin } from 'react-google-login';
 import withTheme from './../ThemeProvider';
-import {ThemedLinkContainer} from '../../components/StyledComponents';
+import { ThemedLinkContainer } from '../../components/StyledComponents';
 
 interface SignInPageProps {
   history: History;
   location: Location;
-  theme: any
+  theme: any;
 }
 interface SignInPageState {
   form: {
@@ -49,9 +49,6 @@ class SignInMutationComponent extends Mutation<
   SignInMutationVariables
 > {}
 type SignInMutationFn = MutationFn<SignInMutation, SignInMutationVariables>;
-
-
-
 
 class SignInPage extends React.Component<SignInPageProps, SignInPageState> {
   state: SignInPageState = {
@@ -137,9 +134,10 @@ class SignInPage extends React.Component<SignInPageProps, SignInPageState> {
                 this.setState({ errors: ['Invalid email or password'] });
               }}>
               {signIn => (
-                <form 
+                <form
                   onSubmit={e => {
                     e.preventDefault();
+                    console.log('here');
                     this.handleSignIn(signIn);
                   }}>
                   <StyledFormControl

--- a/front/app/types/SuggestedLabelsQuery.ts
+++ b/front/app/types/SuggestedLabelsQuery.ts
@@ -8,6 +8,7 @@
 export interface SuggestedLabelsQuery_crowdAggFacets_aggs_buckets {
   __typename: "AggBucket";
   key: string;
+  keyAsString: string | null;
   docCount: number;
 }
 


### PR DESCRIPTION
* Filter missing values from the workflow panel properly
* Noticed that some bucket values should be getting
  rendered with `keyAsString` instead of `key`, so
  added some support there.

I already fixed this once, but I saw that the login form
button was turned back into a div. *This breaks logging
in through submitting by a carriage return. Usability is important!*
I've changed the `ThemedButton` from a styled div to a styled
button.