### PR TITLE
518 Profile Updates && 537 User Ranking Config 

### DIFF
--- a/app/graphql/mutations/create_site.rb
+++ b/app/graphql/mutations/create_site.rb
@@ -7,6 +7,7 @@ module Mutations
     argument :subdomain, String, required: true
     argument :skip_landing, Boolean, required: false
     argument :themes, String, required: false
+    argument :user_rank, String, required: false
     argument :editor_emails, [String], required: false
 
     def resolve(attrs)

--- a/app/graphql/mutations/sign_up.rb
+++ b/app/graphql/mutations/sign_up.rb
@@ -10,6 +10,7 @@ module Mutations
     argument :o_auth_token, String, required:false
 
     def resolve(email:, password:, default_query_string: nil, o_auth_token:nil)
+      picture_url= nil
       hmac_secret = Rails.application.secrets.secret_key_base
       exp_secs = ENV["JWT_EXPIRATION_TIME_SECS"] || 86_400
       raise GraphQL::ExecutionError, "SECRET_KEY_BASE env variable is not set" if hmac_secret.blank?
@@ -22,11 +23,12 @@ module Mutations
         email = payload["email"]
         password = Devise.friendly_token(8)
         provider = payload["iss"]
+        picture_url = payload["picture"]
       end
       user = User.find_by(email: email)
       return { jwt: nil, user: nil, errors: ["Email already exists"] } if user
 
-      user = User.new(email: email, default_query_string: default_query_string,)
+      user = User.new(email: email, default_query_string: default_query_string, picture_url: picture_url)
       user.password = password
       # user.provider = provider if provider
 

--- a/app/graphql/mutations/update_site.rb
+++ b/app/graphql/mutations/update_site.rb
@@ -6,6 +6,7 @@ module Mutations
     argument :id, Int, required: true
     argument :name, String, required: false
     argument :themes, String, required: false
+    argument :user_rank, String, required: false
     argument :skip_landing, Boolean, required: false
     argument :subdomain, String, required: false
     argument :editor_emails, [String], required: false

--- a/app/graphql/types/public_user_type.rb
+++ b/app/graphql/types/public_user_type.rb
@@ -3,5 +3,27 @@ module Types
     field :id, Int, "Id", null: false
     field :first_name, String, "First name", null: true
     field :last_name, String, "Last name", null: true
+    field :review_count, Integer, "Number of reviews the user has done", null: false
+    field :reviews, [ReviewType], null: false
+    field :contributions, Integer, null: false
+    field :picture_url, String, null: true
+    field :rank, String, null: true
+
+    def review_count
+      reviews.count
+    end
+
+    def contributions
+      object.wiki_pages.distinct.count
+    end
+    def rank
+      ranking = JSON.parse(context[:current_site].user_rank)
+      rank_sort = ranking.sort_by{|rank| rank["gte"]}.reverse
+      rank = rank_sort.find{|rank| contributions >= rank["gte"]}
+      rank["rank"]
+    rescue JSON::ParserError
+      "Error in parsing JSON string"
+    end
+
   end
 end

--- a/app/graphql/types/review_type.rb
+++ b/app/graphql/types/review_type.rb
@@ -13,7 +13,7 @@ module Types
       object.meta.to_json
     end
     def brief_title
-      object.study.brief_title
+      object.study ? object.study.brief_title : "Study Remmoved"
     end
 
     def user

--- a/app/graphql/types/site_type.rb
+++ b/app/graphql/types/site_type.rb
@@ -11,6 +11,7 @@ module Types
     field :site_view, SiteViewType, null: false do
       argument :url, type: String, required: false
     end
+    field :user_rank, type:String,null: false
 
     def owners
       User.with_role(:site_owner, object)

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -26,6 +26,15 @@ module Types
       Site.with_role(:site_owner, current_user)
     end
 
+    def rank
+      ranking = JSON.parse(context[:current_site].user_rank)
+      rank_sort = ranking.sort_by{|rank| rank["gte"]}.reverse
+      rank = rank_sort.find{|rank| contributions >= rank["gte"]}
+      rank["rank"]
+    rescue JSON::ParserError
+      "Error in parsing JSON string"
+    end
+
     def editor_sites
       return [] if current_user.blank?
 

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -12,7 +12,9 @@ module Types
     field :review_count, Integer, "Number of reviews the user has done", null: false
     field :reviews, [ReviewType], null: false
     field :contributions, Integer, null: false
-
+    field :picture_url, String, null: true
+    field :rank, String, null: true
+    
     def review_count
       reviews.count
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,9 @@ class User < ApplicationRecord
       user.email = payload["email"]
       user.password = Devise.friendly_token(8)
     end
+    if !user.picture_url
+      user.picture_url = payload["picture"]
+    end
     user.save
     user
   end

--- a/db/migrate/20200504161212_user_image.rb
+++ b/db/migrate/20200504161212_user_image.rb
@@ -1,0 +1,5 @@
+class UserImage < ActiveRecord::Migration[5.2]
+    def change
+      add_column :users, :picture_url, :string
+    end
+  end

--- a/db/migrate/20200506181422_user_rank_config.rb
+++ b/db/migrate/20200506181422_user_rank_config.rb
@@ -1,0 +1,11 @@
+class UserRankConfig < ActiveRecord::Migration[5.2]
+    def change
+      add_column :sites, :user_rank, :text, default: "#{[
+      {rank:"default", gte:0},
+      {rank:"bronze",gte:26},
+      {rank:"silver",gte:51},
+      {rank:"gold",gte:75},
+      {rank:"platinum",gte:101}
+    ].to_json} "
+    end
+  end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,16 +30,15 @@ ActiveRecord::Schema.define(version: 2020_04_25_183458) do
     t.integer "user_id"
   end
 
-  create_table "facility_locations", force: :cascade do |t|
-    t.string "name"
-    t.string "city"
-    t.string "state"
-    t.string "zip"
-    t.string "country"
+  create_table "facility_locations", primary_key: ["name", "city", "state", "zip", "country"], force: :cascade do |t|
+    t.string "name", null: false
+    t.string "city", null: false
+    t.string "state", null: false
+    t.string "zip", null: false
+    t.string "country", null: false
     t.float "latitude"
     t.float "longitude"
     t.string "status"
-    t.index ["name", "city", "state", "zip", "country"], name: "facility_locations_idx", unique: true
   end
 
   create_table "locations", force: :cascade do |t|
@@ -111,7 +110,7 @@ ActiveRecord::Schema.define(version: 2020_04_25_183458) do
     t.datetime "updated_at", null: false
     t.boolean "skip_landing"
     t.text "themes", default: "{\"primaryColor\":\"#6BA5D6\",\"secondaryColor\":\"#1b2a38\",\"lightTextColor\":\"#eee\",\"secondaryTextColor\":\"#333\",\"backgroundColor\":\"#4D5863\",\"primaryAltColor\":\"#5786AD\",\"authHeaderColor\":\"#5786AD\",\"sideBarColor\":\"#4d5762\"} "
