### PR TITLE
respect aggs in exports

### DIFF
--- a/app/models/search_export.rb
+++ b/app/models/search_export.rb
@@ -10,7 +10,7 @@ class SearchExport < ApplicationRecord
   end
 
   def params
-    JSON.parse(short_link.long)
+    JSON.parse(short_link.long).deep_symbolize_keys!
   end
 
   def fields

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -92,11 +92,11 @@ DEFAULT_AGG_OPTIONS = {
     limit: 10,
     order: { "_term" => "asc" },
   },
-  :"wiki_page_edits.email" => {
+  "wiki_page_edits.email": {
     limit: 10,
     order: { "_term" => "asc" },
   },
-  :"wiki_page_edits.created_at"=> {
+  "wiki_page_edits.created_at": {
     date_histogram: {
       field: :"wiki_page_edits.created_at",
       interval: :year,
@@ -166,7 +166,7 @@ class SearchService
   end
 
   def enrich_body(body)
-    body[:query][:bool][:must] =[ { query_string: { query: search_query } }]
+    body[:query][:bool][:must] = [{ query_string: { query: search_query } }]
     body[:query][:bool][:must] += nested_filters unless nested_filters.empty?
     body[:query][:bool][:must] += nested_range_filters unless nested_range_filters.empty?
   end
@@ -362,9 +362,8 @@ class SearchService
     nested.map { |filter| nested_filter(key_for(filter: filter), filter) }
   end
 
-
   def nested_range_filters
-    #Nested range has to include gte and lte and a dot
+    # Nested range has to include gte and lte and a dot
     nested = params.fetch(:agg_filters, []).select { |filter| filter[:field].to_s.include?(".") && !filter.slice(:gte, :lte).empty? }
     nested.map { |filter| nested_range_filter(key_for(filter: filter), filter) }
   end
@@ -389,15 +388,16 @@ class SearchService
   def nested_range_filter(key, filter)
     range_hash = filter.is_a?(Hash) ? filter.slice(:gte, :lte) : {}
     return nil unless key.to_s.include?(".") && !range_hash.empty?
+
     top_key, nested_key = key.to_s.split(".")
-    #Not sure what happesn if nil is in lte
+    # Not sure what happesn if nil is in lte
     {
       nested: {
         path: top_key,
         query: {
           bool: {
-            should:{
-              range: { key=> {gte: cast(range_hash[:gte]),lte: cast(range_hash[:lte])}},
+            should: {
+              range: { key => { gte: cast(range_hash[:gte]), lte: cast(range_hash[:lte]) } },
             },
           },
         },
@@ -407,6 +407,7 @@ class SearchService
 
   def range_filter(key, filter)
     return nil if key.to_s.include? "."
+
     range_hash = filter.slice(:gte, :lte)
     return nil if range_hash.empty?
 

--- a/spec/graphql/__snapshots__/basic_agg_filter_search_graphql_response.snap
+++ b/spec/graphql/__snapshots__/basic_agg_filter_search_graphql_response.snap
@@ -1,1 +1,500 @@
-{"data"=>{"search"=>{"recordsTotal"=>46, "aggs"=>[{"buckets"=>[{"key"=>"Phase 1", "docCount"=>28}, {"key"=>"Phase 2", "docCount"=>18}]}, {"buckets"=>[{"key"=>"Antibodies", "docCount"=>7}, {"key"=>"Everolimus", "docCount"=>5}, {"key"=>"Sirolimus", "docCount"=>5}, {"key"=>"Vaccines", "docCount"=>5}, {"key"=>"Antibodies, Monoclonal", "docCount"=>4}, {"key"=>"Irinotecan", "docCount"=>4}, {"key"=>"Fluorouracil", "docCount"=>3}, {"key"=>"Gemcitabine", "docCount"=>3}, {"key"=>"Immunoglobulins", "docCount"=>3}, {"key"=>"Immunotoxins", "docCount"=>3}]}, {"buckets"=>[{"key"=>"Chicago", "docCount"=>5}, {"key"=>"Houston", "docCount"=>5}, {"key"=>"Rochester", "docCount"=>5}, {"key"=>"Bethesda", "docCount"=>4}, {"key"=>"Billings", "docCount"=>3}, {"key"=>"Boston", "docCount"=>3}, {"key"=>"San Francisco", "docCount"=>3}, {"key"=>"Scottsdale", "docCount"=>3}, {"key"=>"Bettendorf", "docCount"=>2}, {"key"=>"Bismarck", "docCount"=>2}]}, {"buckets"=>[{"key"=>"Completed", "docCount"=>29}, {"key"=>"Terminated", "docCount"=>9}, {"key"=>"Unknown status", "docCount"=>5}, {"key"=>"Active, not recruiting", "docCount"=>2}, {"key"=>"Withdrawn", "docCount"=>1}]}, {"buckets"=>[{"key"=>"0", "docCount"=>46}]}, {"buckets"=>[]}, {"buckets"=>[{"key"=>"Pancreatic Neoplasms", "docCount"=>46}, {"key"=>"Stomach Neoplasms", "docCount"=>38}, {"key"=>"Intestinal Neoplasms", "docCount"=>17}, {"key"=>"Breast Neoplasms", "docCount"=>14}, {"key"=>"Cholangiocarcinoma", "docCount"=>13}, {"key"=>"Esophageal Neoplasms", "docCount"=>13}, {"key"=>"Gallbladder Neoplasms", "docCount"=>13}, {"key"=>"Bile Duct Neoplasms", "docCount"=>12}, {"key"=>"Lung Neoplasms", "docCount"=>12}, {"key"=>"Carcinoid Tumor", "docCount"=>11}]}, {"buckets"=>[{"key"=>"Mayo Clinic", "docCount"=>3}, {"key"=>"Abbott-Northwestern Hospital", "docCount"=>2}, {"key"=>"CCOP - Duluth", "docCount"=>2}, {"key"=>"CCOP - Missouri Valley Cancer Consortium", "docCount"=>2}, {"key"=>"Dana-Farber Cancer Institute", "docCount"=>2}, {"key"=>"Fox Chase Cancer Center", "docCount"=>2}, {"key"=>"M D Anderson Cancer Center", "docCount"=>2}, {"key"=>"Mayo Clinic Cancer Center", "docCount"=>2}, {"key"=>"Rapid City Regional Hospital", "docCount"=>2}, {"key"=>"University of Wisconsin Hospital and Clinics", "docCount"=>2}]}, {"buckets"=>[{"key"=>"United States", "docCount"=>35}, {"key"=>"Canada", "docCount"=>2}, {"key"=>"Germany", "docCount"=>2}, {"key"=>"China", "docCount"=>1}, {"key"=>"Greece", "docCount"=>1}, {"key"=>"Israel", "docCount"=>1}, {"key"=>"Italy", "docCount"=>1}, {"key"=>"Korea, Republic of", "docCount"=>1}, {"key"=>"Netherlands", "docCount"=>1}, {"key"=>"Serbia", "docCount"=>1}]}, {"buckets"=>[{"key"=>"Interventional", "docCount"=>46}]}, {"buckets"=>[{"key"=>"National Cancer Institute (NCI)", "docCount"=>31}, {"key"=>"Alliance for Clinical Trials in Oncology", "docCount"=>2}, {"key"=>"City of Hope Medical Center", "docCount"=>2}, {"key"=>"M.D. Anderson Cancer Center", "docCount"=>2}, {"key"=>"Novartis", "docCount"=>2}, {"key"=>"Agensys, Inc.", "docCount"=>1}, {"key"=>"Arcispedale Santa Maria Nuova-IRCCS", "docCount"=>1}, {"key"=>"Cancer Institute and Hospital, Chinese Academy of Medical Sciences", "docCount"=>1}, {"key"=>"Cancer Research UK", "docCount"=>1}, {"key"=>"Clovis Oncology, Inc.", "docCount"=>1}]}, {"buckets"=>[{"key"=>"Texas", "docCount"=>9}, {"key"=>"", "docCount"=>8}, {"key"=>"California", "docCount"=>7}, {"key"=>"Illinois", "docCount"=>7}, {"key"=>"Arizona", "docCount"=>5}, {"key"=>"Maryland", "docCount"=>5}, {"key"=>"Minnesota", "docCount"=>5}, {"key"=>"New York", "docCount"=>5}, {"key"=>"North Carolina", "docCount"=>5}, {"key"=>"Pennsylvania", "docCount"=>5}]}, {"buckets"=>[]}, {"buckets"=>[{"key"=>"laboratory biomarker analysis", "docCount"=>4}, {"key"=>"Laboratory Biomarker Analysis", "docCount"=>3}, {"key"=>"Everolimus", "docCount"=>2}, {"key"=>"Pazopanib Hydrochloride", "docCount"=>2}, {"key"=>"Pharmacological Study", "docCount"=>2}, {"key"=>"irinotecan hydrochloride", "docCount"=>2}, {"key"=>"oxaliplatin", "docCount"=>2}, {"key"=>"placebo", "docCount"=>2}, {"key"=>"24 Gy in 3 fractions", "docCount"=>1}, {"key"=>"7-hydroxystaurosporine", "docCount"=>1}]}], "studies"=>[{"nctId"=>"NCT00001805"}, {"nctId"=>"NCT00003046"}, {"nctId"=>"NCT00003125"}, {"nctId"=>"NCT00003157"}, {"nctId"=>"NCT00003427"}, {"nctId"=>"NCT00004074"}, {"nctId"=>"NCT00004604"}, {"nctId"=>"NCT00004895"}, {"nctId"=>"NCT00010270"}, {"nctId"=>"NCT00012246"}, {"nctId"=>"NCT00014456"}, {"nctId"=>"NCT00019435"}, {"nctId"=>"NCT00019474"}, {"nctId"=>"NCT00024063"}, {"nctId"=>"NCT00025532"}, {"nctId"=>"NCT00027534"}, {"nctId"=>"NCT00028496"}, {"nctId"=>"NCT00031681"}, {"nctId"=>"NCT00249301"}, {"nctId"=>"NCT00376987"}, {"nctId"=>"NCT00397384"}, {"nctId"=>"NCT00454363"}, {"nctId"=>"NCT00534001"}, {"nctId"=>"NCT00544193"}, {"nctId"=>"NCT00621556"}]}}}
+{
+  "data": {
+    "search": {
+      "recordsTotal": 46,
+      "aggs": [
+        {
+          "buckets": [
+            {
+              "key": "Phase 1",
+              "docCount": 28
+            },
+            {
+              "key": "Phase 2",
+              "docCount": 18
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Antibodies",
+              "docCount": 7
+            },
+            {
+              "key": "Everolimus",
+              "docCount": 5
+            },
+            {
+              "key": "Sirolimus",
+              "docCount": 5
+            },
+            {
+              "key": "Vaccines",
+              "docCount": 5
+            },
+            {
+              "key": "Antibodies, Monoclonal",
+              "docCount": 4
+            },
+            {
+              "key": "Irinotecan",
+              "docCount": 4
+            },
+            {
+              "key": "Fluorouracil",
+              "docCount": 3
+            },
+            {
+              "key": "Gemcitabine",
+              "docCount": 3
+            },
+            {
+              "key": "Immunoglobulins",
+              "docCount": 3
+            },
+            {
+              "key": "Immunotoxins",
+              "docCount": 3
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Chicago",
+              "docCount": 5
+            },
+            {
+              "key": "Houston",
+              "docCount": 5
+            },
+            {
+              "key": "Rochester",
+              "docCount": 5
+            },
+            {
+              "key": "Bethesda",
+              "docCount": 4
+            },
+            {
+              "key": "Billings",
+              "docCount": 3
+            },
+            {
+              "key": "Boston",
+              "docCount": 3
+            },
+            {
+              "key": "San Francisco",
+              "docCount": 3
+            },
+            {
+              "key": "Scottsdale",
+              "docCount": 3
+            },
+            {
+              "key": "Bettendorf",
+              "docCount": 2
+            },
+            {
+              "key": "Bismarck",
+              "docCount": 2
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Completed",
+              "docCount": 29
+            },
+            {
+              "key": "Terminated",
+              "docCount": 9
+            },
+            {
+              "key": "Unknown status",
+              "docCount": 5
+            },
+            {
+              "key": "Active, not recruiting",
+              "docCount": 2
+            },
+            {
+              "key": "Withdrawn",
+              "docCount": 1
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "0",
+              "docCount": 46
+            }
+          ]
+        },
+        {
+          "buckets": [
+
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Pancreatic Neoplasms",
+              "docCount": 46
+            },
+            {
+              "key": "Stomach Neoplasms",
+              "docCount": 38
+            },
+            {
+              "key": "Intestinal Neoplasms",
+              "docCount": 17
+            },
+            {
+              "key": "Breast Neoplasms",
+              "docCount": 14
+            },
+            {
+              "key": "Cholangiocarcinoma",
+              "docCount": 13
+            },
+            {
+              "key": "Esophageal Neoplasms",
+              "docCount": 13
+            },
+            {
+              "key": "Gallbladder Neoplasms",
+              "docCount": 13
+            },
+            {
+              "key": "Bile Duct Neoplasms",
+              "docCount": 12
+            },
+            {
+              "key": "Lung Neoplasms",
+              "docCount": 12
+            },
+            {
+              "key": "Carcinoid Tumor",
+              "docCount": 11
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Mayo Clinic",
+              "docCount": 3
+            },
+            {
+              "key": "Abbott-Northwestern Hospital",
+              "docCount": 2
+            },
+            {
+              "key": "CCOP - Duluth",
+              "docCount": 2
+            },
+            {
+              "key": "CCOP - Missouri Valley Cancer Consortium",
+              "docCount": 2
+            },
+            {
+              "key": "Dana-Farber Cancer Institute",
+              "docCount": 2
+            },
+            {
+              "key": "Fox Chase Cancer Center",
+              "docCount": 2
+            },
+            {
+              "key": "M D Anderson Cancer Center",
+              "docCount": 2
+            },
+            {
+              "key": "Mayo Clinic Cancer Center",
+              "docCount": 2
+            },
+            {
+              "key": "Rapid City Regional Hospital",
+              "docCount": 2
+            },
+            {
+              "key": "University of Wisconsin Hospital and Clinics",
+              "docCount": 2
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "United States",
+              "docCount": 35
+            },
+            {
+              "key": "Canada",
+              "docCount": 2
+            },
+            {
+              "key": "Germany",
+              "docCount": 2
+            },
+            {
+              "key": "China",
+              "docCount": 1
+            },
+            {
+              "key": "Greece",
+              "docCount": 1
+            },
+            {
+              "key": "Israel",
+              "docCount": 1
+            },
+            {
+              "key": "Italy",
+              "docCount": 1
+            },
+            {
+              "key": "Korea, Republic of",
+              "docCount": 1
+            },
+            {
+              "key": "Netherlands",
+              "docCount": 1
+            },
+            {
+              "key": "Serbia",
+              "docCount": 1
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Interventional",
+              "docCount": 46
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "National Cancer Institute (NCI)",
+              "docCount": 31
+            },
+            {
+              "key": "Alliance for Clinical Trials in Oncology",
+              "docCount": 2
+            },
+            {
+              "key": "City of Hope Medical Center",
+              "docCount": 2
+            },
+            {
+              "key": "M.D. Anderson Cancer Center",
+              "docCount": 2
+            },
+            {
+              "key": "Novartis",
+              "docCount": 2
+            },
+            {
+              "key": "Agensys, Inc.",
+              "docCount": 1
+            },
+            {
+              "key": "Arcispedale Santa Maria Nuova-IRCCS",
+              "docCount": 1
+            },
+            {
+              "key": "Cancer Institute and Hospital, Chinese Academy of Medical Sciences",
+              "docCount": 1
+            },
+            {
+              "key": "Cancer Research UK",
+              "docCount": 1
+            },
+            {
+              "key": "Clovis Oncology, Inc.",
+              "docCount": 1
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Texas",
+              "docCount": 9
+            },
+            {
+              "key": "",
+              "docCount": 8
+            },
+            {
+              "key": "California",
+              "docCount": 7
+            },
+            {
+              "key": "Illinois",
+              "docCount": 7
+            },
+            {
+              "key": "Arizona",
+              "docCount": 5
+            },
+            {
+              "key": "Maryland",
+              "docCount": 5
+            },
+            {
+              "key": "Minnesota",
+              "docCount": 5
+            },
+            {
+              "key": "New York",
+              "docCount": 5
+            },
+            {
+              "key": "North Carolina",
+              "docCount": 5
+            },
+            {
+              "key": "Pennsylvania",
+              "docCount": 5
+            }
+          ]
+        },
+        {
+          "buckets": [
+
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "laboratory biomarker analysis",
+              "docCount": 4
+            },
+            {
+              "key": "Laboratory Biomarker Analysis",
+              "docCount": 3
+            },
+            {
+              "key": "Everolimus",
+              "docCount": 2
+            },
+            {
+              "key": "Pazopanib Hydrochloride",
+              "docCount": 2
+            },
+            {
+              "key": "Pharmacological Study",
+              "docCount": 2
+            },
+            {
+              "key": "irinotecan hydrochloride",
+              "docCount": 2
+            },
+            {
+              "key": "oxaliplatin",
+              "docCount": 2
+            },
+            {
+              "key": "placebo",
+              "docCount": 2
+            },
+            {
+              "key": "24 Gy in 3 fractions",
+              "docCount": 1
+            },
+            {
+              "key": "7-hydroxystaurosporine",
+              "docCount": 1
+            }
+          ]
+        }
+      ],
+      "studies": [
+        {
+          "nctId": "NCT00001805"
+        },
+        {
+          "nctId": "NCT00003046"
+        },
+        {
+          "nctId": "NCT00003125"
+        },
+        {
+          "nctId": "NCT00003157"
+        },
+        {
+          "nctId": "NCT00003427"
+        },
+        {
+          "nctId": "NCT00004074"
+        },
+        {
+          "nctId": "NCT00004604"
+        },
+        {
+          "nctId": "NCT00004895"
+        },
+        {
+          "nctId": "NCT00010270"
+        },
+        {
+          "nctId": "NCT00012246"
+        },
+        {
+          "nctId": "NCT00014456"
+        },
+        {
+          "nctId": "NCT00019435"
+        },
+        {
+          "nctId": "NCT00019474"
+        },
+        {
+          "nctId": "NCT00024063"
+        },
+        {
+          "nctId": "NCT00025532"
+        },
+        {
+          "nctId": "NCT00027534"
+        },
+        {
+          "nctId": "NCT00028496"
+        },
+        {
+          "nctId": "NCT00031681"
+        },
+        {
+          "nctId": "NCT00249301"
+        },
+        {
+          "nctId": "NCT00376987"
+        },
+        {
+          "nctId": "NCT00397384"
+        },
+        {
+          "nctId": "NCT00454363"
+        },
+        {
+          "nctId": "NCT00534001"
+        },
+        {
+          "nctId": "NCT00544193"
+        },
+        {
+          "nctId": "NCT00621556"
+        }
+      ]
+    }
+  }
+}

--- a/spec/graphql/__snapshots__/basic_agg_filter_search_query.snap
+++ b/spec/graphql/__snapshots__/basic_agg_filter_search_query.snap
@@ -1,1 +1,1216 @@
-{"aggs":{"average_rating":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"term":{"phase":{"value":"Phase 1"}}}]}},{"bool":{"filter":[{"term":{"phase":{"value":"Phase 2"}}}]}}]}}]}},{"bool":{"filter":[]}}]}}]}},"aggs":{"average_rating":{"terms":{"field":"average_rating","size":10}}}},"overall_status":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"term":{"phase":{"value":"Phase 1"}}}]}},{"bool":{"filter":[{"term":{"phase":{"value":"Phase 2"}}}]}}]}}]}},{"bool":{"filter":[]}}]}}]}},"aggs":{"overall_status":{"terms":{"field":"overall_status","size":10}}}},"facility_states":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"term":{"phase":{"value":"Phase 1"}}}]}},{"bool":{"filter":[{"term":{"phase":{"value":"Phase 2"}}}]}}]}}]}},{"bool":{"filter":[]}}]}}]}},"aggs":{"facility_states":{"terms":{"field":"facility_states","size":10}}}},"facility_cities":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"term":{"phase":{"value":"Phase 1"}}}]}},{"bool":{"filter":[{"term":{"phase":{"value":"Phase 2"}}}]}}]}}]}},{"bool":{"filter":[]}}]}}]}},"aggs":{"facility_cities":{"terms":{"field":"facility_cities","size":10}}}},"facility_names":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"term":{"phase":{"value":"Phase 1"}}}]}},{"bool":{"filter":[{"term":{"phase":{"value":"Phase 2"}}}]}}]}}]}},{"bool":{"filter":[]}}]}}]}},"aggs":{"facility_names":{"terms":{"field":"facility_names","size":10}}}},"facility_countries":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"term":{"phase":{"value":"Phase 1"}}}]}},{"bool":{"filter":[{"term":{"phase":{"value":"Phase 2"}}}]}}]}}]}},{"bool":{"filter":[]}}]}}]}},"aggs":{"facility_countries":{"terms":{"field":"facility_countries","size":10}}}},"study_type":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"term":{"phase":{"value":"Phase 1"}}}]}},{"bool":{"filter":[{"term":{"phase":{"value":"Phase 2"}}}]}}]}}]}},{"bool":{"filter":[]}}]}}]}},"aggs":{"study_type":{"terms":{"field":"study_type","size":10}}}},"sponsors":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"term":{"phase":{"value":"Phase 1"}}}]}},{"bool":{"filter":[{"term":{"phase":{"value":"Phase 2"}}}]}}]}}]}},{"bool":{"filter":[]}}]}}]}},"aggs":{"sponsors":{"terms":{"field":"sponsors","size":10}}}},"browse_condition_mesh_terms":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"term":{"phase":{"value":"Phase 1"}}}]}},{"bool":{"filter":[{"term":{"phase":{"value":"Phase 2"}}}]}}]}}]}},{"bool":{"filter":[]}}]}}]}},"aggs":{"browse_condition_mesh_terms":{"terms":{"field":"browse_condition_mesh_terms","size":10}}}},"phase":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"term":{"phase":{"value":"Phase 1"}}}]}},{"bool":{"filter":[{"term":{"phase":{"value":"Phase 2"}}}]}}]}}]}},{"bool":{"filter":[]}}]}}]}},"aggs":{"phase":{"terms":{"field":"phase","size":10}}}},"rating_dimensions":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"term":{"phase":{"value":"Phase 1"}}}]}},{"bool":{"filter":[{"term":{"phase":{"value":"Phase 2"}}}]}}]}}]}},{"bool":{"filter":[]}}]}}]}},"aggs":{"rating_dimensions":{"terms":{"field":"rating_dimensions","size":10}}}},"browse_interventions_mesh_terms":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"term":{"phase":{"value":"Phase 1"}}}]}},{"bool":{"filter":[{"term":{"phase":{"value":"Phase 2"}}}]}}]}}]}},{"bool":{"filter":[]}}]}}]}},"aggs":{"browse_interventions_mesh_terms":{"terms":{"field":"browse_interventions_mesh_terms","size":10}}}},"interventions_mesh_terms":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"term":{"phase":{"value":"Phase 1"}}}]}},{"bool":{"filter":[{"term":{"phase":{"value":"Phase 2"}}}]}}]}}]}},{"bool":{"filter":[]}}]}}]}},"aggs":{"interventions_mesh_terms":{"terms":{"field":"interventions_mesh_terms","size":10}}}},"front_matter_keys":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"term":{"phase":{"value":"Phase 1"}}}]}},{"bool":{"filter":[{"term":{"phase":{"value":"Phase 2"}}}]}}]}}]}},{"bool":{"filter":[]}}]}}]}},"aggs":{"front_matter_keys":{"terms":{"field":"front_matter_keys","size":10}}}},"start_date":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"term":{"phase":{"value":"Phase 1"}}}]}},{"bool":{"filter":[{"term":{"phase":{"value":"Phase 2"}}}]}}]}}]}},{"bool":{"filter":[]}}]}}]}},"aggs":{"start_date":{"terms":{"field":"start_date","size":10}}}}},"query":{"bool":{"must":{"query_string":{"query":"stomach"}},"filter":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[{"bool":{"filter":[{"term":{"phase":{"value":"Phase 1"}}}]}},{"bool":{"filter":[{"term":{"phase":{"value":"Phase 2"}}}]}}]}}]}},{"bool":{"filter":[]}}]}}]}},"sort":[{"nct_id":"asc"}],"timeout":"11s","_source":false,"size":25,"from":25}
+{
+  "aggs": {
+    "average_rating": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "average_rating": {
+          "terms": {
+            "field": "average_rating",
+            "size": 10
+          }
+        }
+      }
+    },
+    "overall_status": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "overall_status": {
+          "terms": {
+            "field": "overall_status",
+            "size": 10
+          }
+        }
+      }
+    },
+    "facility_states": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "facility_states": {
+          "terms": {
+            "field": "facility_states",
+            "size": 10
+          }
+        }
+      }
+    },
+    "facility_cities": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "facility_cities": {
+          "terms": {
+            "field": "facility_cities",
+            "size": 10
+          }
+        }
+      }
+    },
+    "facility_names": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "facility_names": {
+          "terms": {
+            "field": "facility_names",
+            "size": 10
+          }
+        }
+      }
+    },
+    "facility_countries": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "facility_countries": {
+          "terms": {
+            "field": "facility_countries",
+            "size": 10
+          }
+        }
+      }
+    },
+    "study_type": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "study_type": {
+          "terms": {
+            "field": "study_type",
+            "size": 10
+          }
+        }
+      }
+    },
+    "sponsors": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "sponsors": {
+          "terms": {
+            "field": "sponsors",
+            "size": 10
+          }
+        }
+      }
+    },
+    "browse_condition_mesh_terms": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "browse_condition_mesh_terms": {
+          "terms": {
+            "field": "browse_condition_mesh_terms",
+            "size": 10
+          }
+        }
+      }
+    },
+    "phase": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "phase": {
+          "terms": {
+            "field": "phase",
+            "size": 10
+          }
+        }
+      }
+    },
+    "rating_dimensions": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "rating_dimensions": {
+          "terms": {
+            "field": "rating_dimensions",
+            "size": 10
+          }
+        }
+      }
+    },
+    "browse_interventions_mesh_terms": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "browse_interventions_mesh_terms": {
+          "terms": {
+            "field": "browse_interventions_mesh_terms",
+            "size": 10
+          }
+        }
+      }
+    },
+    "interventions_mesh_terms": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "interventions_mesh_terms": {
+          "terms": {
+            "field": "interventions_mesh_terms",
+            "size": 10
+          }
+        }
+      }
+    },
+    "front_matter_keys": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "front_matter_keys": {
+          "terms": {
+            "field": "front_matter_keys",
+            "size": 10
+          }
+        }
+      }
+    },
+    "start_date": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "start_date": {
+          "terms": {
+            "field": "start_date",
+            "size": 10
+          }
+        }
+      }
+    },
+    "wiki_page_edits.email": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "wiki_page_edits.email": {
+          "terms": {
+            "field": "wiki_page_edits.email",
+            "size": 10
+          }
+        }
+      }
+    },
+    "wiki_page_edits.created_at": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 1"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "bool": {
+                                  "filter": [
+                                    {
+                                      "term": {
+                                        "phase": {
+                                          "value": "Phase 2"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "wiki_page_edits.created_at": {
+          "terms": {
+            "field": "wiki_page_edits.created_at",
+            "size": 10
+          }
+        }
+      }
+    }
+  },
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "query_string": {
+            "query": "stomach"
+          }
+        }
+      ],
+      "filter": [
+        {
+          "bool": {
+            "must": [
+              {
+                "bool": {
+                  "filter": [
+                    {
+                      "bool": {
+                        "should": [
+                          {
+                            "bool": {
+                              "filter": [
+                                {
+                                  "term": {
+                                    "phase": {
+                                      "value": "Phase 1"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "bool": {
+                              "filter": [
+                                {
+                                  "term": {
+                                    "phase": {
+                                      "value": "Phase 2"
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "filter": [
+
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "sort": [
+    {
+      "nct_id": "asc"
+    }
+  ],
+  "timeout": "11s",
+  "_source": false,
+  "size": 25,
+  "from": 25
+}

--- a/spec/graphql/__snapshots__/basic_search_graphql_response.snap
+++ b/spec/graphql/__snapshots__/basic_search_graphql_response.snap
@@ -1,1 +1,528 @@
-{"data"=>{"search"=>{"recordsTotal"=>85, "aggs"=>[{"buckets"=>[{"key"=>"Phase 1", "docCount"=>28}, {"key"=>"Phase 2", "docCount"=>18}, {"key"=>"N/A", "docCount"=>12}, {"key"=>"Phase 1/Phase 2", "docCount"=>5}, {"key"=>"Phase 4", "docCount"=>3}, {"key"=>"Phase 3", "docCount"=>2}, {"key"=>"Phase 2/Phase 3", "docCount"=>1}]}, {"buckets"=>[{"key"=>"Antibodies", "docCount"=>7}, {"key"=>"Everolimus", "docCount"=>5}, {"key"=>"Pancrelipase", "docCount"=>5}, {"key"=>"Sirolimus", "docCount"=>5}, {"key"=>"Vaccines", "docCount"=>5}, {"key"=>"Antibodies, Monoclonal", "docCount"=>4}, {"key"=>"Irinotecan", "docCount"=>4}, {"key"=>"Oxaliplatin", "docCount"=>4}, {"key"=>"Capecitabine", "docCount"=>3}, {"key"=>"Fluorouracil", "docCount"=>3}]}, {"buckets"=>[{"key"=>"Houston", "docCount"=>8}, {"key"=>"Chicago", "docCount"=>7}, {"key"=>"Scottsdale", "docCount"=>6}, {"key"=>"Bethesda", "docCount"=>5}, {"key"=>"Philadelphia", "docCount"=>5}, {"key"=>"Boston", "docCount"=>4}, {"key"=>"Danville", "docCount"=>4}, {"key"=>"Rochester", "docCount"=>4}, {"key"=>"San Francisco", "docCount"=>4}, {"key"=>"Nashville", "docCount"=>3}]}, {"buckets"=>[{"key"=>"Completed", "docCount"=>49}, {"key"=>"Terminated", "docCount"=>17}, {"key"=>"Unknown status", "docCount"=>10}, {"key"=>"Active, not recruiting", "docCount"=>5}, {"key"=>"Recruiting", "docCount"=>3}, {"key"=>"Withdrawn", "docCount"=>1}]}, {"buckets"=>[{"key"=>"0", "docCount"=>85}]}, {"buckets"=>[]}, {"buckets"=>[{"key"=>"Pancreatic Neoplasms", "docCount"=>85}, {"key"=>"Stomach Neoplasms", "docCount"=>67}, {"key"=>"Esophageal Neoplasms", "docCount"=>27}, {"key"=>"Intestinal Neoplasms", "docCount"=>25}, {"key"=>"Lung Neoplasms", "docCount"=>24}, {"key"=>"Liver Neoplasms", "docCount"=>23}, {"key"=>"Gallbladder Neoplasms", "docCount"=>19}, {"key"=>"Breast Neoplasms", "docCount"=>18}, {"key"=>"Cholangiocarcinoma", "docCount"=>18}, {"key"=>"Neoplasms", "docCount"=>17}]}, {"buckets"=>[{"key"=>"Mayo Clinic", "docCount"=>3}, {"key"=>"Abbott-Northwestern Hospital", "docCount"=>2}, {"key"=>"CCOP - Duluth", "docCount"=>2}, {"key"=>"CCOP - Missouri Valley Cancer Consortium", "docCount"=>2}, {"key"=>"City of Hope Medical Center", "docCount"=>2}, {"key"=>"Dana-Farber Cancer Institute", "docCount"=>2}, {"key"=>"Massachusetts General Hospital", "docCount"=>2}, {"key"=>"Mayo Clinic Cancer Center", "docCount"=>2}, {"key"=>"Mayo Clinic in Arizona", "docCount"=>2}, {"key"=>"Rapid City Regional Hospital", "docCount"=>2}]}, {"buckets"=>[{"key"=>"United States", "docCount"=>59}, {"key"=>"Germany", "docCount"=>6}, {"key"=>"Canada", "docCount"=>3}, {"key"=>"France", "docCount"=>3}, {"key"=>"Israel", "docCount"=>3}, {"key"=>"Italy", "docCount"=>3}, {"key"=>"Netherlands", "docCount"=>3}, {"key"=>"China", "docCount"=>2}, {"key"=>"Greece", "docCount"=>2}, {"key"=>"Austria", "docCount"=>1}]}, {"buckets"=>[{"key"=>"Interventional", "docCount"=>69}, {"key"=>"Observational", "docCount"=>16}]}, {"buckets"=>[{"key"=>"National Cancer Institute (NCI)", "docCount"=>44}, {"key"=>"M.D. Anderson Cancer Center", "docCount"=>5}, {"key"=>"City of Hope Medical Center", "docCount"=>3}, {"key"=>"Alliance for Clinical Trials in Oncology", "docCount"=>2}, {"key"=>"Columbia University", "docCount"=>2}, {"key"=>"Massachusetts General Hospital", "docCount"=>2}, {"key"=>"Mayo Clinic", "docCount"=>2}, {"key"=>"Northwestern University", "docCount"=>2}, {"key"=>"Novartis", "docCount"=>2}, {"key"=>"Roswell Park Cancer Institute", "docCount"=>2}]}, {"buckets"=>[{"key"=>"", "docCount"=>20}, {"key"=>"Texas", "docCount"=>13}, {"key"=>"New York", "docCount"=>10}, {"key"=>"Pennsylvania", "docCount"=>10}, {"key"=>"California", "docCount"=>9}, {"key"=>"Illinois", "docCount"=>9}, {"key"=>"Arizona", "docCount"=>7}, {"key"=>"Maryland", "docCount"=>7}, {"key"=>"Florida", "docCount"=>6}, {"key"=>"North Carolina", "docCount"=>6}]}, {"buckets"=>[]}, {"buckets"=>[{"key"=>"laboratory biomarker analysis", "docCount"=>4}, {"key"=>"Laboratory Biomarker Analysis", "docCount"=>3}, {"key"=>"Everolimus", "docCount"=>2}, {"key"=>"Pazopanib Hydrochloride", "docCount"=>2}, {"key"=>"Pharmacological Study", "docCount"=>2}, {"key"=>"bupropion hydrochloride", "docCount"=>2}, {"key"=>"educational intervention", "docCount"=>2}, {"key"=>"irinotecan hydrochloride", "docCount"=>2}, {"key"=>"pharmacological study", "docCount"=>2}, {"key"=>"placebo", "docCount"=>2}]}], "studies"=>[{"nctId"=>"NCT00001805"}, {"nctId"=>"NCT00003046"}, {"nctId"=>"NCT00003125"}, {"nctId"=>"NCT00003157"}, {"nctId"=>"NCT00003427"}, {"nctId"=>"NCT00004074"}, {"nctId"=>"NCT00004604"}, {"nctId"=>"NCT00004895"}, {"nctId"=>"NCT00004910"}, {"nctId"=>"NCT00010270"}, {"nctId"=>"NCT00012246"}, {"nctId"=>"NCT00014456"}, {"nctId"=>"NCT00019435"}, {"nctId"=>"NCT00019474"}, {"nctId"=>"NCT00024063"}, {"nctId"=>"NCT00025532"}, {"nctId"=>"NCT00027534"}, {"nctId"=>"NCT00028496"}, {"nctId"=>"NCT00031681"}, {"nctId"=>"NCT00041808"}, {"nctId"=>"NCT00087191"}, {"nctId"=>"NCT00249301"}, {"nctId"=>"NCT00279292"}, {"nctId"=>"NCT00310115"}, {"nctId"=>"NCT00359320"}]}}}
+{
+  "data": {
+    "search": {
+      "recordsTotal": 85,
+      "aggs": [
+        {
+          "buckets": [
+            {
+              "key": "Phase 1",
+              "docCount": 28
+            },
+            {
+              "key": "Phase 2",
+              "docCount": 18
+            },
+            {
+              "key": "N/A",
+              "docCount": 12
+            },
+            {
+              "key": "Phase 1/Phase 2",
+              "docCount": 5
+            },
+            {
+              "key": "Phase 4",
+              "docCount": 3
+            },
+            {
+              "key": "Phase 3",
+              "docCount": 2
+            },
+            {
+              "key": "Phase 2/Phase 3",
+              "docCount": 1
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Antibodies",
+              "docCount": 7
+            },
+            {
+              "key": "Everolimus",
+              "docCount": 5
+            },
+            {
+              "key": "Pancrelipase",
+              "docCount": 5
+            },
+            {
+              "key": "Sirolimus",
+              "docCount": 5
+            },
+            {
+              "key": "Vaccines",
+              "docCount": 5
+            },
+            {
+              "key": "Antibodies, Monoclonal",
+              "docCount": 4
+            },
+            {
+              "key": "Irinotecan",
+              "docCount": 4
+            },
+            {
+              "key": "Oxaliplatin",
+              "docCount": 4
+            },
+            {
+              "key": "Capecitabine",
+              "docCount": 3
+            },
+            {
+              "key": "Fluorouracil",
+              "docCount": 3
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Houston",
+              "docCount": 8
+            },
+            {
+              "key": "Chicago",
+              "docCount": 7
+            },
+            {
+              "key": "Scottsdale",
+              "docCount": 6
+            },
+            {
+              "key": "Bethesda",
+              "docCount": 5
+            },
+            {
+              "key": "Philadelphia",
+              "docCount": 5
+            },
+            {
+              "key": "Boston",
+              "docCount": 4
+            },
+            {
+              "key": "Danville",
+              "docCount": 4
+            },
+            {
+              "key": "Rochester",
+              "docCount": 4
+            },
+            {
+              "key": "San Francisco",
+              "docCount": 4
+            },
+            {
+              "key": "Nashville",
+              "docCount": 3
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Completed",
+              "docCount": 49
+            },
+            {
+              "key": "Terminated",
+              "docCount": 17
+            },
+            {
+              "key": "Unknown status",
+              "docCount": 10
+            },
+            {
+              "key": "Active, not recruiting",
+              "docCount": 5
+            },
+            {
+              "key": "Recruiting",
+              "docCount": 3
+            },
+            {
+              "key": "Withdrawn",
+              "docCount": 1
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "0",
+              "docCount": 85
+            }
+          ]
+        },
+        {
+          "buckets": [
+
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Pancreatic Neoplasms",
+              "docCount": 85
+            },
+            {
+              "key": "Stomach Neoplasms",
+              "docCount": 67
+            },
+            {
+              "key": "Esophageal Neoplasms",
+              "docCount": 27
+            },
+            {
+              "key": "Intestinal Neoplasms",
+              "docCount": 25
+            },
+            {
+              "key": "Lung Neoplasms",
+              "docCount": 24
+            },
+            {
+              "key": "Liver Neoplasms",
+              "docCount": 23
+            },
+            {
+              "key": "Gallbladder Neoplasms",
+              "docCount": 19
+            },
+            {
+              "key": "Breast Neoplasms",
+              "docCount": 18
+            },
+            {
+              "key": "Cholangiocarcinoma",
+              "docCount": 18
+            },
+            {
+              "key": "Neoplasms",
+              "docCount": 17
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Mayo Clinic",
+              "docCount": 3
+            },
+            {
+              "key": "Abbott-Northwestern Hospital",
+              "docCount": 2
+            },
+            {
+              "key": "CCOP - Duluth",
+              "docCount": 2
+            },
+            {
+              "key": "CCOP - Missouri Valley Cancer Consortium",
+              "docCount": 2
+            },
+            {
+              "key": "City of Hope Medical Center",
+              "docCount": 2
+            },
+            {
+              "key": "Dana-Farber Cancer Institute",
+              "docCount": 2
+            },
+            {
+              "key": "Massachusetts General Hospital",
+              "docCount": 2
+            },
+            {
+              "key": "Mayo Clinic Cancer Center",
+              "docCount": 2
+            },
+            {
+              "key": "Mayo Clinic in Arizona",
+              "docCount": 2
+            },
+            {
+              "key": "Rapid City Regional Hospital",
+              "docCount": 2
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "United States",
+              "docCount": 59
+            },
+            {
+              "key": "Germany",
+              "docCount": 6
+            },
+            {
+              "key": "Canada",
+              "docCount": 3
+            },
+            {
+              "key": "France",
+              "docCount": 3
+            },
+            {
+              "key": "Israel",
+              "docCount": 3
+            },
+            {
+              "key": "Italy",
+              "docCount": 3
+            },
+            {
+              "key": "Netherlands",
+              "docCount": 3
+            },
+            {
+              "key": "China",
+              "docCount": 2
+            },
+            {
+              "key": "Greece",
+              "docCount": 2
+            },
+            {
+              "key": "Austria",
+              "docCount": 1
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Interventional",
+              "docCount": 69
+            },
+            {
+              "key": "Observational",
+              "docCount": 16
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "National Cancer Institute (NCI)",
+              "docCount": 44
+            },
+            {
+              "key": "M.D. Anderson Cancer Center",
+              "docCount": 5
+            },
+            {
+              "key": "City of Hope Medical Center",
+              "docCount": 3
+            },
+            {
+              "key": "Alliance for Clinical Trials in Oncology",
+              "docCount": 2
+            },
+            {
+              "key": "Columbia University",
+              "docCount": 2
+            },
+            {
+              "key": "Massachusetts General Hospital",
+              "docCount": 2
+            },
+            {
+              "key": "Mayo Clinic",
+              "docCount": 2
+            },
+            {
+              "key": "Northwestern University",
+              "docCount": 2
+            },
+            {
+              "key": "Novartis",
+              "docCount": 2
+            },
+            {
+              "key": "Roswell Park Cancer Institute",
+              "docCount": 2
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "",
+              "docCount": 20
+            },
+            {
+              "key": "Texas",
+              "docCount": 13
+            },
+            {
+              "key": "New York",
+              "docCount": 10
+            },
+            {
+              "key": "Pennsylvania",
+              "docCount": 10
+            },
+            {
+              "key": "California",
+              "docCount": 9
+            },
+            {
+              "key": "Illinois",
+              "docCount": 9
+            },
+            {
+              "key": "Arizona",
+              "docCount": 7
+            },
+            {
+              "key": "Maryland",
+              "docCount": 7
+            },
+            {
+              "key": "Florida",
+              "docCount": 6
+            },
+            {
+              "key": "North Carolina",
+              "docCount": 6
+            }
+          ]
+        },
+        {
+          "buckets": [
+
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "laboratory biomarker analysis",
+              "docCount": 4
+            },
+            {
+              "key": "Laboratory Biomarker Analysis",
+              "docCount": 3
+            },
+            {
+              "key": "Everolimus",
+              "docCount": 2
+            },
+            {
+              "key": "Pazopanib Hydrochloride",
+              "docCount": 2
+            },
+            {
+              "key": "Pharmacological Study",
+              "docCount": 2
+            },
+            {
+              "key": "bupropion hydrochloride",
+              "docCount": 2
+            },
+            {
+              "key": "educational intervention",
+              "docCount": 2
+            },
+            {
+              "key": "irinotecan hydrochloride",
+              "docCount": 2
+            },
+            {
+              "key": "pharmacological study",
+              "docCount": 2
+            },
+            {
+              "key": "placebo",
+              "docCount": 2
+            }
+          ]
+        }
+      ],
+      "studies": [
+        {
+          "nctId": "NCT00001805"
+        },
+        {
+          "nctId": "NCT00003046"
+        },
+        {
+          "nctId": "NCT00003125"
+        },
+        {
+          "nctId": "NCT00003157"
+        },
+        {
+          "nctId": "NCT00003427"
+        },
+        {
+          "nctId": "NCT00004074"
+        },
+        {
+          "nctId": "NCT00004604"
+        },
+        {
+          "nctId": "NCT00004895"
+        },
+        {
+          "nctId": "NCT00004910"
+        },
+        {
+          "nctId": "NCT00010270"
+        },
+        {
+          "nctId": "NCT00012246"
+        },
+        {
+          "nctId": "NCT00014456"
+        },
+        {
+          "nctId": "NCT00019435"
+        },
+        {
+          "nctId": "NCT00019474"
+        },
+        {
+          "nctId": "NCT00024063"
+        },
+        {
+          "nctId": "NCT00025532"
+        },
+        {
+          "nctId": "NCT00027534"
+        },
+        {
+          "nctId": "NCT00028496"
+        },
+        {
+          "nctId": "NCT00031681"
+        },
+        {
+          "nctId": "NCT00041808"
+        },
+        {
+          "nctId": "NCT00087191"
+        },
+        {
+          "nctId": "NCT00249301"
+        },
+        {
+          "nctId": "NCT00279292"
+        },
+        {
+          "nctId": "NCT00310115"
+        },
+        {
+          "nctId": "NCT00359320"
+        }
+      ]
+    }
+  }
+}

--- a/spec/graphql/__snapshots__/basic_search_query.snap
+++ b/spec/graphql/__snapshots__/basic_search_query.snap
@@ -1,1 +1,424 @@
-{"aggs":{"average_rating":{"filter":{"bool":{"must":[{"bool":{"must":[]}}]}},"aggs":{"average_rating":{"terms":{"field":"average_rating","size":10}}}},"overall_status":{"filter":{"bool":{"must":[{"bool":{"must":[]}}]}},"aggs":{"overall_status":{"terms":{"field":"overall_status","size":10}}}},"facility_states":{"filter":{"bool":{"must":[{"bool":{"must":[]}}]}},"aggs":{"facility_states":{"terms":{"field":"facility_states","size":10}}}},"facility_cities":{"filter":{"bool":{"must":[{"bool":{"must":[]}}]}},"aggs":{"facility_cities":{"terms":{"field":"facility_cities","size":10}}}},"facility_names":{"filter":{"bool":{"must":[{"bool":{"must":[]}}]}},"aggs":{"facility_names":{"terms":{"field":"facility_names","size":10}}}},"facility_countries":{"filter":{"bool":{"must":[{"bool":{"must":[]}}]}},"aggs":{"facility_countries":{"terms":{"field":"facility_countries","size":10}}}},"study_type":{"filter":{"bool":{"must":[{"bool":{"must":[]}}]}},"aggs":{"study_type":{"terms":{"field":"study_type","size":10}}}},"sponsors":{"filter":{"bool":{"must":[{"bool":{"must":[]}}]}},"aggs":{"sponsors":{"terms":{"field":"sponsors","size":10}}}},"browse_condition_mesh_terms":{"filter":{"bool":{"must":[{"bool":{"must":[]}}]}},"aggs":{"browse_condition_mesh_terms":{"terms":{"field":"browse_condition_mesh_terms","size":10}}}},"phase":{"filter":{"bool":{"must":[{"bool":{"must":[]}}]}},"aggs":{"phase":{"terms":{"field":"phase","size":10}}}},"rating_dimensions":{"filter":{"bool":{"must":[{"bool":{"must":[]}}]}},"aggs":{"rating_dimensions":{"terms":{"field":"rating_dimensions","size":10}}}},"browse_interventions_mesh_terms":{"filter":{"bool":{"must":[{"bool":{"must":[]}}]}},"aggs":{"browse_interventions_mesh_terms":{"terms":{"field":"browse_interventions_mesh_terms","size":10}}}},"interventions_mesh_terms":{"filter":{"bool":{"must":[{"bool":{"must":[]}}]}},"aggs":{"interventions_mesh_terms":{"terms":{"field":"interventions_mesh_terms","size":10}}}},"front_matter_keys":{"filter":{"bool":{"must":[{"bool":{"must":[]}}]}},"aggs":{"front_matter_keys":{"terms":{"field":"front_matter_keys","size":10}}}},"start_date":{"filter":{"bool":{"must":[{"bool":{"must":[]}}]}},"aggs":{"start_date":{"terms":{"field":"start_date","size":10}}}}},"query":{"bool":{"must":{"query_string":{"query":"stomach"}},"filter":[{"bool":{"must":[]}}]}},"sort":[{"nct_id":"asc"}],"timeout":"11s","_source":false,"size":25,"from":25}
+{
+  "aggs": {
+    "average_rating": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "average_rating": {
+          "terms": {
+            "field": "average_rating",
+            "size": 10
+          }
+        }
+      }
+    },
+    "overall_status": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "overall_status": {
+          "terms": {
+            "field": "overall_status",
+            "size": 10
+          }
+        }
+      }
+    },
+    "facility_states": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "facility_states": {
+          "terms": {
+            "field": "facility_states",
+            "size": 10
+          }
+        }
+      }
+    },
+    "facility_cities": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "facility_cities": {
+          "terms": {
+            "field": "facility_cities",
+            "size": 10
+          }
+        }
+      }
+    },
+    "facility_names": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "facility_names": {
+          "terms": {
+            "field": "facility_names",
+            "size": 10
+          }
+        }
+      }
+    },
+    "facility_countries": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "facility_countries": {
+          "terms": {
+            "field": "facility_countries",
+            "size": 10
+          }
+        }
+      }
+    },
+    "study_type": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "study_type": {
+          "terms": {
+            "field": "study_type",
+            "size": 10
+          }
+        }
+      }
+    },
+    "sponsors": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "sponsors": {
+          "terms": {
+            "field": "sponsors",
+            "size": 10
+          }
+        }
+      }
+    },
+    "browse_condition_mesh_terms": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "browse_condition_mesh_terms": {
+          "terms": {
+            "field": "browse_condition_mesh_terms",
+            "size": 10
+          }
+        }
+      }
+    },
+    "phase": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "phase": {
+          "terms": {
+            "field": "phase",
+            "size": 10
+          }
+        }
+      }
+    },
+    "rating_dimensions": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "rating_dimensions": {
+          "terms": {
+            "field": "rating_dimensions",
+            "size": 10
+          }
+        }
+      }
+    },
+    "browse_interventions_mesh_terms": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "browse_interventions_mesh_terms": {
+          "terms": {
+            "field": "browse_interventions_mesh_terms",
+            "size": 10
+          }
+        }
+      }
+    },
+    "interventions_mesh_terms": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "interventions_mesh_terms": {
+          "terms": {
+            "field": "interventions_mesh_terms",
+            "size": 10
+          }
+        }
+      }
+    },
+    "front_matter_keys": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "front_matter_keys": {
+          "terms": {
+            "field": "front_matter_keys",
+            "size": 10
+          }
+        }
+      }
+    },
+    "start_date": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "start_date": {
+          "terms": {
+            "field": "start_date",
+            "size": 10
+          }
+        }
+      }
+    },
+    "wiki_page_edits.email": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "wiki_page_edits.email": {
+          "terms": {
+            "field": "wiki_page_edits.email",
+            "size": 10
+          }
+        }
+      }
+    },
+    "wiki_page_edits.created_at": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "wiki_page_edits.created_at": {
+          "terms": {
+            "field": "wiki_page_edits.created_at",
+            "size": 10
+          }
+        }
+      }
+    }
+  },
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "query_string": {
+            "query": "stomach"
+          }
+        }
+      ],
+      "filter": [
+        {
+          "bool": {
+            "must": [
+
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "sort": [
+    {
+      "nct_id": "asc"
+    }
+  ],
+  "timeout": "11s",
+  "_source": false,
+  "size": 25,
+  "from": 25
+}

--- a/spec/graphql/__snapshots__/range_filter_search_graphql_response.snap
+++ b/spec/graphql/__snapshots__/range_filter_search_graphql_response.snap
@@ -1,1 +1,516 @@
-{"data"=>{"search"=>{"recordsTotal"=>27, "aggs"=>[{"buckets"=>[{"key"=>"Phase 1", "docCount"=>9}, {"key"=>"N/A", "docCount"=>6}, {"key"=>"Phase 2", "docCount"=>6}, {"key"=>"Phase 1/Phase 2", "docCount"=>1}, {"key"=>"Phase 4", "docCount"=>1}]}, {"buckets"=>[{"key"=>"Antibodies", "docCount"=>3}, {"key"=>"Everolimus", "docCount"=>3}, {"key"=>"Sirolimus", "docCount"=>3}, {"key"=>"Oxaliplatin", "docCount"=>2}, {"key"=>"Antibodies, Monoclonal", "docCount"=>1}, {"key"=>"Calcium", "docCount"=>1}, {"key"=>"Capecitabine", "docCount"=>1}, {"key"=>"Darbepoetin alfa", "docCount"=>1}, {"key"=>"Fluorouracil", "docCount"=>1}, {"key"=>"Gabapentin", "docCount"=>1}]}, {"buckets"=>[{"key"=>"Houston", "docCount"=>4}, {"key"=>"Athens", "docCount"=>2}, {"key"=>"Berlin", "docCount"=>2}, {"key"=>"Chicago", "docCount"=>2}, {"key"=>"Jerusalem", "docCount"=>2}, {"key"=>"Madison", "docCount"=>2}, {"key"=>"'Aiea", "docCount"=>1}, {"key"=>"Aalst", "docCount"=>1}, {"key"=>"Adrian", "docCount"=>1}, {"key"=>"Aix en Provence", "docCount"=>1}]}, {"buckets"=>[{"key"=>"Completed", "docCount"=>14}, {"key"=>"Unknown status", "docCount"=>5}, {"key"=>"Terminated", "docCount"=>4}, {"key"=>"Active, not recruiting", "docCount"=>3}, {"key"=>"Recruiting", "docCount"=>1}]}, {"buckets"=>[{"key"=>"0", "docCount"=>27}]}, {"buckets"=>[]}, {"buckets"=>[{"key"=>"Pancreatic Neoplasms", "docCount"=>27}, {"key"=>"Stomach Neoplasms", "docCount"=>20}, {"key"=>"Intestinal Neoplasms", "docCount"=>7}, {"key"=>"Neoplasms", "docCount"=>7}, {"key"=>"Neuroendocrine Tumors", "docCount"=>7}, {"key"=>"Ovarian Neoplasms", "docCount"=>5}, {"key"=>"Adenocarcinoma", "docCount"=>4}, {"key"=>"Colonic Neoplasms", "docCount"=>4}, {"key"=>"Rectal Neoplasms", "docCount"=>4}, {"key"=>"Carcinoma", "docCount"=>3}]}, {"buckets"=>[{"key"=>"City of Hope Medical Center", "docCount"=>2}, {"key"=>"University of Wisconsin Hospital and Clinics", "docCount"=>2}, {"key"=>"21st Century Oncology", "docCount"=>1}, {"key"=>"21st Century Oncology-Fort Apache", "docCount"=>1}, {"key"=>"21st Century Oncology-Henderson", "docCount"=>1}, {"key"=>"21st Century Oncology-Vegas Tenaya", "docCount"=>1}, {"key"=>"2nd Dept of Internal Medicine, Agios Savvas Cancer Hospital", "docCount"=>1}, {"key"=>"2nd Dept of Internal Medicine, General Hospital of Athens \"Hippokratio\"", "docCount"=>1}, {"key"=>"2nd Dept of Internal Medicine, Propaedeutic, University Hospital \"Attikon\"", "docCount"=>1}, {"key"=>"2nd Dept of Medical Oncology, Metropolitan Hospital", "docCount"=>1}]}, {"buckets"=>[{"key"=>"United States", "docCount"=>13}, {"key"=>"Italy", "docCount"=>3}, {"key"=>"China", "docCount"=>2}, {"key"=>"France", "docCount"=>2}, {"key"=>"Germany", "docCount"=>2}, {"key"=>"Greece", "docCount"=>2}, {"key"=>"Israel", "docCount"=>2}, {"key"=>"Netherlands", "docCount"=>2}, {"key"=>"Austria", "docCount"=>1}, {"key"=>"Belgium", "docCount"=>1}]}, {"buckets"=>[{"key"=>"Interventional", "docCount"=>23}, {"key"=>"Observational", "docCount"=>4}]}, {"buckets"=>[{"key"=>"National Cancer Institute (NCI)", "docCount"=>7}, {"key"=>"City of Hope Medical Center", "docCount"=>2}, {"key"=>"Agensys, Inc.", "docCount"=>1}, {"key"=>"American Cancer Society (ACS) National Office", "docCount"=>1}, {"key"=>"Amgen", "docCount"=>1}, {"key"=>"Arcispedale Santa Maria Nuova-IRCCS", "docCount"=>1}, {"key"=>"Cancer Institute and Hospital, Chinese Academy of Medical Sciences", "docCount"=>1}, {"key"=>"Clalit Health Services", "docCount"=>1}, {"key"=>"Clovis Oncology, Inc.", "docCount"=>1}, {"key"=>"Columbia University", "docCount"=>1}]}, {"buckets"=>[{"key"=>"", "docCount"=>12}, {"key"=>"California", "docCount"=>6}, {"key"=>"Texas", "docCount"=>5}, {"key"=>"Illinois", "docCount"=>3}, {"key"=>"Arizona", "docCount"=>2}, {"key"=>"Maryland", "docCount"=>2}, {"key"=>"Minnesota", "docCount"=>2}, {"key"=>"New York", "docCount"=>2}, {"key"=>"Wisconsin", "docCount"=>2}, {"key"=>"Alabama", "docCount"=>1}]}, {"buckets"=>[]}, {"buckets"=>[{"key"=>"laboratory biomarker analysis", "docCount"=>3}, {"key"=>"Everolimus", "docCount"=>2}, {"key"=>"Laboratory Biomarker Analysis", "docCount"=>2}, {"key"=>"oxaliplatin", "docCount"=>2}, {"key"=>"24 Gy in 3 fractions", "docCount"=>1}, {"key"=>"ASG-5ME", "docCount"=>1}, {"key"=>"Cixutumumab", "docCount"=>1}, {"key"=>"Endoscopic ultrasound guided needle tissue acquisition.", "docCount"=>1}, {"key"=>"Everolimus followed by Pasireotide LAR + Everolimus", "docCount"=>1}, {"key"=>"Famitinib", "docCount"=>1}]}], "studies"=>[{"nctId"=>"NCT01166490"}, {"nctId"=>"NCT01191684"}, {"nctId"=>"NCT01204476"}, {"nctId"=>"NCT01233505"}, {"nctId"=>"NCT01236053"}, {"nctId"=>"NCT01263353"}, {"nctId"=>"NCT01324856"}, {"nctId"=>"NCT01384253"}, {"nctId"=>"NCT01437007"}, {"nctId"=>"NCT01444456"}, {"nctId"=>"NCT01598194"}, {"nctId"=>"NCT01643499"}, {"nctId"=>"NCT01648465"}, {"nctId"=>"NCT01675258"}, {"nctId"=>"NCT01698190"}, {"nctId"=>"NCT01747096"}, {"nctId"=>"NCT01819961"}, {"nctId"=>"NCT01841736"}, {"nctId"=>"NCT01846520"}, {"nctId"=>"NCT01898741"}, {"nctId"=>"NCT01994213"}, {"nctId"=>"NCT01996540"}, {"nctId"=>"NCT02041936"}, {"nctId"=>"NCT02042378"}, {"nctId"=>"NCT02055313"}]}}}
+{
+  "data": {
+    "search": {
+      "recordsTotal": 27,
+      "aggs": [
+        {
+          "buckets": [
+            {
+              "key": "Phase 1",
+              "docCount": 9
+            },
+            {
+              "key": "N/A",
+              "docCount": 6
+            },
+            {
+              "key": "Phase 2",
+              "docCount": 6
+            },
+            {
+              "key": "Phase 1/Phase 2",
+              "docCount": 1
+            },
+            {
+              "key": "Phase 4",
+              "docCount": 1
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Antibodies",
+              "docCount": 3
+            },
+            {
+              "key": "Everolimus",
+              "docCount": 3
+            },
+            {
+              "key": "Sirolimus",
+              "docCount": 3
+            },
+            {
+              "key": "Oxaliplatin",
+              "docCount": 2
+            },
+            {
+              "key": "Antibodies, Monoclonal",
+              "docCount": 1
+            },
+            {
+              "key": "Calcium",
+              "docCount": 1
+            },
+            {
+              "key": "Capecitabine",
+              "docCount": 1
+            },
+            {
+              "key": "Darbepoetin alfa",
+              "docCount": 1
+            },
+            {
+              "key": "Fluorouracil",
+              "docCount": 1
+            },
+            {
+              "key": "Gabapentin",
+              "docCount": 1
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Houston",
+              "docCount": 4
+            },
+            {
+              "key": "Athens",
+              "docCount": 2
+            },
+            {
+              "key": "Berlin",
+              "docCount": 2
+            },
+            {
+              "key": "Chicago",
+              "docCount": 2
+            },
+            {
+              "key": "Jerusalem",
+              "docCount": 2
+            },
+            {
+              "key": "Madison",
+              "docCount": 2
+            },
+            {
+              "key": "'Aiea",
+              "docCount": 1
+            },
+            {
+              "key": "Aalst",
+              "docCount": 1
+            },
+            {
+              "key": "Adrian",
+              "docCount": 1
+            },
+            {
+              "key": "Aix en Provence",
+              "docCount": 1
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Completed",
+              "docCount": 14
+            },
+            {
+              "key": "Unknown status",
+              "docCount": 5
+            },
+            {
+              "key": "Terminated",
+              "docCount": 4
+            },
+            {
+              "key": "Active, not recruiting",
+              "docCount": 3
+            },
+            {
+              "key": "Recruiting",
+              "docCount": 1
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "0",
+              "docCount": 27
+            }
+          ]
+        },
+        {
+          "buckets": [
+
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Pancreatic Neoplasms",
+              "docCount": 27
+            },
+            {
+              "key": "Stomach Neoplasms",
+              "docCount": 20
+            },
+            {
+              "key": "Intestinal Neoplasms",
+              "docCount": 7
+            },
+            {
+              "key": "Neoplasms",
+              "docCount": 7
+            },
+            {
+              "key": "Neuroendocrine Tumors",
+              "docCount": 7
+            },
+            {
+              "key": "Ovarian Neoplasms",
+              "docCount": 5
+            },
+            {
+              "key": "Adenocarcinoma",
+              "docCount": 4
+            },
+            {
+              "key": "Colonic Neoplasms",
+              "docCount": 4
+            },
+            {
+              "key": "Rectal Neoplasms",
+              "docCount": 4
+            },
+            {
+              "key": "Carcinoma",
+              "docCount": 3
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "City of Hope Medical Center",
+              "docCount": 2
+            },
+            {
+              "key": "University of Wisconsin Hospital and Clinics",
+              "docCount": 2
+            },
+            {
+              "key": "21st Century Oncology",
+              "docCount": 1
+            },
+            {
+              "key": "21st Century Oncology-Fort Apache",
+              "docCount": 1
+            },
+            {
+              "key": "21st Century Oncology-Henderson",
+              "docCount": 1
+            },
+            {
+              "key": "21st Century Oncology-Vegas Tenaya",
+              "docCount": 1
+            },
+            {
+              "key": "2nd Dept of Internal Medicine, Agios Savvas Cancer Hospital",
+              "docCount": 1
+            },
+            {
+              "key": "2nd Dept of Internal Medicine, General Hospital of Athens \"Hippokratio\"",
+              "docCount": 1
+            },
+            {
+              "key": "2nd Dept of Internal Medicine, Propaedeutic, University Hospital \"Attikon\"",
+              "docCount": 1
+            },
+            {
+              "key": "2nd Dept of Medical Oncology, Metropolitan Hospital",
+              "docCount": 1
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "United States",
+              "docCount": 13
+            },
+            {
+              "key": "Italy",
+              "docCount": 3
+            },
+            {
+              "key": "China",
+              "docCount": 2
+            },
+            {
+              "key": "France",
+              "docCount": 2
+            },
+            {
+              "key": "Germany",
+              "docCount": 2
+            },
+            {
+              "key": "Greece",
+              "docCount": 2
+            },
+            {
+              "key": "Israel",
+              "docCount": 2
+            },
+            {
+              "key": "Netherlands",
+              "docCount": 2
+            },
+            {
+              "key": "Austria",
+              "docCount": 1
+            },
+            {
+              "key": "Belgium",
+              "docCount": 1
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "Interventional",
+              "docCount": 23
+            },
+            {
+              "key": "Observational",
+              "docCount": 4
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "National Cancer Institute (NCI)",
+              "docCount": 7
+            },
+            {
+              "key": "City of Hope Medical Center",
+              "docCount": 2
+            },
+            {
+              "key": "Agensys, Inc.",
+              "docCount": 1
+            },
+            {
+              "key": "American Cancer Society (ACS) National Office",
+              "docCount": 1
+            },
+            {
+              "key": "Amgen",
+              "docCount": 1
+            },
+            {
+              "key": "Arcispedale Santa Maria Nuova-IRCCS",
+              "docCount": 1
+            },
+            {
+              "key": "Cancer Institute and Hospital, Chinese Academy of Medical Sciences",
+              "docCount": 1
+            },
+            {
+              "key": "Clalit Health Services",
+              "docCount": 1
+            },
+            {
+              "key": "Clovis Oncology, Inc.",
+              "docCount": 1
+            },
+            {
+              "key": "Columbia University",
+              "docCount": 1
+            }
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "",
+              "docCount": 12
+            },
+            {
+              "key": "California",
+              "docCount": 6
+            },
+            {
+              "key": "Texas",
+              "docCount": 5
+            },
+            {
+              "key": "Illinois",
+              "docCount": 3
+            },
+            {
+              "key": "Arizona",
+              "docCount": 2
+            },
+            {
+              "key": "Maryland",
+              "docCount": 2
+            },
+            {
+              "key": "Minnesota",
+              "docCount": 2
+            },
+            {
+              "key": "New York",
+              "docCount": 2
+            },
+            {
+              "key": "Wisconsin",
+              "docCount": 2
+            },
+            {
+              "key": "Alabama",
+              "docCount": 1
+            }
+          ]
+        },
+        {
+          "buckets": [
+
+          ]
+        },
+        {
+          "buckets": [
+            {
+              "key": "laboratory biomarker analysis",
+              "docCount": 3
+            },
+            {
+              "key": "Everolimus",
+              "docCount": 2
+            },
+            {
+              "key": "Laboratory Biomarker Analysis",
+              "docCount": 2
+            },
+            {
+              "key": "oxaliplatin",
+              "docCount": 2
+            },
+            {
+              "key": "24 Gy in 3 fractions",
+              "docCount": 1
+            },
+            {
+              "key": "ASG-5ME",
+              "docCount": 1
+            },
+            {
+              "key": "Cixutumumab",
+              "docCount": 1
+            },
+            {
+              "key": "Endoscopic ultrasound guided needle tissue acquisition.",
+              "docCount": 1
+            },
+            {
+              "key": "Everolimus followed by Pasireotide LAR + Everolimus",
+              "docCount": 1
+            },
+            {
+              "key": "Famitinib",
+              "docCount": 1
+            }
+          ]
+        }
+      ],
+      "studies": [
+        {
+          "nctId": "NCT01166490"
+        },
+        {
+          "nctId": "NCT01191684"
+        },
+        {
+          "nctId": "NCT01204476"
+        },
+        {
+          "nctId": "NCT01233505"
+        },
+        {
+          "nctId": "NCT01236053"
+        },
+        {
+          "nctId": "NCT01263353"
+        },
+        {
+          "nctId": "NCT01324856"
+        },
+        {
+          "nctId": "NCT01384253"
+        },
+        {
+          "nctId": "NCT01437007"
+        },
+        {
+          "nctId": "NCT01444456"
+        },
+        {
+          "nctId": "NCT01598194"
+        },
+        {
+          "nctId": "NCT01643499"
+        },
+        {
+          "nctId": "NCT01648465"
+        },
+        {
+          "nctId": "NCT01675258"
+        },
+        {
+          "nctId": "NCT01698190"
+        },
+        {
+          "nctId": "NCT01747096"
+        },
+        {
+          "nctId": "NCT01819961"
+        },
+        {
+          "nctId": "NCT01841736"
+        },
+        {
+          "nctId": "NCT01846520"
+        },
+        {
+          "nctId": "NCT01898741"
+        },
+        {
+          "nctId": "NCT01994213"
+        },
+        {
+          "nctId": "NCT01996540"
+        },
+        {
+          "nctId": "NCT02041936"
+        },
+        {
+          "nctId": "NCT02042378"
+        },
+        {
+          "nctId": "NCT02055313"
+        }
+      ]
+    }
+  }
+}

--- a/spec/graphql/__snapshots__/range_filter_search_query.snap
+++ b/spec/graphql/__snapshots__/range_filter_search_query.snap
@@ -1,1 +1,892 @@
-{"aggs":{"average_rating":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[]}}]}},{"bool":{"filter":[{"range":{"start_date":{"from":"2010-01-01T05:00:00.000Z","include_lower":true}}}]}}]}}]}},"aggs":{"average_rating":{"terms":{"field":"average_rating","size":10}}}},"overall_status":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[]}}]}},{"bool":{"filter":[{"range":{"start_date":{"from":"2010-01-01T05:00:00.000Z","include_lower":true}}}]}}]}}]}},"aggs":{"overall_status":{"terms":{"field":"overall_status","size":10}}}},"facility_states":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[]}}]}},{"bool":{"filter":[{"range":{"start_date":{"from":"2010-01-01T05:00:00.000Z","include_lower":true}}}]}}]}}]}},"aggs":{"facility_states":{"terms":{"field":"facility_states","size":10}}}},"facility_cities":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[]}}]}},{"bool":{"filter":[{"range":{"start_date":{"from":"2010-01-01T05:00:00.000Z","include_lower":true}}}]}}]}}]}},"aggs":{"facility_cities":{"terms":{"field":"facility_cities","size":10}}}},"facility_names":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[]}}]}},{"bool":{"filter":[{"range":{"start_date":{"from":"2010-01-01T05:00:00.000Z","include_lower":true}}}]}}]}}]}},"aggs":{"facility_names":{"terms":{"field":"facility_names","size":10}}}},"facility_countries":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[]}}]}},{"bool":{"filter":[{"range":{"start_date":{"from":"2010-01-01T05:00:00.000Z","include_lower":true}}}]}}]}}]}},"aggs":{"facility_countries":{"terms":{"field":"facility_countries","size":10}}}},"study_type":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[]}}]}},{"bool":{"filter":[{"range":{"start_date":{"from":"2010-01-01T05:00:00.000Z","include_lower":true}}}]}}]}}]}},"aggs":{"study_type":{"terms":{"field":"study_type","size":10}}}},"sponsors":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[]}}]}},{"bool":{"filter":[{"range":{"start_date":{"from":"2010-01-01T05:00:00.000Z","include_lower":true}}}]}}]}}]}},"aggs":{"sponsors":{"terms":{"field":"sponsors","size":10}}}},"browse_condition_mesh_terms":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[]}}]}},{"bool":{"filter":[{"range":{"start_date":{"from":"2010-01-01T05:00:00.000Z","include_lower":true}}}]}}]}}]}},"aggs":{"browse_condition_mesh_terms":{"terms":{"field":"browse_condition_mesh_terms","size":10}}}},"phase":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[]}}]}},{"bool":{"filter":[{"range":{"start_date":{"from":"2010-01-01T05:00:00.000Z","include_lower":true}}}]}}]}}]}},"aggs":{"phase":{"terms":{"field":"phase","size":10}}}},"rating_dimensions":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[]}}]}},{"bool":{"filter":[{"range":{"start_date":{"from":"2010-01-01T05:00:00.000Z","include_lower":true}}}]}}]}}]}},"aggs":{"rating_dimensions":{"terms":{"field":"rating_dimensions","size":10}}}},"browse_interventions_mesh_terms":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[]}}]}},{"bool":{"filter":[{"range":{"start_date":{"from":"2010-01-01T05:00:00.000Z","include_lower":true}}}]}}]}}]}},"aggs":{"browse_interventions_mesh_terms":{"terms":{"field":"browse_interventions_mesh_terms","size":10}}}},"interventions_mesh_terms":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[]}}]}},{"bool":{"filter":[{"range":{"start_date":{"from":"2010-01-01T05:00:00.000Z","include_lower":true}}}]}}]}}]}},"aggs":{"interventions_mesh_terms":{"terms":{"field":"interventions_mesh_terms","size":10}}}},"front_matter_keys":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[]}}]}},{"bool":{"filter":[{"range":{"start_date":{"from":"2010-01-01T05:00:00.000Z","include_lower":true}}}]}}]}}]}},"aggs":{"front_matter_keys":{"terms":{"field":"front_matter_keys","size":10}}}},"start_date":{"filter":{"bool":{"must":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[]}}]}},{"bool":{"filter":[{"range":{"start_date":{"from":"2010-01-01T05:00:00.000Z","include_lower":true}}}]}}]}}]}},"aggs":{"start_date":{"terms":{"field":"start_date","size":10}}}}},"query":{"bool":{"must":{"query_string":{"query":"stomach"}},"filter":[{"bool":{"must":[{"bool":{"filter":[{"bool":{"should":[]}}]}},{"bool":{"filter":[{"range":{"start_date":{"from":"2010-01-01T05:00:00.000Z","include_lower":true}}}]}}]}}]}},"sort":[{"nct_id":"asc"}],"timeout":"11s","_source":false,"size":25,"from":25}
+{
+  "aggs": {
+    "average_rating": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "average_rating": {
+          "terms": {
+            "field": "average_rating",
+            "size": 10
+          }
+        }
+      }
+    },
+    "overall_status": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "overall_status": {
+          "terms": {
+            "field": "overall_status",
+            "size": 10
+          }
+        }
+      }
+    },
+    "facility_states": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "facility_states": {
+          "terms": {
+            "field": "facility_states",
+            "size": 10
+          }
+        }
+      }
+    },
+    "facility_cities": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "facility_cities": {
+          "terms": {
+            "field": "facility_cities",
+            "size": 10
+          }
+        }
+      }
+    },
+    "facility_names": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "facility_names": {
+          "terms": {
+            "field": "facility_names",
+            "size": 10
+          }
+        }
+      }
+    },
+    "facility_countries": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "facility_countries": {
+          "terms": {
+            "field": "facility_countries",
+            "size": 10
+          }
+        }
+      }
+    },
+    "study_type": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "study_type": {
+          "terms": {
+            "field": "study_type",
+            "size": 10
+          }
+        }
+      }
+    },
+    "sponsors": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "sponsors": {
+          "terms": {
+            "field": "sponsors",
+            "size": 10
+          }
+        }
+      }
+    },
+    "browse_condition_mesh_terms": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "browse_condition_mesh_terms": {
+          "terms": {
+            "field": "browse_condition_mesh_terms",
+            "size": 10
+          }
+        }
+      }
+    },
+    "phase": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "phase": {
+          "terms": {
+            "field": "phase",
+            "size": 10
+          }
+        }
+      }
+    },
+    "rating_dimensions": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "rating_dimensions": {
+          "terms": {
+            "field": "rating_dimensions",
+            "size": 10
+          }
+        }
+      }
+    },
+    "browse_interventions_mesh_terms": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "browse_interventions_mesh_terms": {
+          "terms": {
+            "field": "browse_interventions_mesh_terms",
+            "size": 10
+          }
+        }
+      }
+    },
+    "interventions_mesh_terms": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "interventions_mesh_terms": {
+          "terms": {
+            "field": "interventions_mesh_terms",
+            "size": 10
+          }
+        }
+      }
+    },
+    "front_matter_keys": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "front_matter_keys": {
+          "terms": {
+            "field": "front_matter_keys",
+            "size": 10
+          }
+        }
+      }
+    },
+    "start_date": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "start_date": {
+          "terms": {
+            "field": "start_date",
+            "size": 10
+          }
+        }
+      }
+    },
+    "wiki_page_edits.email": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "wiki_page_edits.email": {
+          "terms": {
+            "field": "wiki_page_edits.email",
+            "size": 10
+          }
+        }
+      }
+    },
+    "wiki_page_edits.created_at": {
+      "filter": {
+        "bool": {
+          "must": [
+            {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "bool": {
+                            "should": [
+
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "bool": {
+                      "filter": [
+                        {
+                          "range": {
+                            "start_date": {
+                              "from": "2010-01-01T05:00:00.000Z",
+                              "include_lower": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "wiki_page_edits.created_at": {
+          "terms": {
+            "field": "wiki_page_edits.created_at",
+            "size": 10
+          }
+        }
+      }
+    }
+  },
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "query_string": {
+            "query": "stomach"
+          }
+        }
+      ],
+      "filter": [
+        {
+          "bool": {
+            "must": [
+              {
+                "bool": {
+                  "filter": [
+                    {
+                      "bool": {
+                        "should": [
+
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "bool": {
+                  "filter": [
+                    {
+                      "range": {
+                        "start_date": {
+                          "from": "2010-01-01T05:00:00.000Z",
+                          "include_lower": true
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "sort": [
+    {
+      "nct_id": "asc"
+    }
+  ],
+  "timeout": "11s",
+  "_source": false,
+  "size": 25,
+  "from": 25
+}

--- a/spec/models/search_export_spec.rb
+++ b/spec/models/search_export_spec.rb
@@ -9,7 +9,7 @@ describe SearchExport, type: :model do
 
   describe "#params" do
     subject { export.params }
-    it { is_expected.to eql(JSON.parse(short_link.long)) }
+    it { is_expected.to eql(JSON.parse(short_link.long).deep_symbolize_keys!) }
   end
 
   describe "#fields" do


### PR DESCRIPTION
`SearchExport#params`, which we rely on for passing the expect parameters to the search service, was passing the parsed JSON, which had keys that were strings, and not symbols. We use `deep_symbolize_keys!` to enforce the expected behavior for interacting with the agg filters.

There are also some fixes related to autoformatting in here, and it looks like the snapshots for some of the tests weren't updated to the pretty-printed JSON that we had introduced in a previous change, so I fixed that here. All tests are now passing again.