### PR TITLE
540 Additional Number Range Features

### DIFF
--- a/app/graphql/types/field_display_type.rb
+++ b/app/graphql/types/field_display_type.rb
@@ -5,6 +5,7 @@ module Types
     value "DATE"
     value "DATE_RANGE"
     value "NUMBER_RANGE"
-    value "RANGE"
+    value "LESS_THAN_RANGE"
+    value "GREATER_THAN_RANGE"
   end
 end

--- a/app/graphql/types/site_agg_field_type.rb
+++ b/app/graphql/types/site_agg_field_type.rb
@@ -7,6 +7,8 @@ module Types
     field :preselected, SiteSelectType, null: false
     field :visible_options, SiteSelectType, null: false
     field :order, SiteOrderType, null:true
+    field :range_start_label, String, null: true
+    field :range_end_label, String, null: true
 
     def display
       object[:display]
@@ -18,6 +20,12 @@ module Types
 
     def visible_options
       object[:visibleOptions]
+    end
+    def range_start_label
+      object[:rangeStartLabel]
+    end
+    def range_end_label
+      object[:rangeEndLabel]
     end
   end
 end

--- a/app/models/site_view.rb
+++ b/app/models/site_view.rb
@@ -375,6 +375,8 @@ class SiteView < ApplicationRecord # rubocop:disable Metrics/ClassLength
       autoSuggest: false,
       display: default_agg_param_display(name),
       order: default_agg_param_order(name),
+      range_start_label: nil,
+      range_end_label:nil,
       preselected: {
         kind: "WHITELIST",
         values: [],

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_25_183458) do
+ActiveRecord::Schema.define(version: 2020_05_04_161212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -147,6 +147,7 @@ ActiveRecord::Schema.define(version: 2020_04_25_183458) do
     t.string "last_name"
     t.string "default_query_string"
     t.json "search_result_columns"
+    t.string "picture_url"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/front/app/components/SiteForm/AggField.tsx
+++ b/front/app/components/SiteForm/AggField.tsx
@@ -131,7 +131,19 @@ class AggField extends React.Component<AggFieldProps, AggFieldState> {
       currentTarget: { name: e.currentTarget.name, value: !value },
     });
   };
-
+  renderNumberRangeConfig=(configType)=>{
+    return(
+      <StyledFormControl
+      name={`set:${this.getPath(configType)}.display`}
+      componentClass="select"
+      onChange={this.props.onAddMutation}
+      defaultValue={this.props.field.display}>
+      <option value="LESS_THAN">Less Than</option>
+      <option value="GREATER_THAN">Greater Than</option>
+      <option value="NUMBER_RANGE">Range</option>
+    </StyledFormControl>
+    );
+  }
   handleOpen = (kind: 'preselected' | 'visibleOptions') => (
     agg: string,
     aggKind: AggKind
@@ -295,8 +307,12 @@ class AggField extends React.Component<AggFieldProps, AggFieldState> {
               <option value="DATE">Date</option>
               <option value="DATE_RANGE">Date Range</option>
               <option value="NUMBER_RANGE">Number Range</option>
+              <option value="LESS_THAN">Less Than</option>
+              <option value="GREATER_THAN">Greater Than</option>
             </StyledFormControl>
           </div>
+          {/* {this.props.field.display =='NUMBER_RANGE' || 'LESS_THAN'||'GREATER_THAN' ? (this.renderNumberRangeConfig(configType)):(null)
+          }  */}
         </ThemedContainer>
       </>
     );

--- a/front/app/components/SiteForm/AggField.tsx
+++ b/front/app/components/SiteForm/AggField.tsx
@@ -131,19 +131,57 @@ class AggField extends React.Component<AggFieldProps, AggFieldState> {
       currentTarget: { name: e.currentTarget.name, value: !value },
     });
   };