-    t.text "user_rank", default: "{\"default\":{\"gte\":0},\"bronze\":{\"gte\":26},\"silver\":{\"gte\":51},\"gold\":{\"gte\":75},\"platinum\":{\"gte\":101}} "
+    t.text "user_rank", default: "[{\"rank\":\"default\",\"gte\":0},{\"rank\":\"bronze\",\"gte\":26},{\"rank\":\"silver\",\"gte\":51},{\"rank\":\"gold\",\"gte\":75},{\"rank\":\"platinum\",\"gte\":101}] "
     t.index ["subdomain"], name: "index_sites_on_subdomain", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 2020_04_25_183458) do
     t.datetime "updated_at", null: false
     t.boolean "skip_landing"
     t.text "themes", default: "{\"primaryColor\":\"#6BA5D6\",\"secondaryColor\":\"#1b2a38\",\"lightTextColor\":\"#eee\",\"secondaryTextColor\":\"#333\",\"backgroundColor\":\"#4D5863\",\"primaryAltColor\":\"#5786AD\",\"authHeaderColor\":\"#5786AD\",\"sideBarColor\":\"#4d5762\"} "
+    t.text "user_rank", default: "{\"default\":{\"gte\":0},\"bronze\":{\"gte\":26},\"silver\":{\"gte\":51},\"gold\":{\"gte\":75},\"platinum\":{\"gte\":101}} "
     t.index ["subdomain"], name: "index_sites_on_subdomain", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_25_183458) do
