### PR TITLE
576 take two

### DIFF
--- a/front/src/components/AuthHeader/UserProfileHeaderButton.tsx
+++ b/front/src/components/AuthHeader/UserProfileHeaderButton.tsx
@@ -7,8 +7,6 @@ import SiteProvider from 'containers/SiteProvider';
 import withTheme from 'containers/ThemeProvider/ThemeProvider';
 import { UserFragment } from 'types/UserFragment';
 
-const UserButtonWrapper = styled.div``;
-
 const UserImage = styled.img`
   width: 25px;
   height: 25px;
@@ -287,7 +285,7 @@ class UserProfileHeaderButton extends React.PureComponent<
         <SiteProvider>
           {(site) => {
             return (
-              <UserButtonWrapper
+              <div
                 ref={(node: any) => {
                   this.dropDown = node;
                 }}>
@@ -353,7 +351,7 @@ class UserProfileHeaderButton extends React.PureComponent<
                     </ThemedDropDownItem>
                   </DropDownMenu>
                 )}
-              </UserButtonWrapper>
+              </div>
             );
           }}
         </SiteProvider>

--- a/front/src/containers/App/App.tsx
+++ b/front/src/containers/App/App.tsx
@@ -39,8 +39,6 @@ const AppWrapper = styled.div`
 
 const ThemedAppWrapper = withTheme(AppWrapper);
 
-const MainWrapper = styled.div``;
-
 class App extends React.PureComponent<AppProps> {
   render() {
     return (
@@ -49,7 +47,7 @@ class App extends React.PureComponent<AppProps> {
           {(user, refetch) =>
             <span>
               <AuthHeader user={user} history={this.props.history} />
-              <MainWrapper className="main" style={{ paddingTop: '50px' }}>
+              <div className="main" style={{ paddingTop: '50px' }}>
                 <Switch>
                   <Route
                     exact
@@ -84,7 +82,7 @@ class App extends React.PureComponent<AppProps> {
                   <Route path="/update_password" component={UpdatePassword} />
                   <Route component={NotFoundPage} />
                 </Switch>
-              </MainWrapper>
+              </div>
             </span>
           }
         </CurrentUser>

--- a/front/src/containers/BulkEditPage/BulkEditPage.tsx
+++ b/front/src/containers/BulkEditPage/BulkEditPage.tsx
@@ -150,8 +150,8 @@ const groupBucketsByLabel = ({ data, labels }) =>
     (accum, label) => ({
       ...accum,
       [label]: {
-        all: extractBucketKeys(data[`${el(label)}All`]),
-        selected: extractBucketKeys(data[`${el(label)}Selected`]),
+        all: extractBucketKeys(data?.[`${el(label)}All`]),
+        selected: extractBucketKeys(data?.[`${el(label)}Selected`]),
       },
     }),
     {}

--- a/front/src/containers/BulkEditPage/BulkEditPage.tsx
+++ b/front/src/containers/BulkEditPage/BulkEditPage.tsx
@@ -129,10 +129,6 @@ const bucketsForLabels = (labels: string[]) => {
   return query;
 };
 
-// const extractBucketKeys = pipe(
-//   pathOr([], ['aggs', 0, 'buckets']),
-//   map(prop('key'))
-// );
 interface GotAggs {
   aggs:
     | {
@@ -146,7 +142,7 @@ interface GotAggs {
     | undefined;
 }
 function extractBucketKeys(arg?: GotAggs) {
-  return arg?.aggs?.[0]?.buckets?.map(k => k.key);
+  return arg?.aggs?.[0]?.buckets?.map(k => k.key) || [];
 }
 
 const groupBucketsByLabel = ({ data, labels }) =>

--- a/front/src/containers/StudyPage/StudyPage.tsx
+++ b/front/src/containers/StudyPage/StudyPage.tsx
@@ -137,7 +137,6 @@ type Section = {
     | SiteStudyExtendedGenericSectionFragment;
 };
 
-const StudyWrapper = styled.div``;
 const ReviewsWrapper = styled.div`
   display: flex;
   justify-content: flex-end;
@@ -457,7 +456,7 @@ class StudyPage extends React.Component<StudyPageProps, StudyPageState> {
                   variables={{ nctId: this.props.match.params.nctId }}
                   fetchPolicy="cache-only">
                   {({ data }) => (
-                    <StudyWrapper>
+                    <div>
                       <Row
                         md={12}
                         style={{
@@ -578,7 +577,7 @@ class StudyPage extends React.Component<StudyPageProps, StudyPageState> {
                           {() => null}
                         </PrefetchQueryComponent>
                       )}
-                    </StudyWrapper>
+                    </div>
                   )}
                 </QueryComponent>
               );

--- a/front/src/containers/StudyPage/components/StudyPageCounter/StudyPageCounter.tsx
+++ b/front/src/containers/StudyPage/components/StudyPageCounter/StudyPageCounter.tsx
@@ -5,17 +5,12 @@ interface StudyPageCounterProps {
   counter: number;
   recordsTotal: number | Element;
 }
-// interface StudyPageCounterState {
-// }
-
-const StudyPageCounterWrapper = styled.div``;
 
 // A simple counter that displays which study you're on on the study page, in the middle of the prev and next buttons
 class StudyPageCounter extends React.PureComponent<StudyPageCounterProps> {
   render() {
     return (
-      // There is an error complaining about PropTypes, but none of the other components have this. Weird.
-      <StudyPageCounterWrapper>
+      <div>
         <div id="navbuttonsonstudypage">
           {this.props.counter === null ? null : 'record '}
           <b>
@@ -24,7 +19,7 @@ class StudyPageCounter extends React.PureComponent<StudyPageCounterProps> {
             {this.props.recordsTotal} &nbsp;
           </b>
         </div>
-      </StudyPageCounterWrapper>
+      </div>
     );
   }
 }


### PR DESCRIPTION
-Makes _Edit Profile_  and the _X_ a link to make it more clear to the user it's clickable
-Makes the input boxes white so it is more clear to the user it's clickable
-The Star rank was off center previously 
-Themed the buttons in results section
-Small bug fix: Previously when adding more than one button in results and trying to set the icon and target to the second it would default back to just one button. 

The following gif shows all the user profile edits:
![Screen Recording 2020-05-27 at 11 36 46 AM (1)](https://user-images.githubusercontent.com/17464571/83159291-6ca85d80-a0cb-11ea-9b0e-13f71b0e1414.gif)

The image shows the results button themed:
![Screen Shot 2020-05-27 at 12 36 10 PM](https://user-images.githubusercontent.com/17464571/83159451-9b263880-a0cb-11ea-9326-3d42a35b0e26.png)



