### PR TITLE
576 small fixes

### DIFF
--- a/front/app/components/SiteForm/SearchForm.tsx
+++ b/front/app/components/SiteForm/SearchForm.tsx
@@ -318,6 +318,7 @@ class SearchForm extends React.Component<SearchFormProps, SearchFormState> {
     let newItem = { icon: '', target: '', __typename: 'ResultButtonItems' };
     let newItems = [...items, newItem];
 
+    this.setState({resultsButtonsArray : newItems})
     this.handleAddMutation(
       { currentTarget: { name: name, value: newItems } },
       view

--- a/front/app/components/StyledComponents/index.ts
+++ b/front/app/components/StyledComponents/index.ts
@@ -88,7 +88,6 @@ const MainContainer = styled(Col)`
     color: #fff !important;
   }
 
-  span,
   h2 {
     padding-left: 15px;
   }
@@ -213,11 +212,10 @@ export const ScoreBoard = styled.div`
   }
 `;
 export const StyledProfileForm = styled(FormControl)`
-  background: rgba(255, 255, 255, 0.2);
   font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 1.25em;
   border: none;
-  padding: 0;
+  padding: 10px;
   margin: 0 1em 1em 1em;
   border-bottom: solid white;
   width: auto;

--- a/front/app/containers/ProfilePage/EditProfilePage.tsx
+++ b/front/app/containers/ProfilePage/EditProfilePage.tsx
@@ -128,13 +128,12 @@ class EditProfilePage extends React.Component<
     if (this.props.user) {
       return (
         <div>
-          //@ts-ignore
           <ProfilePicture pictureUrl={this.props.user.pictureUrl} />
-          <span
-            style={{ paddingLeft: '15px' }}
+          <a
+            style={{ paddingLeft: '15px', cursor: 'pointer' }}
             onClick={() => this.toggleEditProfile()}>
             X
-          </span>
+          </a>
           <SearchContainer>
             <StyledProfileLabel>First Name:</StyledProfileLabel>
             <StyledProfileForm
@@ -200,12 +199,12 @@ class EditProfilePage extends React.Component<
       return (
         <div>
           <ProfilePicture pictureUrl={pictureUrl} />
-          <span
-            style={{ paddingLeft: '15px' }}
+          <a
+            style={{ paddingLeft: '15px', cursor: 'pointer' }}
             onClick={() => this.toggleEditProfile()}>
             {' '}
             Edit Profile
-          </span>
+          </a>
 
           <SearchContainer>
             <StyledProfileLabel>First Name:</StyledProfileLabel>

--- a/front/app/containers/SearchPage/SearchView.tsx
+++ b/front/app/containers/SearchPage/SearchView.tsx
@@ -3,6 +3,7 @@ import { SearchParams, AggKind, SearchQuery } from './shared';
 import ReactTable from 'react-table';
 import ReactStars from 'react-stars';
 import SearchFieldName from 'components/SearchFieldName';
+import ThemedButton from 'components/StyledComponents'
 import styled from 'styled-components';
 import * as FontAwesome from 'react-fontawesome';
 import { PulseLoader, BeatLoader } from 'react-spinners';
@@ -737,11 +738,11 @@ class SearchView extends React.Component<SearchViewProps, SearchViewState> {
             return (
               <ButtonGroup>
                 {buttonsArray.map((button, index) => (
-                  <Button
+                  <ThemedButton
                     href={`/search?hash=${this.props.searchHash}&sv=${button.target}`}
                     key={button.target + index}>
                     {this.renderViewButton(button.icon)}
-                  </Button>
+                  </ThemedButton>
                 ))}
               </ButtonGroup>
             );


### PR DESCRIPTION
-Makes _Edit Profile_  and the _X_ a link to make it more clear to the user it's clickable
-Makes the input boxes white so it is more clear to the user it's clickable
-The Star rank was off center previously 
-Themed the buttons in results section
-Small bug fix: Previously when adding more than one button in results and trying to set the icon and target to the second it would default back to just one button. 

The following gif shows all the user profile edits:
![Screen Recording 2020-05-27 at 11 36 46 AM (1)](https://user-images.githubusercontent.com/17464571/83159291-6ca85d80-a0cb-11ea-9b0e-13f71b0e1414.gif)

The image shows the results button themed:
![Screen Shot 2020-05-27 at 12 36 10 PM](https://user-images.githubusercontent.com/17464571/83159451-9b263880-a0cb-11ea-9326-3d42a35b0e26.png)