+ActiveRecord::Schema.define(version: 2020_05_06_181422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,15 +30,16 @@ ActiveRecord::Schema.define(version: 2020_04_25_183458) do
     t.integer "user_id"
   end
 
-  create_table "facility_locations", primary_key: ["name", "city", "state", "zip", "country"], force: :cascade do |t|
-    t.string "name", null: false
-    t.string "city", null: false
-    t.string "state", null: false
-    t.string "zip", null: false
-    t.string "country", null: false
+  create_table "facility_locations", force: :cascade do |t|
+    t.string "name"
+    t.string "city"
+    t.string "state"
+    t.string "zip"
+    t.string "country"
     t.float "latitude"
     t.float "longitude"
     t.string "status"
+    t.index ["name", "city", "state", "zip", "country"], name: "facility_locations_idx", unique: true
   end
 
   create_table "locations", force: :cascade do |t|
@@ -147,6 +148,7 @@ ActiveRecord::Schema.define(version: 2020_04_25_183458) do
     t.string "last_name"
     t.string "default_query_string"
     t.json "search_result_columns"
+    t.string "picture_url"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/front/app/components/Edits/EditBlurb.tsx
+++ b/front/app/components/Edits/EditBlurb.tsx
@@ -18,7 +18,6 @@ class EditBlurb extends React.Component<EditBlurbProps> {
     const {
       edit: { user },
     } = this.props;
-    console.log("Useer", user)
     if (!user) {
       return 'Anonymous';
     }

--- a/front/app/components/Edits/EditBlurb.tsx
+++ b/front/app/components/Edits/EditBlurb.tsx
@@ -18,14 +18,15 @@ class EditBlurb extends React.Component<EditBlurbProps> {
     const {
       edit: { user },
     } = this.props;
+    console.log("Useer", user)
     if (!user) {
       return 'Anonymous';
     }
     if (user.firstName) {
       const userName = `${user.firstName} ${user.lastName && user.lastName[0]}`;
-      return <Link to={`/profile/${user.email}?sv=user`}>`${userName}`</Link>;
+      return <Link to={`/profile/${user.email}?sv=user&uid=${user.id}&username=${userName}`}>`${userName}`</Link>;
     }
-    return <Link to={`/profile/${user.email}?sv=user`}>{user.email}</Link>;
+    return <Link to={`/profile/${user.email}?sv=user&uid=${user.id}&username=${user.email}`}>{user.email}</Link>;
   }
 
   getBlurb() {

--- a/front/app/components/SiteForm/MainForm.tsx
+++ b/front/app/components/SiteForm/MainForm.tsx
@@ -97,7 +97,7 @@ class MainForm extends React.Component<MainFormProps, MainFormState> {
 
   handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.currentTarget;
-    if (name == 'themes') {
+    if (name == 'themes' || name=='userRank' ) {
       try {
         let parseResponse = JSON.parse(value);
         if (parseResponse && parseResponse.error)
@@ -110,7 +110,7 @@ class MainForm extends React.Component<MainFormProps, MainFormState> {
         this.setState({ themeError: '' });
       } catch (e) {
         this.setState({
-          themeError: 'There is an error in your theme object.',
+          themeError: `There is an error in your ${name} object.`,
         });
         this.props.handleThemeError(true);
       }
@@ -209,9 +209,24 @@ class MainForm extends React.Component<MainFormProps, MainFormState> {
               value={this.props.form.themes}
               onChange={this.handleInputChange}
             />
-            <div>{this.state.themeError}</div>
+            {/* <div>{this.state.themeError}</div> */}
+            <h3>User Ranking</h3>
+            <StyledFormInput
+              componentClass="textarea"
+              name="userRank"
+              //@ts-ignore
+              placeholder={this.props.form.userRank}
+              //@ts-ignore
+              value={this.props.form.userRank}
+              onChange={this.handleInputChange}
+            />
+
           </Col>
+          {/* <div>{this.state.themeError}</div> */}
+
         </Row>
+        <div>{this.state.themeError}</div>
+
       </StyledContainer>
     );
   }

--- a/front/app/components/SiteForm/SiteForm.tsx
+++ b/front/app/components/SiteForm/SiteForm.tsx
@@ -72,6 +72,7 @@ class SiteForm extends React.Component<SiteFormProps, SiteFormState> {
       name
       subdomain
       skipLanding
+      userRank
       editors {
         email
       }
@@ -82,7 +83,8 @@ class SiteForm extends React.Component<SiteFormProps, SiteFormState> {
     props: SiteFormProps,
     state: SiteFormState
   ): SiteFormState | null => {
-    const { name, subdomain, skipLanding, editors, themes } = props.site;
+    //@ts-ignore
+    const { name, subdomain, skipLanding, editors, themes, userRank } = props.site;
     const editorEmails = editors.map(prop('email'));
     const form = {
       name,
@@ -90,6 +92,7 @@ class SiteForm extends React.Component<SiteFormProps, SiteFormState> {
       skipLanding,
       editorEmails,
       themes,
+      userRank
     };
     if (form && !equals(form, state.prevForm as any)) {
       return { ...state, form, prevForm: form };
@@ -103,6 +106,7 @@ class SiteForm extends React.Component<SiteFormProps, SiteFormState> {
     this.setState({ inSiteViewEdit: false });
   };
   handleSave = () => {
+    console.log("Handle SAve",this.state.form)
     this.props.onSave(this.state.form);
   };
 
@@ -118,6 +122,7 @@ class SiteForm extends React.Component<SiteFormProps, SiteFormState> {
   };
 
   handleFormChange = (form: CreateSiteInput) => {
+    console.log(form)
     this.setState({ form });
   };
 

--- a/front/app/components/StyledComponents/index.ts
+++ b/front/app/components/StyledComponents/index.ts
@@ -26,6 +26,28 @@ const StyledButton = styled.button`
 
 export const ThemedButton = withTheme(StyledButton);
 
+const AutosuggestButton = styled.div`
+  background: ${props => props.theme.button};
+  padding: 5px 7px;
+  display: inline-block;
+  margin-bottom: 0;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.42857143;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: 0.5s;
+  color: #fff;
+  &:hover {
+    background: ${props => props.theme.buttonSecondary};
+  }
+`;
+
+export const ThemedAutosuggestButton = withTheme(AutosuggestButton);
+
 const LinkContainer = styled.div`
   position: absolute;
   bottom: 30px;
@@ -49,7 +71,6 @@ const MainContainer = styled(Col)`
   @media (max-width: 768px) {
     flex-direction: column;
   }
-
   .rt-th {
     text-transform: capitalize;
     padding: 15px !important;
@@ -57,29 +78,23 @@ const MainContainer = styled(Col)`
       props.theme.searchResults.resultsHeaderBackground} !important;
     color: #fff;
   }
-
   .ReactTable .-pagination .-btn {
     background: ${props =>
       props.theme.searchResults.resultsPaginationButtons} !important;
   }
-
   div.rt-tbody div.rt-tr:hover {
     background: ${props =>
       props.theme.searchResults.resultsRowHighlight} !important;
     color: #fff !important;
   }
-
   .rt-table {
   }
-  span, h2{
+   h2{
     padding-left: 15px;
   }
 `;
 
-
 export const ThemedMainContainer = withTheme(MainContainer);
-
-
 
 const PresearchCard = styled.div`
   display: flex;
@@ -88,7 +103,6 @@ const PresearchCard = styled.div`
   border-width: 1px;
   border-style: solid;
   border-color: ${props => props.theme.buttonSecondary};
-
   margin: 10px;
   flex: 1;
   // height: 310px;
@@ -163,52 +177,55 @@ export const SearchContainer = styled.div`
   padding: 10px;
 `;
 
-export const  StyledProfileLabel = styled.div`
-  font-size:1em;
-  font-weight:400;
-  color: rgba(0,0,0,0.6);
+export const StyledProfileLabel = styled.div`
+  font-size: 1em;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.6);
   padding-left: 1.2em;
 `;
-export const  StyledProfileScoreLabel = styled.div`
-  font-size:1em;
-  font-weight:400;
-  color: rgba(0,0,0,0.6);
+export const StyledProfileScoreLabel = styled.div`
+  font-size: 1em;
+  font-weight: 400;
+  color: rgba(0, 0, 0, 0.6);
 `;
 export const StyledProfileValue = styled.div`
-font-size:1.25em;
-border-bottom: solid white;
-margin: 0 1em 1em 1em;
+  font-size: 1.25em;
+  border-bottom: solid white;
+  margin: 0 1em 1em 1em;
+`;
+export const StyledProfileRanking= styled.div`
+display:flex;
 `;
 export const StyledProfileScoreValue = styled.div`
-  font-size:1.25em;
+  font-size: 1.25em;
 `;
 export const StyledLabelValuePair = styled.div`
-  margin-left:5%;
+  margin:auto;
   width:25%;
   text-align: center;
-  cursor:pointer;
+  cursor: pointer;
 `;
 export const ScoreBoard = styled.div`
-  display:flex;
+  display: flex;
   padding: 1em 0 1em 0;
   margin: 0 1.2em;
-  :nth-child(1){
+  :nth-child(1) {
     border-bottom: solid white;
   }
 `;
 export const StyledProfileForm = styled(FormControl)`
-background: rgba(255,255,255,0.2);
-    font-family: 'Lato','Helvetica Neue',Helvetica,Arial,sans-serif;
-    font-size: 1.25em;
-    border: none;
-    padding:0;
-    margin: 0 1em 1em 1em;
-    border-bottom: solid white;
-    width: auto;
-    box-shadow: none !important;
-    color: black;
-&::placeholder {
-  color: rgba(0, 0, 0, 0.5);
-  opacity: 1;
-}
+  background: rgba(255, 255, 255, 0.2);
+  font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 1.25em;
+  border: none;
+  padding: 0;
+  margin: 0 1em 1em 1em;
+  border-bottom: solid white;
+  width: auto;
+  box-shadow: none !important;
+  color: black;
+  &::placeholder {
+    color: rgba(0, 0, 0, 0.5);
+    opacity: 1;
+  }
 `;

--- a/front/app/containers/App/App.tsx
+++ b/front/app/containers/App/App.tsx
@@ -4,7 +4,7 @@ import { Switch, Route, withRouter, Redirect } from 'react-router-dom';
 import NotFoundPage from 'containers/NotFoundPage';
 import NotConfiguredPage from 'containers/NotConfiguredPage';
 import SearchPage from 'containers/SearchPage';
-import ProfilePage from 'containers/ProfilePage';
+import {ProfilePage, EditProfilePage} from 'containers/ProfilePage';
 import LandingPage from 'containers/LandingPage';
 import AboutPage from 'containers/AboutPage';
 import ReleaseNotes from 'containers/ReleaseNotes';
@@ -15,7 +15,7 @@ import {
   SignInPage,
   SignUpPage,
   ResetPasswordPage,
-  EditProfilePage,
+  
 } from 'containers/LoginPage';
 import AuthHeader from 'components/AuthHeader';
 import { History } from 'history';

--- a/front/app/containers/CurrentUser/CurrentUser.tsx
+++ b/front/app/containers/CurrentUser/CurrentUser.tsx
@@ -20,12 +20,15 @@ const FRAGMENT = gql`
     reviewCount
     reviews
     
+    
     {
       content
       briefTitle
       nctId
     }
     contributions
+    pictureUrl
+    rank
   }
 `;
 
@@ -52,6 +55,7 @@ class CurrentUser extends React.PureComponent<CurrentUserProps> {
           if (loading || error || !data) {
             return this.props.children(null);
           }
+          console.log("DATA",data)
           return this.props.children(data.me);
         }}
       </QueryComponent>

--- a/front/app/containers/CurrentUser/CurrentUser.tsx
+++ b/front/app/containers/CurrentUser/CurrentUser.tsx
@@ -55,7 +55,7 @@ class CurrentUser extends React.PureComponent<CurrentUserProps> {
           if (loading || error || !data) {
             return this.props.children(null);
           }
-          console.log("DATA",data)
+          // console.log("DATA",data)
           return this.props.children(data.me);
         }}
       </QueryComponent>

--- a/front/app/containers/CurrentUser/CurrentUser.tsx
+++ b/front/app/containers/CurrentUser/CurrentUser.tsx
@@ -19,6 +19,7 @@ const FRAGMENT = gql`
     roles
     reviewCount
     reviews
+    
     {
       content
       briefTitle

--- a/front/app/containers/LoginPage/EditProfilePage.tsx
+++ b/front/app/containers/LoginPage/EditProfilePage.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as FontAwesome from 'react-fontawesome';
 import styled from 'styled-components';
 import { Row, Col } from 'react-bootstrap';
 import { Mutation, MutationFn } from 'react-apollo';
@@ -10,7 +11,7 @@ import {
 import SearchPage from 'containers/SearchPage';
 import { match } from 'react-router-dom';
 import { History, Location } from 'history';
-import StyledError from './StyledError';
+import StyledError from '../LoginPage/StyledError';
 import CurrentUser from 'containers/CurrentUser';
 import { UserFragment } from 'types/UserFragment';
 import { equals, pick } from 'ramda';
@@ -21,9 +22,10 @@ import {
   StyledProfileValue,
   StyledProfileForm,
 } from 'components/StyledComponents';
-import { ThemedButton } from './StyledButton';
-import ProfileScoreBoard from '../ProfilePage/ProfileScoreBoard';
-import RenderReviews from '../ProfilePage/RenderReviews';
+import { ThemedButton } from '../LoginPage/StyledButton';
+import ProfileScoreBoard from '../ProfilePage/components/ProfileScoreBoard';
+import ProfilePicture from '../ProfilePage/components/ProfilePicture';
+import ReviewsTable from '../ProfilePage/components/ReviewsTable';
 
 interface EditProfilePageProps {
   user: UserFragment | null;
@@ -53,7 +55,6 @@ const EDIT_PROFILE_MUTATION = gql`
       }
     }
   }
-
   ${CurrentUser.fragment}
 `;
 
@@ -109,6 +110,7 @@ class EditProfilePage extends React.Component<
 
   handleEditProfile = (editProfile: EditProfileMutationFn) => () => {
     editProfile({ variables: { input: this.state.form } });
+    this.toggleEditProfile()
   };
   toggleEditProfile = () => {
     this.setState({ isEditing: !this.state.isEditing });
@@ -123,9 +125,13 @@ class EditProfilePage extends React.Component<
     );
   };
   renderEditForm = () => {
+    if(this.props.user){
     return (
       <div>
-        <span onClick={() => this.toggleEditProfile()}>X</span>
+        //@ts-ignore
+        <ProfilePicture pictureUrl={this.props.user.pictureUrl}/>
+
+        <span style={{paddingLeft:'15px'}} onClick={() => this.toggleEditProfile()}>X</span>
 
         <SearchContainer>
           <StyledProfileLabel>First Name:</StyledProfileLabel>
@@ -183,12 +189,15 @@ class EditProfilePage extends React.Component<
         </SearchContainer>
       </div>
     );
+            }
   };
   renderProfileInfo = () => {
     if (this.props.user) {
       return (
         <div>
-          <span onClick={() => this.toggleEditProfile()}> Edit Profile</span>
+          //@ts-ignore
+          <ProfilePicture pictureUrl={this.props.user.pictureUrl}/>
+          <span style={{paddingLeft:'15px'}} onClick={() => this.toggleEditProfile()}> Edit Profile</span>
 
           <SearchContainer>
             <StyledProfileLabel>First Name:</StyledProfileLabel>
@@ -224,6 +233,8 @@ class EditProfilePage extends React.Component<
     switch (this.state.currentDisplay) {
       case 'contributions':
         return (
+          <div>
+          <h2>Contributed Studies:</h2>
           <SearchPage
             history={this.props.history}
             location={this.props.location}
@@ -233,13 +244,17 @@ class EditProfilePage extends React.Component<
             //userId={this.props.match.params.id}
             //profileParams={this.getUserParams(this.props.match.params.id)}
           />
+          </div>
         );
       case 'reviews':
         return (
-          <RenderReviews
+          <div>
+          <h2>Reviewed Studies:</h2>
+          <ReviewsTable
             reviewData={this.props.user?.reviews}
             history={this.props.history}
           />
+          </div>
         );
     }
   };

--- a/front/app/containers/LoginPage/index.ts
+++ b/front/app/containers/LoginPage/index.ts
@@ -1,4 +1,3 @@
 export { default as SignInPage } from './SignInPage';
 export { default as SignUpPage } from './SignUpPage';
 export { default as ResetPasswordPage } from './ResetPasswordPage';
-export { default as EditProfilePage } from './EditProfilePage';

--- a/front/app/containers/ProfilePage/EditProfilePage.tsx
+++ b/front/app/containers/ProfilePage/EditProfilePage.tsx
@@ -23,9 +23,9 @@ import {
   StyledProfileForm,
 } from 'components/StyledComponents';
 import { ThemedButton } from '../LoginPage/StyledButton';
-import ProfileScoreBoard from '../ProfilePage/components/ProfileScoreBoard';
-import ProfilePicture from '../ProfilePage/components/ProfilePicture';
-import ReviewsTable from '../ProfilePage/components/ReviewsTable';
+import ProfileScoreBoard from './components/ProfileScoreBoard';
+import ProfilePicture from './components/ProfilePicture';
+import ReviewsTable from './components/ReviewsTable';
 
 interface EditProfilePageProps {
   user: UserFragment | null;
@@ -192,11 +192,12 @@ class EditProfilePage extends React.Component<
             }
   };
   renderProfileInfo = () => {
+    //@ts-ignore
+    let pictureUrl =this.props.user.pictureUrl || null
     if (this.props.user) {
       return (
         <div>
-          //@ts-ignore
-          <ProfilePicture pictureUrl={this.props.user.pictureUrl}/>
+          <ProfilePicture pictureUrl={pictureUrl}/>
           <span style={{paddingLeft:'15px'}} onClick={() => this.toggleEditProfile()}> Edit Profile</span>
 
           <SearchContainer>
@@ -261,6 +262,7 @@ class EditProfilePage extends React.Component<
   render() {
     let userContributions = this.props.user?.contributions;
     let reviewCount = this.props.user?.reviewCount;
+    if(this.props.user){
     return (
       <ThemedMainContainer>
         <h2>My profile</h2>
@@ -276,6 +278,8 @@ class EditProfilePage extends React.Component<
             totalTags={'Coming Soon'}
             totalFavorites={0}
             handleDisplayChange={this.handleDisplayChange}
+            //@ts-ignore
+            rank={this.props.user.rank}
           />
         </SearchContainer>
         {this.props.user ? (
@@ -285,6 +289,8 @@ class EditProfilePage extends React.Component<
         )}
       </ThemedMainContainer>
     );
+        }
+        return(<div>No user</div>)
   }
 }
 

--- a/front/app/containers/ProfilePage/ProfilePage.tsx
+++ b/front/app/containers/ProfilePage/ProfilePage.tsx
@@ -3,7 +3,19 @@ import styled from 'styled-components';
 import SearchPage from 'containers/SearchPage';
 import { match } from 'react-router-dom';
 import { History, Location } from 'history';
-
+import {
+  ThemedMainContainer,
+  SearchContainer,
+  StyledProfileLabel,
+  StyledProfileValue,
+  StyledProfileForm,
+} from 'components/StyledComponents';
+import ThemedLoaderWrapper from '../../components/LoadingPane/LoadingPane';
+import ProfileScoreBoard from './components/ProfileScoreBoard';
+import ProfilePicture from './components/ProfilePicture';
+import ReviewsTable from './components/ReviewsTable';
+import { Query } from 'react-apollo';
+import { gql } from 'apollo-boost';
 
 interface ProfilePageProps {
   history: History;
@@ -57,9 +69,9 @@ class ProfilePage extends React.Component<ProfilePageProps, ProfilePageState> {
   this.setState({username:this.username()})
   }
   componentDidUpdate(currentState){
-     if(currentState.username!= this.username() ){
-       this.setState({username: this.username()})
-     }
+    //  if(currentState.username!= this.username() ){
+    //    this.setState({username: this.username()})
+    //  }
   }
   handleDisplayChange = display => {
     this.setState({ currentDisplay: display });

--- a/front/app/containers/ProfilePage/ProfilePage.tsx
+++ b/front/app/containers/ProfilePage/ProfilePage.tsx
@@ -4,16 +4,38 @@ import SearchPage from 'containers/SearchPage';
 import { match } from 'react-router-dom';
 import { History, Location } from 'history';
 
+
 interface ProfilePageProps {
   history: History;
   location: Location;
   match: any;
 }
+interface ProfilePageState {
+  currentDisplay: string;
+  username:string;
+}
 
-class ProfilePage extends React.Component<ProfilePageProps> {
-  componentDidMount() {
-    console.log('This.props', this.props);
+const USER_QUERY = gql`
+  query User($userId: Int!) {
+    user(userId: $userId) {
+      firstName
+      lastName
+      reviewCount
+      reviews {
+        nctId
+        briefTitle
+        content
+      }
+      contributions
+      pictureUrl
+    }
   }
+`;
+class ProfilePage extends React.Component<ProfilePageProps, ProfilePageState> {
+  state: ProfilePageState = {
+    currentDisplay: 'contributions',
+    username: '',
+  };
 
   getUserParams = (userId: string) => {
     return {
@@ -26,15 +48,88 @@ class ProfilePage extends React.Component<ProfilePageProps> {
     };
   };
 
+   username = () => {
+    return new URLSearchParams(this.props.location.search)
+  .getAll('username')
+  .toString();
+}
+  componentDidMount(){
+  this.setState({username:this.username()})
+  }
+  componentDidUpdate(currentState){
+     if(currentState.username!= this.username() ){
+       this.setState({username: this.username()})
+     }
+  }
+  handleDisplayChange = display => {
+    this.setState({ currentDisplay: display });
+  };
+  renderResults = reviews => {
+    switch (this.state.currentDisplay) {
+      case 'reviews':
+        return (
+          <ReviewsTable reviewData={reviews} history={this.props.history} />
+        );
+      case 'contributions':
+        return (
+          <SearchPage
+            history={this.props.history}
+            location={this.props.location}
+            match={this.props.match}
+            email={this.props.match.params.id}
+            profileParams={this.getUserParams(this.props.match.params.id)}
+          />
+        );
+    }
+  };
+
+  renderHeader = user => {
+    switch (this.state.currentDisplay) {
+      case 'contributions':
+        return <h2>{user.firstName || this.state.username}'s Contributed Studies</h2>;
+      case 'reviews':
+        return <h2> {user.firstName || this.state.username}'s Reviewed Studies</h2>;
+    }
+  };
   render() {
+    let userId = new URLSearchParams(this.props.location.search)
+      .getAll('uid')
+      .toString();
     return (
-        <SearchPage
-          history={this.props.history}
-          location={this.props.location}
-          match={this.props.match}
-          email={this.props.match.params.id}
-          profileParams={this.getUserParams(this.props.match.params.id)}
-        />
+      <Query query={USER_QUERY} variables={{ userId: parseInt(userId) }}>
+        {({ loading, error, data }) => {
+          if (loading)
+            return (
+              <ThemedMainContainer>
+                <ThemedLoaderWrapper />
+              </ThemedMainContainer>
+            );
+          if (error) return <div>Error</div>;
+          const userData = data;
+          return (
+            <div>
+              <ThemedMainContainer>
+                <ProfilePicture pictureUrl={userData.user.pictureUrl} />
+                <h2>
+                  {userData.user.firstName || this.state.username}'s Contributions
+                </h2>
+                <SearchContainer>
+                  <ProfileScoreBoard
+                    totalPoints={0}
+                    totalContributions={userData.user.contributions}
+                    totalReviews={userData.user.reviewCount}
+                    totalTags={'Coming Soon'}
+                    totalFavorites={0}
+                    handleDisplayChange={this.handleDisplayChange}
+                  />
+                </SearchContainer>
+                {this.renderHeader(userData.user)}
+                {this.renderResults(userData.user.reviews)}
+              </ThemedMainContainer>
+            </div>
+          );
+        }}
+      </Query>
     );
   }
 }

--- a/front/app/containers/ProfilePage/ProfilePage.tsx
+++ b/front/app/containers/ProfilePage/ProfilePage.tsx
@@ -33,6 +33,7 @@ const USER_QUERY = gql`
       firstName
       lastName
       reviewCount
+      rank
       reviews {
         nctId
         briefTitle
@@ -118,6 +119,7 @@ class ProfilePage extends React.Component<ProfilePageProps, ProfilePageState> {
             );
           if (error) return <div>Error</div>;
           const userData = data;
+          console.log("userData",userData)
           return (
             <div>
               <ThemedMainContainer>
@@ -133,6 +135,7 @@ class ProfilePage extends React.Component<ProfilePageProps, ProfilePageState> {
                     totalTags={'Coming Soon'}
                     totalFavorites={0}
                     handleDisplayChange={this.handleDisplayChange}
+                    rank={userData.user.rank}
                   />
                 </SearchContainer>
                 {this.renderHeader(userData.user)}

--- a/front/app/containers/ProfilePage/ProfileScoreBoard.tsx
+++ b/front/app/containers/ProfilePage/ProfileScoreBoard.tsx
@@ -31,7 +31,19 @@ class ProfileScoreBoard extends React.Component<ProfileScoreBoardProps> {
     } else if (100 > totalContributions && totalContributions > 50) {
       return <img style={{ maxWidth: '1.25em' }} src="/gold_star.png" />;
     } else if (totalContributions > 100) {
-      return 'Platinum Star';
+      return (
+        <span>
+        <ReactStars
+          count={1}
+          color1={'#E5E4E2'}
+          color2={'#E5E4E2'}
+          half={false}
+          size={25}
+          // value={}
+          //onChange={value => this.handleRatingChange(key, value)}
+        />
+      </span>
+      );
     }
   };
 

--- a/front/app/containers/ProfilePage/components/ProfilePicture.tsx
+++ b/front/app/containers/ProfilePage/components/ProfilePicture.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import * as FontAwesome from 'react-fontawesome';
+
+interface ProfilePictureProps {
+  pictureUrl: string | null;
+}
+
+class ProfilePicture extends React.Component<ProfilePictureProps> {
+  render() {
+    if (this.props.pictureUrl) {
+      return (
+        <img
+          style={{
+            borderRadius: '50%',
+            margin: '1em',
+            display: 'flex',
+            maxWidth: '5em',
+          }}
+          src={this.props.pictureUrl}
+          alt="profile-picture"
+        />
+      );
+    } else {
+      return (
+        <FontAwesome
+          className="fa-user"
+          name=" fa-user"
+          style={{
+            display: 'flex',
+            maxWidth: '5em',
+            margin: '0.2em',
+            fontSize: '5em',
+          }}
+        />
+      );
+    }
+  }
+}
+
+export default ProfilePicture;

--- a/front/app/containers/ProfilePage/components/ProfileScoreBoard.tsx
+++ b/front/app/containers/ProfilePage/components/ProfileScoreBoard.tsx
@@ -21,70 +21,72 @@ interface ProfileScoreBoardProps {
   totalTags: any;
   totalFavorites: any;
   handleDisplayChange?: any;
-  rank?:any;
+  rank?: any;
 }
 
 class ProfileScoreBoard extends React.Component<ProfileScoreBoardProps> {
   starLogo = totalContributions => {
-    if (this.props.rank == "default") {
-      return (
-        <span style={{ display: 'flex', margin: 'auto' }}>
-          <ReactStars
-            count={1}
-            color1={'#A97142'}
-            color2={'#A97142'}
-            half={false}
-            size={25}
-            // value={}
-            //onChange={value => this.handleRatingChange(key, value)}
-          />
-        </span>
-      );
-      // return <img style={{ maxWidth: '1.25em' }} src="/star_outline.png" />;
-    } else if (this.props.rank == "bronze") {
-      // return <img style={{ maxWidth: '1.25em' }} src="/silver_star.png" />;
-      return (
-        <span>
-          <ReactStars
-            count={1}
-            color1={'#C0C0C0'}
-            color2={'#C0C0C0'}
-            half={false}
-            size={25}
-            // value={}
-            //onChange={value => this.handleRatingChange(key, value)}
-          />
-        </span>
-      );
-    } else if (this.props.rank == "silver") {
-      return (
-        <span>
-          <ReactStars
-            count={1}
-            color1={'#D4AF37'}
-            color2={'#D4AF37'}
-            half={false}
-            size={25}
-            // value={}
-            //onChange={value => this.handleRatingChange(key, value)}
-          />
-        </span>
-      );
-    } else if (this.props.rank == "platinum") {
-      return (
-        <span>
-        <ReactStars
-          count={1}
-          color1={'#E5E4E2'}
-          color2={'#E5E4E2'}
-          half={false}
-          size={25}
-          // value={}
-          //onChange={value => this.handleRatingChange(key, value)}
-        />
-      </span>
-      );
-    }
+      const firstTier = '#A97142';
+      const secondTier = '#C0C0C0';
+      const thirdTier = '#D4AF37';
+      const fourthTier = '#E5E4E2';
+
+      let color = '';
+      switch (this.props.rank) {
+        case 'default':
+          color = firstTier;
+          return (
+            <span style={{ display: 'flex', margin: 'auto' }}>
+              <ReactStars
+                count={1}
+                color1={color}
+                color2={color}
+                half={false}
+                size={25}
+              />
+            </span>
+          );
+        case 'silver':
+          color = secondTier;
+          return (
+            <span style={{ display: 'flex', margin: 'auto' }}>
+              <ReactStars
+                count={1}
+                color1={color}
+                color2={color}
+                half={false}
+                size={25}
+              />
+            </span>
+          );
+        case 'gold':
+          color = thirdTier;
+          return (
+            <span style={{ display: 'flex', margin: 'auto' }}>
+              <ReactStars
+                count={1}
+                color1={color}
+                color2={color}
+                half={false}
+                size={25}
+              />
+            </span>
+          );
+        case 'platinum':
+          color = fourthTier;
+          return (
+            <span style={{ display: 'flex', margin: 'auto' }}>
+              <ReactStars
+                count={1}
+                color1={color}
+                color2={color}
+                half={false}
+                size={25}
+              />
+            </span>
+          );
+      }
+    return;
   };
 
   render() {

--- a/front/app/containers/ProfilePage/components/ProfileScoreBoard.tsx
+++ b/front/app/containers/ProfilePage/components/ProfileScoreBoard.tsx
@@ -11,6 +11,7 @@ import {
   StyledProfileValue,
   StyledProfileScoreValue,
   ScoreBoard,
+  StyledProfileRanking,
 } from 'components/StyledComponents';
 
 interface ProfileScoreBoardProps {
@@ -19,19 +20,57 @@ interface ProfileScoreBoardProps {
   totalReviews: any;
   totalTags: any;
   totalFavorites: any;
-  handleDisplayChange:any;
+  handleDisplayChange?: any;
+  rank?:any;
 }
 
 class ProfileScoreBoard extends React.Component<ProfileScoreBoardProps> {
-
   starLogo = totalContributions => {
-    if (10 > totalContributions && totalContributions > 0) {
-      return <img style={{ maxWidth: '1.25em' }} src="/star_outline.png" />;
-    } else if (50 > totalContributions && totalContributions > 10) {
-      return <img style={{ maxWidth: '1.25em' }} src="/silver_star.png" />;
-    } else if (100 > totalContributions && totalContributions > 50) {
-      return <img style={{ maxWidth: '1.25em' }} src="/gold_star.png" />;
-    } else if (totalContributions > 100) {
+    if (this.props.rank == "default") {
+      return (
+        <span style={{ display: 'flex', margin: 'auto' }}>
+          <ReactStars
+            count={1}
+            color1={'#A97142'}
+            color2={'#A97142'}
+            half={false}
+            size={25}
+            // value={}
+            //onChange={value => this.handleRatingChange(key, value)}
+          />
+        </span>
+      );
+      // return <img style={{ maxWidth: '1.25em' }} src="/star_outline.png" />;
+    } else if (this.props.rank == "bronze") {
+      // return <img style={{ maxWidth: '1.25em' }} src="/silver_star.png" />;
+      return (
+        <span>
+          <ReactStars
+            count={1}
+            color1={'#C0C0C0'}
+            color2={'#C0C0C0'}
+            half={false}
+            size={25}
+            // value={}
+            //onChange={value => this.handleRatingChange(key, value)}
+          />
+        </span>
+      );
+    } else if (this.props.rank == "silver") {
+      return (
+        <span>
+          <ReactStars
+            count={1}
+            color1={'#D4AF37'}
+            color2={'#D4AF37'}
+            half={false}
+            size={25}
+            // value={}
+            //onChange={value => this.handleRatingChange(key, value)}
+          />
+        </span>
+      );
+    } else if (this.props.rank == "platinum") {
       return (
         <span>
         <ReactStars
@@ -53,20 +92,22 @@ class ProfileScoreBoard extends React.Component<ProfileScoreBoardProps> {
       <div>
         <ScoreBoard>
           <StyledLabelValuePair>
-            <StyledProfileScoreValue>
+            <StyledProfileRanking>
               {this.starLogo(this.props.totalContributions)}
-            </StyledProfileScoreValue>
+            </StyledProfileRanking>
             <StyledProfileScoreLabel>Star Level</StyledProfileScoreLabel>
           </StyledLabelValuePair>
         </ScoreBoard>
         <ScoreBoard>
-          <StyledLabelValuePair onClick={()=>this.props.handleDisplayChange("contributions")}>
+          <StyledLabelValuePair
+            onClick={() => this.props.handleDisplayChange('contributions')}>
             <StyledProfileScoreValue>
               {this.props.totalContributions}
             </StyledProfileScoreValue>
             <StyledProfileScoreLabel>Contributions</StyledProfileScoreLabel>
           </StyledLabelValuePair>
-          <StyledLabelValuePair onClick={()=>this.props.handleDisplayChange("reviews")}>
+          <StyledLabelValuePair
+            onClick={() => this.props.handleDisplayChange('reviews')}>
             <StyledProfileScoreValue>
               {this.props.totalReviews}
             </StyledProfileScoreValue>

--- a/front/app/containers/ProfilePage/components/ProfileScoreBoard.tsx
+++ b/front/app/containers/ProfilePage/components/ProfileScoreBoard.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import ReactStars from 'react-stars';
 import styled from 'styled-components';
 import SearchPage from 'containers/SearchPage';
 import { match } from 'react-router-dom';

--- a/front/app/containers/ProfilePage/components/ReviewsTable.tsx
+++ b/front/app/containers/ProfilePage/components/ReviewsTable.tsx
@@ -3,12 +3,12 @@ import { History, Location } from 'history';
 import { SearchContainer } from 'components/StyledComponents';
 import ReactTable from 'react-table'
 
-interface RenderReviewsProps {
+interface ReviewsTableProps {
 reviewData: any;
 history: History;
 }
 
-class RenderReviews extends React.Component<RenderReviewsProps> {
+class ReviewsTable extends React.Component<ReviewsTableProps> {
   componentDidMount() {
 
   };
@@ -63,4 +63,4 @@ class RenderReviews extends React.Component<RenderReviewsProps> {
   }
 }
 
-export default RenderReviews;
+export default ReviewsTable;

--- a/front/app/containers/ProfilePage/index.ts
+++ b/front/app/containers/ProfilePage/index.ts
@@ -1,1 +1,2 @@
-export { default } from './ProfilePage';
+export { default as ProfilePage } from './ProfilePage';
+export { default as EditProfilePage } from './EditProfilePage';

--- a/front/app/containers/SearchPage/SearchPage.tsx
+++ b/front/app/containers/SearchPage/SearchPage.tsx
@@ -731,7 +731,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     const siteViewUrl = searchQueryString.getAll('sv').toString() || 'default';
 
         const userId = searchQueryString.getAll('uid').toString();
-
+        const userName = searchQueryString.getAll('username').toString();
         if (data?.provisionSearchHash?.searchHash?.short) {
           if (this.props.match.path == '/profile') {
             this.props.history.push(
@@ -745,7 +745,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
             this.props.history.push(
               `/profile/user?hash=${
                 data!.provisionSearchHash!.searchHash!.short
-              }&sv=${siteViewUrl}&uid=${userId}&username=${profile && profile.values.toString()}`
+              }&sv=${siteViewUrl}&uid=${userId}&username=${userName}`
             );
             return;
           }

--- a/front/app/containers/SearchPage/SearchPage.tsx
+++ b/front/app/containers/SearchPage/SearchPage.tsx
@@ -736,13 +736,8 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
           `/profile?hash=${
             data!.provisionSearchHash!.searchHash!.short
           }&sv=${siteViewUrl}`
-        ); return;
-      }else if(this.findFilter("wiki_page_edits.email")){
-        this.props.history.push(
-          `/profile/user?hash=${
-            data!.provisionSearchHash!.searchHash!.short
-          }&sv=${siteViewUrl}`
-        ); return;
+        );
+        return;
       }
       this.props.history.push(
         `/search?hash=${
@@ -751,7 +746,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
       );
       return;
     }
-
   };
 
   getTotalResults = total => {
@@ -762,7 +756,16 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     }
     return null;
   };
-
+  findFilter=(variable:string)=>{	
+    let aggFilter = this.state.params?.aggFilters;	
+    let response = find(propEq('field', variable ), aggFilter||[]) as {	
+      field:string;	
+      gte:string;	
+      lte:string;	
+      values:any[];	
+    }|null ;	
+    return response	
+  }
   handlePresearchButtonClick = (hash, target) => {
     const url = `/search?hash=${hash}&sv=${target}`;
     this.props.history.push(url);
@@ -939,26 +942,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
                 showFacetBar,
                 showBreadCrumbs,
               } = currentSiteView.search.config.fields;
-              if(profile && profile.values.toString() !== this.props.email){
-                return (
-                  <ThemedMainContainer>
-                  <h2>{profile && profile.values.toString()}'s Contributions</h2>
-                  <SearchPageWrapper>
-                    {showFacetBar && (
-                      <ThemedSidebarContainer md={2}>
-                        {this.renderAggs(currentSiteView)}
-                      </ThemedSidebarContainer>
-                    )}
-                    <ThemedMainContainer>
-                      {showBreadCrumbs && this.renderCrumbs(currentSiteView)}
-                      {showPresearch && this.renderPresearch(hash)}
-                      {this.renderSearch()}
-                    </ThemedMainContainer>
-                  </SearchPageWrapper>
-                  </ThemedMainContainer>
-                );
-
-              }
               return (
                 <SearchPageWrapper>
                   {showFacetBar && (

--- a/front/app/containers/SearchPage/SearchPage.tsx
+++ b/front/app/containers/SearchPage/SearchPage.tsx
@@ -725,28 +725,38 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     const variables = { ...this.state.params, ...params };
     const { data } = await this.props.mutate({ variables });
 
-    const siteViewUrl =
-      new URLSearchParams(this.props.history.location.search)
-        .getAll('sv')
-        .toString() || 'default';
+    const searchQueryString = new URLSearchParams(
+      this.props.history.location.search
+    );
+    const siteViewUrl = searchQueryString.getAll('sv').toString() || 'default';
 
-    if (data?.provisionSearchHash?.searchHash?.short) {
-      if(this.props.match.path =="/profile"){
-        this.props.history.push(
-          `/profile?hash=${
-            data!.provisionSearchHash!.searchHash!.short
-          }&sv=${siteViewUrl}`
-        );
-        return;
-      }
-      this.props.history.push(
-        `/search?hash=${
-          data!.provisionSearchHash!.searchHash!.short
-        }&sv=${siteViewUrl}`
-      );
-      return;
-    }
-  };
+        const userId = searchQueryString.getAll('uid').toString();
+
+        if (data?.provisionSearchHash?.searchHash?.short) {
+          if (this.props.match.path == '/profile') {
+            this.props.history.push(
+              `/profile?hash=${
+                data!.provisionSearchHash!.searchHash!.short
+              }&sv=${siteViewUrl}`
+            );
+            return;
+          } else if (userId) {
+            let profile = this.findFilter("wiki_page_edits.email")	
+            this.props.history.push(
+              `/profile/user?hash=${
+                data!.provisionSearchHash!.searchHash!.short
+              }&sv=${siteViewUrl}&uid=${userId}&username=${profile && profile.values.toString()}`
+            );
+            return;
+          }
+          this.props.history.push(
+            `/search?hash=${
+              data!.provisionSearchHash!.searchHash!.short
+            }&sv=${siteViewUrl}`
+          );
+          return;
+        }
+      };
 
   getTotalResults = total => {
     if (total) {
@@ -756,16 +766,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     }
     return null;
   };
-  findFilter=(variable:string)=>{	
-    let aggFilter = this.state.params?.aggFilters;	
-    let response = find(propEq('field', variable ), aggFilter||[]) as {	
-      field:string;	
-      gte:string;	
-      lte:string;	
-      values:any[];	
-    }|null ;	
-    return response	
-  }
   handlePresearchButtonClick = (hash, target) => {
     const url = `/search?hash=${hash}&sv=${target}`;
     this.props.history.push(url);

--- a/front/app/containers/SiteProvider/SiteProvider.tsx
+++ b/front/app/containers/SiteProvider/SiteProvider.tsx
@@ -253,6 +253,7 @@ const SITE_FRAGMENT = gql`
     skipLanding
     subdomain
     themes
+    userRank
     owners {
       email
     }

--- a/front/app/types/CreateSiteMutation.ts
+++ b/front/app/types/CreateSiteMutation.ts
@@ -733,6 +733,7 @@ export interface CreateSiteMutation_createSite_site {
   skipLanding: boolean | null;
   subdomain: string;
   themes: string;
+  userRank: string;
   owners: CreateSiteMutation_createSite_site_owners[];
   siteView: CreateSiteMutation_createSite_site_siteView;
   siteViews: CreateSiteMutation_createSite_site_siteViews[];

--- a/front/app/types/CurrentUserQuery.ts
+++ b/front/app/types/CurrentUserQuery.ts
@@ -41,6 +41,8 @@ export interface CurrentUserQuery_me {
   reviewCount: number;
   reviews: CurrentUserQuery_me_reviews[];
   contributions: number;
+  pictureUrl: string | null;
+  rank: string | null;
 }
 
 export interface CurrentUserQuery {

--- a/front/app/types/EditProfileMutation.ts
+++ b/front/app/types/EditProfileMutation.ts
@@ -43,6 +43,8 @@ export interface EditProfileMutation_updateProfile_user {
   reviewCount: number;
   reviews: EditProfileMutation_updateProfile_user_reviews[];
   contributions: number;
+  pictureUrl: string | null;
+  rank: string | null;
 }
 
 export interface EditProfileMutation_updateProfile {

--- a/front/app/types/SignInMutation.ts
+++ b/front/app/types/SignInMutation.ts
@@ -43,6 +43,8 @@ export interface SignInMutation_signIn_user {
   reviewCount: number;
   reviews: SignInMutation_signIn_user_reviews[];
   contributions: number;
+  pictureUrl: string | null;
+  rank: string | null;
 }
 
 export interface SignInMutation_signIn {

--- a/front/app/types/SignUpMutation.ts
+++ b/front/app/types/SignUpMutation.ts
@@ -43,6 +43,8 @@ export interface SignUpMutation_signUp_user {
   reviewCount: number;
   reviews: SignUpMutation_signUp_user_reviews[];
   contributions: number;
+  pictureUrl: string | null;
+  rank: string | null;
 }
 
 export interface SignUpMutation_signUp {

--- a/front/app/types/SiteFragment.ts
+++ b/front/app/types/SiteFragment.ts
@@ -733,6 +733,7 @@ export interface SiteFragment {
   skipLanding: boolean | null;
   subdomain: string;
   themes: string;
+  userRank: string;
   owners: SiteFragment_owners[];
   siteView: SiteFragment_siteView;
   siteViews: SiteFragment_siteViews[];

--- a/front/app/types/SiteProviderQuery.ts
+++ b/front/app/types/SiteProviderQuery.ts
@@ -733,6 +733,7 @@ export interface SiteProviderQuery_site {
   skipLanding: boolean | null;
   subdomain: string;
   themes: string;
+  userRank: string;
   owners: SiteProviderQuery_site_owners[];
   siteView: SiteProviderQuery_site_siteView;
   siteViews: SiteProviderQuery_site_siteViews[];

--- a/front/app/types/UpdateSiteMutation.ts
+++ b/front/app/types/UpdateSiteMutation.ts
@@ -733,6 +733,7 @@ export interface UpdateSiteMutation_updateSite_site {
   skipLanding: boolean | null;
   subdomain: string;
   themes: string;
+  userRank: string;
   owners: UpdateSiteMutation_updateSite_site_owners[];
   siteView: UpdateSiteMutation_updateSite_site_siteView;
   siteViews: UpdateSiteMutation_updateSite_site_siteViews[];

--- a/front/app/types/User.ts
+++ b/front/app/types/User.ts
@@ -1,0 +1,43 @@
+/* tslint:disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: User
+// ====================================================
+
+export interface User_user_reviews {
+  __typename: "Review";
+  nctId: string;
+  briefTitle: string;
+  content: string;
+}
+
+export interface User_user {
+  __typename: "PublicUser";
+  /**
+   * First name
+   */
+  firstName: string | null;
+  /**
+   * Last name
+   */
+  lastName: string | null;
+  /**
+   * Number of reviews the user has done
+   */
+  reviewCount: number;
+  reviews: User_user_reviews[];
+  contributions: number;
+  pictureUrl: string | null;
+}
+
+export interface User {
+  /**
+   * Public Profile User
+   */
+  user: User_user;
+}
+
+export interface UserVariables {
+  userId: number;
+}

--- a/front/app/types/User.ts
+++ b/front/app/types/User.ts
@@ -26,6 +26,7 @@ export interface User_user {
    * Number of reviews the user has done
    */
   reviewCount: number;
+  rank: string | null;
   reviews: User_user_reviews[];
   contributions: number;
   pictureUrl: string | null;

--- a/front/app/types/UserFragment.ts
+++ b/front/app/types/UserFragment.ts
@@ -41,4 +41,6 @@ export interface UserFragment {
   reviewCount: number;
   reviews: UserFragment_reviews[];
   contributions: number;
+  pictureUrl: string | null;
+  rank: string | null;
 }

--- a/front/app/types/globalTypes.ts
+++ b/front/app/types/globalTypes.ts
@@ -85,6 +85,7 @@ export interface CreateSiteInput {
   subdomain: string;
   skipLanding?: boolean | null;
   themes?: string | null;
+  userRank?: string | null;
   editorEmails?: string[] | null;
   clientMutationId?: string | null;
 }
@@ -221,6 +222,7 @@ export interface UpdateSiteInput {
   id: number;
   name?: string | null;
   themes?: string | null;
+  userRank?: string | null;
   skipLanding?: boolean | null;
   subdomain?: string | null;
   editorEmails?: string[] | null;


### PR DESCRIPTION
This PR takes care of the pending items in issue #518  pertaining to user profile. 

In addition, it includes the user ranking configuration which goes hand in hand, as it is what handles the star display on user profiles.

Screenshots:
This first image is of how I configured my ranking for the site from where the screenshots came from

![Screen Shot 2020-05-13 at 1 36 40 PM](https://user-images.githubusercontent.com/17464571/81851448-165deb00-951f-11ea-9df3-f5a38919ace5.png)


This second image is my personal profile.

As you can see, I have 6 contributions.In my site form I configured my "gold" tier to anything greater than or equal to 6 (but less than 8, as thats the next rank up), so my star is gold.
 
![Screen Shot 2020-05-13 at 1 34 48 PM](https://user-images.githubusercontent.com/17464571/81851524-37bed700-951f-11ea-9af8-a63ca220221a.png)

This next screenshot shows the public profile of a user with no first name (generally because it was a normal email sign up)

![Screen Shot 2020-05-13 at 1 35 51 PM](https://user-images.githubusercontent.com/17464571/81851930-d6e3ce80-951f-11ea-9200-099742bcebd7.png)


and in comparison a profile of someone who might sign up with google:
![Screen Shot 2020-05-13 at 1 36 10 PM](https://user-images.githubusercontent.com/17464571/81851986-ec58f880-951f-11ea-81f4-8c1c422eecb6.png)
