### PR TITLE
Front end not passing agg options sort in the query

### DIFF
--- a/front/app/queries/SearchPageCrowdAggBucketsQuery.ts
+++ b/front/app/queries/SearchPageCrowdAggBucketsQuery.ts
@@ -9,6 +9,7 @@ export default gql`
     $page: Int!
     $pageSize: Int!
     $aggOptionsFilter: String
+    $aggOptionsSort: [SortInput!]
     $url: String
     $configType: String
     $returnAll: Boolean
@@ -24,6 +25,7 @@ export default gql`
         aggFilters: $aggFilters
         crowdAggFilters: $crowdAggFilters
         aggOptionsFilter: $aggOptionsFilter
+        aggOptionsSort: $aggOptionsSort
         page: $page
         pageSize: $pageSize
       }

--- a/front/app/types/SearchPageCrowdAggBucketsQuery.ts
+++ b/front/app/types/SearchPageCrowdAggBucketsQuery.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
-import { SearchQueryInput, AggFilterInput } from "./globalTypes";
+import { SearchQueryInput, AggFilterInput, SortInput } from "./globalTypes";
 
 // ====================================================
 // GraphQL query operation: SearchPageCrowdAggBucketsQuery
@@ -36,6 +36,7 @@ export interface SearchPageCrowdAggBucketsQueryVariables {
   page: number;
   pageSize: number;
   aggOptionsFilter?: string | null;
+  aggOptionsSort?: SortInput[] | null;
   url?: string | null;
   configType?: string | null;
   returnAll?: boolean | null;


### PR DESCRIPTION
I think this fixes not getting the :agg_options_sort in the backend, the query for it did not have the argument but the front end must have set a variable up but never passed it 