-  renderNumberRangeConfig=(configType)=>{
-    return(
-      <StyledFormControl
-      name={`set:${this.getPath(configType)}.display`}
-      componentClass="select"
-      onChange={this.props.onAddMutation}
-      defaultValue={this.props.field.display}>
-      <option value="LESS_THAN">Less Than</option>
-      <option value="GREATER_THAN">Greater Than</option>
-      <option value="NUMBER_RANGE">Range</option>
-    </StyledFormControl>
-    );
-  }
+  renderNumberRangeConfig = (configType, display) => {
+    if (display == 'NUMBER_RANGE' || display == 'DATE_RANGE') {
+      return (
+        <span>
+          <StyledLabel>Range Start Label</StyledLabel>
+
+          <StyledFormControl
+            name={`set:${this.getPath(configType)}.rangeStartLabel`}
+            placeholder="Start"
+            //@ts-ignore
+            value={this.props.field.rangeStartLabel}
+            onChange={this.props.onAddMutation}
+          />
+          <StyledLabel>Range End Label</StyledLabel>
+
+          <StyledFormControl
+            name={`set:${this.getPath(configType)}.rangeEndLabel`}
+            placeholder="End"
+            //@ts-ignore
+            value={this.props.field.rangeEndLabel}
+            onChange={this.props.onAddMutation}
+          />
+        </span>
+      );
+    } else {
+      return (
+        <span>
+          <StyledLabel>Range Label</StyledLabel>
+
+          <StyledFormControl
+            name={
+              display == 'GREATER_THAN_RANGE'
+                ? `set:${this.getPath(configType)}.rangeStartLabel`
+                : `set:${this.getPath(configType)}.rangeEndLabel`
+            }
+            //@ts-ignore
+            placeholder={display == 'GREATER_THAN_RANGE' ? this.props.field.rangeStartLabel : this.props.field.rangeEndLabel}
+
+            value={
+              display == 'GREATER_THAN_RANGE'
+              //@ts-ignore
+                ? this.props.field.rangeStartLabel
+              //@ts-ignore
+                : this.props.field.rangeEndLabel
+            }
+            onChange={this.props.onAddMutation}
+          />
+        </span>
+      );
+    }
+  };
   handleOpen = (kind: 'preselected' | 'visibleOptions') => (
     agg: string,
     aggKind: AggKind
@@ -307,12 +345,16 @@ class AggField extends React.Component<AggFieldProps, AggFieldState> {
               <option value="DATE">Date</option>
               <option value="DATE_RANGE">Date Range</option>
               <option value="NUMBER_RANGE">Number Range</option>
-              <option value="LESS_THAN">Less Than</option>
-              <option value="GREATER_THAN">Greater Than</option>
+              <option value="LESS_THAN_RANGE">Less Than Range</option>
+              <option value="GREATER_THAN_RANGE">Greater Than Range</option>
             </StyledFormControl>
           </div>
-          {/* {this.props.field.display =='NUMBER_RANGE' || 'LESS_THAN'||'GREATER_THAN' ? (this.renderNumberRangeConfig(configType)):(null)
-          }  */}
+          {this.props.field.display == 'NUMBER_RANGE' ||
+          this.props.field.display == 'LESS_THAN_RANGE' ||
+          this.props.field.display == 'GREATER_THAN_RANGE' ||
+          this.props.field.display == 'DATE_RANGE'
+            ? this.renderNumberRangeConfig(configType, this.props.field.display)
+            : null}
         </ThemedContainer>
       </>
     );

--- a/front/app/containers/AggDropDown/AggDropDown.tsx
+++ b/front/app/containers/AggDropDown/AggDropDown.tsx
@@ -400,7 +400,9 @@ class AggDropDown extends React.Component<AggDropDownProps, AggDropDownState> {
     const field = this.findFields();
     if (
       field?.display === FieldDisplay.DATE_RANGE ||
-      field?.display === FieldDisplay.NUMBER_RANGE
+      field?.display === FieldDisplay.NUMBER_RANGE ||
+      field?.display === FieldDisplay.LESS_THAN_RANGE ||
+      field?.display === FieldDisplay.GREATER_THAN_RANGE 
     ) {
       return (
         <Panel.Collapse id="range-selector">
@@ -413,10 +415,9 @@ class AggDropDown extends React.Component<AggDropDownProps, AggDropDownState> {
                 buckets={buckets}
                 handleLoadMore={this.handleLoadMore}
                 aggType={
-                  field?.display === FieldDisplay.DATE_RANGE
-                    ? FieldDisplay.DATE_RANGE
-                    : FieldDisplay.NUMBER_RANGE
+                  field?.display 
                 }
+                field={field}
               />
             </Container>
             {!loading && (
@@ -512,7 +513,9 @@ class AggDropDown extends React.Component<AggDropDownProps, AggDropDownState> {
     const field = this.findFields();
     if (
       field?.display === FieldDisplay.DATE_RANGE ||
-      field?.display === FieldDisplay.NUMBER_RANGE
+      field?.display === FieldDisplay.NUMBER_RANGE ||
+      field?.display === FieldDisplay.LESS_THAN_RANGE ||
+      field?.display === FieldDisplay.GREATER_THAN_RANGE 
     ) {
       return (
         <PresearchPanel id="range-selector">
@@ -524,10 +527,9 @@ class AggDropDown extends React.Component<AggDropDownProps, AggDropDownState> {
               buckets={buckets}
               handleLoadMore={this.handleLoadMore}
               aggType={
-                field?.display === FieldDisplay.DATE_RANGE
-                  ? FieldDisplay.DATE_RANGE
-                  : FieldDisplay.NUMBER_RANGE
+                field?.display
               }
+              field={field}
             />
           </Container>
           {!loading && (

--- a/front/app/containers/AggDropDown/AggDropDown.tsx
+++ b/front/app/containers/AggDropDown/AggDropDown.tsx
@@ -402,7 +402,7 @@ class AggDropDown extends React.Component<AggDropDownProps, AggDropDownState> {
       field?.display === FieldDisplay.DATE_RANGE ||
       field?.display === FieldDisplay.NUMBER_RANGE ||
       field?.display === FieldDisplay.LESS_THAN_RANGE ||
-      field?.display === FieldDisplay.GREATER_THAN_RANGE 
+      field?.display === FieldDisplay.GREATER_THAN_RANGE
     ) {
       return (
         <Panel.Collapse id="range-selector">
@@ -414,9 +414,7 @@ class AggDropDown extends React.Component<AggDropDownProps, AggDropDownState> {
                 loading={loading}
                 buckets={buckets}
                 handleLoadMore={this.handleLoadMore}
-                aggType={
-                  field?.display 
-                }
+                aggType={field?.display}
                 field={field}
               />
             </Container>
@@ -515,7 +513,7 @@ class AggDropDown extends React.Component<AggDropDownProps, AggDropDownState> {
       field?.display === FieldDisplay.DATE_RANGE ||
       field?.display === FieldDisplay.NUMBER_RANGE ||
       field?.display === FieldDisplay.LESS_THAN_RANGE ||
-      field?.display === FieldDisplay.GREATER_THAN_RANGE 
+      field?.display === FieldDisplay.GREATER_THAN_RANGE
     ) {
       return (
         <PresearchPanel id="range-selector">
@@ -526,9 +524,7 @@ class AggDropDown extends React.Component<AggDropDownProps, AggDropDownState> {
               loading={loading}
               buckets={buckets}
               handleLoadMore={this.handleLoadMore}
-              aggType={
-                field?.display
-              }
+              aggType={field?.display}
               field={field}
             />
           </Container>

--- a/front/app/containers/AggDropDown/RangeSelector.tsx
+++ b/front/app/containers/AggDropDown/RangeSelector.tsx
@@ -38,7 +38,7 @@ interface RangeSelectorProps {
   handleLoadMore: () => void;
   updater: AggFilterInputUpdater;
   aggType: FieldDisplay;
-  field:any;
+  field: any;
 }
 
 interface RangeSelectorState {
@@ -61,13 +61,13 @@ class RangeSelector extends React.Component<
       endText: this.props.updater.input.lte,
     };
   }
-  componentDidMount=()=>{
+  componentDidMount = () => {
     // let showAlternate= true
     // if(showAlternate){
     //   this.setState({startText: 'Greater Than or Equal to:'})
     // }
-  }
-  
+  };
+
   onChange = () =>
     this.props.updater.changeRange([
       this.state.start || this.props.updater.input.gte,
@@ -83,7 +83,7 @@ class RangeSelector extends React.Component<
       handleLoadMore,
       updater,
       aggType,
-      field
+      field,
     } = this.props;
     const { startText, endText } = this.state;
     //Removing Temporarily to see if it fixes date range query issue seems
@@ -134,129 +134,127 @@ class RangeSelector extends React.Component<
     // start.sort();
     // end.sort();
 
-    const startLabel = field && field.rangeStartLabel || 'Start'
-    const endLabel = field && field.rangeEndLabel || 'End'
-    if(aggType==FieldDisplay.GREATER_THAN_RANGE){
-      return(
+    const startLabel = (field && field.rangeStartLabel) || 'Start';
+    const endLabel = (field && field.rangeEndLabel) || 'End';
+    if (aggType == FieldDisplay.GREATER_THAN_RANGE) {
+      return (
         <Col className="range-selector">
-        <Form
-          onSubmit={e => {
-            e.preventDefault();
-            this.setState(
-              { ...this.state, start: startText, end: endText },
-              this.onChange
-            );
-          }}>
-          <FormGroup>
-            <ControlLabel>{startLabel}</ControlLabel>
-            <FormControl
-              type={'text'}
-              value={startText}
-              onChange={e =>
-                this.setState({
-                  ...this.state,
-                  startText: e.target.value,
-                })
-              }
-              onBlur={e =>
-                this.setState(
-                  { ...this.state, start: startText },
-                  this.onChange
-                )
-              }></FormControl>
-          </FormGroup>
-                  {/* this is a placebo, it's really done on onblur */}
-        <ThemedButton type="submit">Enter</ThemedButton>
-
-          </Form>
-          </Col>
-      )
-    }else if(aggType==FieldDisplay.LESS_THAN_RANGE){
-      return(
-        <Col className="range-selector">
-        <Form
-          onSubmit={e => {
-            e.preventDefault();
-            this.setState(
-              { ...this.state, start: startText, end: endText },
-              this.onChange
-            );
-          }}>
-        <FormGroup>
-        <ControlLabel>{endLabel}</ControlLabel>
-        <FormControl
-          type={'text'}
-          value={endText}
-          onChange={e =>
-            this.setState({
-              ...this.state,
-              endText: e.target.value,
-            })
-          }
-          onBlur={e =>
-            this.setState({ ...this.state, end: endText }, this.onChange)
-          }></FormControl>
-      </FormGroup>
-      <FormGroup>
-        {/* this is a placebo, it's really done on onblur */}
-        <ThemedButton type="submit">Enter</ThemedButton>
-      </FormGroup>
-    </Form>
-  </Col>
-      );
-    }else{
-
-    return (
-      <Col className="range-selector">
-        <Form
-          onSubmit={e => {
-            e.preventDefault();
-            this.setState(
-              { ...this.state, start: startText, end: endText },
-              this.onChange
-            );
-          }}>
-          <FormGroup>
-            <ControlLabel>{startLabel}</ControlLabel>
-            <FormControl
-              type={aggType == FieldDisplay.DATE_RANGE ? 'date' : 'text'}
-              value={startText}
-              onChange={e =>
-                this.setState({
-                  ...this.state,
-                  startText: e.target.value,
-                })
-              }
-              onBlur={e =>
-                this.setState(
-                  { ...this.state, start: startText },
-                  this.onChange
-                )
-              }></FormControl>
-          </FormGroup>
-          <FormGroup>
-            <ControlLabel>{endLabel}</ControlLabel>
-            <FormControl
-              type={aggType == FieldDisplay.DATE_RANGE ? 'date' : 'text'}
-              value={endText}
-              onChange={e =>
-                this.setState({
-                  ...this.state,
-                  endText: e.target.value,
-                })
-              }
-              onBlur={e =>
-                this.setState({ ...this.state, end: endText }, this.onChange)
-              }></FormControl>
-          </FormGroup>
-          <FormGroup>
+          <Form
+            onSubmit={e => {
+              e.preventDefault();
+              this.setState(
+                { ...this.state, start: startText, end: endText },
+                this.onChange
+              );
+            }}>
+            <FormGroup>
+              <ControlLabel>{startLabel}</ControlLabel>
+              <FormControl
+                type={'text'}
+                value={startText}
+                onChange={e =>
+                  this.setState({
+                    ...this.state,
+                    startText: e.target.value,
+                  })
+                }
+                onBlur={e =>
+                  this.setState(
+                    { ...this.state, start: startText },
+                    this.onChange
+                  )
+                }></FormControl>
+            </FormGroup>
             {/* this is a placebo, it's really done on onblur */}
             <ThemedButton type="submit">Enter</ThemedButton>
-          </FormGroup>
-        </Form>
-      </Col>
-    );
-  }
+          </Form>
+        </Col>
+      );
+    } else if (aggType == FieldDisplay.LESS_THAN_RANGE) {
+      return (
+        <Col className="range-selector">
+          <Form
+            onSubmit={e => {
+              e.preventDefault();
+              this.setState(
+                { ...this.state, start: startText, end: endText },
+                this.onChange
+              );
+            }}>
+            <FormGroup>
+              <ControlLabel>{endLabel}</ControlLabel>
+              <FormControl
+                type={'text'}
+                value={endText}
+                onChange={e =>
+                  this.setState({
+                    ...this.state,
+                    endText: e.target.value,
+                  })
+                }
+                onBlur={e =>
+                  this.setState({ ...this.state, end: endText }, this.onChange)
+                }></FormControl>
+            </FormGroup>
+            <FormGroup>
+              {/* this is a placebo, it's really done on onblur */}
+              <ThemedButton type="submit">Enter</ThemedButton>
+            </FormGroup>
+          </Form>
+        </Col>
+      );
+    } else {
+      return (
+        <Col className="range-selector">
+          <Form
+            onSubmit={e => {
+              e.preventDefault();
+              this.setState(
+                { ...this.state, start: startText, end: endText },
+                this.onChange
+              );
+            }}>
+            <FormGroup>
+              <ControlLabel>{startLabel}</ControlLabel>
+              <FormControl
+                type={aggType == FieldDisplay.DATE_RANGE ? 'date' : 'text'}
+                value={startText}
+                onChange={e =>
+                  this.setState({
+                    ...this.state,
+                    startText: e.target.value,
+                  })
+                }
+                onBlur={e =>
+                  this.setState(
+                    { ...this.state, start: startText },
+                    this.onChange
+                  )
+                }></FormControl>
+            </FormGroup>
+            <FormGroup>
+              <ControlLabel>{endLabel}</ControlLabel>
+              <FormControl
+                type={aggType == FieldDisplay.DATE_RANGE ? 'date' : 'text'}
+                value={endText}
+                onChange={e =>
+                  this.setState({
+                    ...this.state,
+                    endText: e.target.value,
+                  })
+                }
+                onBlur={e =>
+                  this.setState({ ...this.state, end: endText }, this.onChange)
+                }></FormControl>
+            </FormGroup>
+            <FormGroup>
+              {/* this is a placebo, it's really done on onblur */}
+              <ThemedButton type="submit">Enter</ThemedButton>
+            </FormGroup>
+          </Form>
+        </Col>
+      );
+    }
   }
 }
 

--- a/front/app/containers/AggDropDown/RangeSelector.tsx
+++ b/front/app/containers/AggDropDown/RangeSelector.tsx
@@ -38,6 +38,7 @@ interface RangeSelectorProps {
   handleLoadMore: () => void;
   updater: AggFilterInputUpdater;
   aggType: FieldDisplay;
+  field:any;
 }
 
 interface RangeSelectorState {
@@ -82,6 +83,7 @@ class RangeSelector extends React.Component<
       handleLoadMore,
       updater,
       aggType,
+      field
     } = this.props;
     const { startText, endText } = this.state;
     //Removing Temporarily to see if it fixes date range query issue seems
@@ -132,9 +134,9 @@ class RangeSelector extends React.Component<
     // start.sort();
     // end.sort();
 
-    let showLessThan=false;
-    let showGreater=false;
-    if(showGreater){
+    const startLabel = field && field.rangeStartLabel || 'Start'
+    const endLabel = field && field.rangeEndLabel || 'End'
+    if(aggType==FieldDisplay.GREATER_THAN_RANGE){
       return(
         <Col className="range-selector">
         <Form
@@ -146,9 +148,9 @@ class RangeSelector extends React.Component<
             );
           }}>
           <FormGroup>
-            <ControlLabel>Greater Than</ControlLabel>
+            <ControlLabel>{startLabel}</ControlLabel>
             <FormControl
-              type={aggType == FieldDisplay.DATE_RANGE ? 'date' : 'text'}
+              type={'text'}
               value={startText}
               onChange={e =>
                 this.setState({
@@ -163,10 +165,13 @@ class RangeSelector extends React.Component<
                 )
               }></FormControl>
           </FormGroup>
+                  {/* this is a placebo, it's really done on onblur */}
+        <ThemedButton type="submit">Enter</ThemedButton>
+
           </Form>
           </Col>
       )
-    }else if(showLessThan){
+    }else if(aggType==FieldDisplay.LESS_THAN_RANGE){
       return(
         <Col className="range-selector">
         <Form
@@ -178,9 +183,9 @@ class RangeSelector extends React.Component<
             );
           }}>
         <FormGroup>
-        <ControlLabel>Less Than</ControlLabel>
+        <ControlLabel>{endLabel}</ControlLabel>
         <FormControl
-          type={aggType == FieldDisplay.DATE_RANGE ? 'date' : 'text'}
+          type={'text'}
           value={endText}
           onChange={e =>
             this.setState({
@@ -212,7 +217,7 @@ class RangeSelector extends React.Component<
             );
           }}>
           <FormGroup>
-            <ControlLabel>Start</ControlLabel>
+            <ControlLabel>{startLabel}</ControlLabel>
             <FormControl
               type={aggType == FieldDisplay.DATE_RANGE ? 'date' : 'text'}
               value={startText}
@@ -230,7 +235,7 @@ class RangeSelector extends React.Component<
               }></FormControl>
           </FormGroup>
           <FormGroup>
-            <ControlLabel>End</ControlLabel>
+            <ControlLabel>{endLabel}</ControlLabel>
             <FormControl
               type={aggType == FieldDisplay.DATE_RANGE ? 'date' : 'text'}
               value={endText}

--- a/front/app/containers/AggDropDown/RangeSelector.tsx
+++ b/front/app/containers/AggDropDown/RangeSelector.tsx
@@ -60,7 +60,13 @@ class RangeSelector extends React.Component<
       endText: this.props.updater.input.lte,
     };
   }
-
+  componentDidMount=()=>{
+    // let showAlternate= true
+    // if(showAlternate){
+    //   this.setState({startText: 'Greater Than or Equal to:'})
+    // }
+  }
+  
   onChange = () =>
     this.props.updater.changeRange([
       this.state.start || this.props.updater.input.gte,
@@ -126,6 +132,75 @@ class RangeSelector extends React.Component<
     // start.sort();
     // end.sort();
 
+    let showLessThan=false;
+    let showGreater=false;
+    if(showGreater){
+      return(
+        <Col className="range-selector">
+        <Form
+          onSubmit={e => {
+            e.preventDefault();
+            this.setState(
+              { ...this.state, start: startText, end: endText },
+              this.onChange
+            );
+          }}>
+          <FormGroup>
+            <ControlLabel>Greater Than</ControlLabel>
+            <FormControl
+              type={aggType == FieldDisplay.DATE_RANGE ? 'date' : 'text'}
+              value={startText}
+              onChange={e =>
+                this.setState({
+                  ...this.state,
+                  startText: e.target.value,
+                })
+              }
+              onBlur={e =>
+                this.setState(
+                  { ...this.state, start: startText },
+                  this.onChange
+                )
+              }></FormControl>
+          </FormGroup>
+          </Form>
+          </Col>
+      )
+    }else if(showLessThan){
+      return(
+        <Col className="range-selector">
+        <Form
+          onSubmit={e => {
+            e.preventDefault();
+            this.setState(
+              { ...this.state, start: startText, end: endText },
+              this.onChange
+            );
+          }}>
+        <FormGroup>
+        <ControlLabel>Less Than</ControlLabel>
+        <FormControl
+          type={aggType == FieldDisplay.DATE_RANGE ? 'date' : 'text'}
+          value={endText}
+          onChange={e =>
+            this.setState({
+              ...this.state,
+              endText: e.target.value,
+            })
+          }
+          onBlur={e =>
+            this.setState({ ...this.state, end: endText }, this.onChange)
+          }></FormControl>
+      </FormGroup>
+      <FormGroup>
+        {/* this is a placebo, it's really done on onblur */}
+        <ThemedButton type="submit">Enter</ThemedButton>
+      </FormGroup>
+    </Form>
+  </Col>
+      );
+    }else{
+
     return (
       <Col className="range-selector">
         <Form
@@ -176,6 +251,7 @@ class RangeSelector extends React.Component<
         </Form>
       </Col>
     );
+  }
   }
 }
 

--- a/front/app/containers/SiteProvider/SiteProvider.tsx
+++ b/front/app/containers/SiteProvider/SiteProvider.tsx
@@ -332,7 +332,7 @@ class SiteProvider extends React.PureComponent<SiteProviderProps> {
           // console.log("ID",this.props.id)
           // console.log("url",this.props.url)
           // console.log(this.props)
-          console.log(data)
+          // console.log(data)
           if (error) console.log(`SiteProvider error: ${error}`);
           if (loading || error) return null;
           return this.props.children(data!.site!, refetch);

--- a/front/app/containers/SiteProvider/SiteProvider.tsx
+++ b/front/app/containers/SiteProvider/SiteProvider.tsx
@@ -141,6 +141,8 @@ const SITE_VIEW_FRAGMENT = gql`
             }
             autoSuggest
             rank
+            rangeStartLabel
+            rangeEndLabel
           }
           selected {
             kind
@@ -165,6 +167,8 @@ const SITE_VIEW_FRAGMENT = gql`
             }
             rank
             autoSuggest
+            rangeStartLabel
+            rangeEndLabel
           }
           selected {
             kind
@@ -207,6 +211,8 @@ const SITE_VIEW_FRAGMENT = gql`
           }
           autoSuggest
           rank
+          rangeStartLabel
+          rangeEndLabel
         }
         selected {
           kind
@@ -231,6 +237,8 @@ const SITE_VIEW_FRAGMENT = gql`
           }
           rank
           autoSuggest
+          rangeStartLabel
+          rangeEndLabel
         }
         selected {
           kind
@@ -324,7 +332,7 @@ class SiteProvider extends React.PureComponent<SiteProviderProps> {
           // console.log("ID",this.props.id)
           // console.log("url",this.props.url)
           // console.log(this.props)
-          // console.log(data)
+          console.log(data)
           if (error) console.log(`SiteProvider error: ${error}`);
           if (loading || error) return null;
           return this.props.children(data!.site!, refetch);

--- a/front/app/types/globalTypes.ts
+++ b/front/app/types/globalTypes.ts
@@ -15,8 +15,9 @@ export enum Diff {
 export enum FieldDisplay {
   DATE = "DATE",
   DATE_RANGE = "DATE_RANGE",
+  GREATER_THAN_RANGE = "GREATER_THAN_RANGE",
+  LESS_THAN_RANGE = "LESS_THAN_RANGE",
   NUMBER_RANGE = "NUMBER_RANGE",
-  RANGE = "RANGE",
   STAR = "STAR",
   STRING = "STRING",
 }


### PR DESCRIPTION
-Allows user to configure the start/end description for the number range.
-Allows ability to hide the Start or End to have a Greater Than or Less Than Option

Screenshots:

In this first image is my Facet bar configuration. specifically my crowdAggs:

***Note that instead of adding additional fields to each agg field I created two new display types _Greater than Range_ and _Less Than Range_ ***
![Screen Shot 2020-05-13 at 2 00 21 PM](https://user-images.githubusercontent.com/17464571/81854322-676fde00-9523-11ea-9f6a-0575d53eee22.png)

The following gif shows that configuration in action:
***Note the presearch is purposefully left as text displays to show they are independent of the facet bar config***

This final image shows the presearch display configured to match their title:
![Screen Shot 2020-05-13 at 2 18 42 PM](https://user-images.githubusercontent.com/17464571/81855384-e87ba500-9524-11ea-8996-0918f70eba17.png)

