### PR TITLE
603 double load

### DIFF
--- a/front/src/containers/AggDropDown/BarChart.tsx
+++ b/front/src/containers/AggDropDown/BarChart.tsx
@@ -37,7 +37,6 @@ class BarChartComponent extends React.Component<BarChartComponentProps, BarChart
     this.props.handleLoadMore();
   };
   componentDidUpdate = prevProps => {
-
     if (
       prevProps.buckets !== this.props.buckets &&
       this.props.buckets.length > 0

--- a/front/src/containers/SearchPage/SearchPage.tsx
+++ b/front/src/containers/SearchPage/SearchPage.tsx
@@ -723,6 +723,10 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     return response;
   };
   updateSearchParams = async (params) => {
+    this.setState({	
+      ...this.state,	
+      params: { ...(this.state?.params || {}), ...params },	
+    });
     const variables = { ...this.state.params, ...params };
     const { data } = await this.props.mutate({ variables });
     const searchQueryString = new URLSearchParams(

--- a/front/src/containers/SearchPage/SearchPage.tsx
+++ b/front/src/containers/SearchPage/SearchPage.tsx
@@ -209,7 +209,6 @@ const changeFilter = (add: boolean) => (
 const addFilter = changeFilter(true);
 const removeFilter = changeFilter(false);
 const addFilters = (aggName: string, keys: string[], isCrowd?: boolean) => {
-  console.log("In add Filter")
   return (params: SearchParams) => {
     keys.forEach((k) => {
       params = addFilter(aggName, k, isCrowd)(params);
@@ -230,7 +229,6 @@ const removeFilters = (aggName: string, keys: string[], isCrowd?: boolean) => {
 };
 
 const addSearchTerm = (term: string) => (params: SearchParams) => {
-  console.log("In ADD search term")
   // have to check for empty string because if you press return two times it ends up putting it in the terms
   if (!term.replace(/\s/g, '').length) {
     return params;
@@ -417,7 +415,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
   };
 
   handleResetFilters = (view: SiteViewFragment) => () => {
-    console.log("reset")
     this.setState(
       {
         params: this.getDefaultParams(view, this.props.email),
@@ -447,7 +444,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
   };
 
   handleUpdateParams = (updater: (params: SearchParams) => SearchParams) => {
-    console.log("In handle Update Params")
     const params = updater(this.state.params!);
     this.previousSearchData = [];
     if (!equals(params.q, this.state.params && this.state.params.q)) {
@@ -455,10 +451,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
       // Therefore we close it to refresh later on open
       this.setState({ openedAgg: null });
     }
-    this.setState({ params }
-      //CHECKED
-      , 
-      () => this.updateSearchParams(this.state.params));
+    this.setState({ params }, () => this.updateSearchParams(this.state.params));
   };
 
   isWorkflow = () => {
@@ -505,10 +498,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
       !equals(searchAggs, this.state.searchAggs) ||
       !equals(searchCrowdAggs, this.state.searchCrowdAggs)
     ) {
-      console.log("1")
-      this.setState({ searchAggs, searchCrowdAggs }, 
-        () =>
-    
+      this.setState({ searchAggs, searchCrowdAggs }, () =>
         this.updateSearchParams(this.state.params)
       );
     }
@@ -612,7 +602,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
         ...this.state.params,
         page: this.state.params!.page + 1,
       };
-      console.log("2")
       this.setState({ params }, () =>
         this.updateSearchParams(this.state.params)
       );
@@ -636,7 +625,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
         key: 'AND',
         children: [{ children: [], key: searchTerm.getAll('q').toString() }],
       };
-      console.log("3")
       this.setState(
         {
           params: {
@@ -700,7 +688,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
   }
 
   updateStateFromHash(searchParams, view) {
-    console.log("Updating state from hash")
     const params: SearchParams = this.searchParamsFromQuery(searchParams, view);
     let searchTerm = new URLSearchParams(this.props.location?.search || '');
 
@@ -709,7 +696,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
         key: 'AND',
         children: [{ children: [], key: searchTerm.getAll('q').toString() }],
       };
-      console.log("4")
       this.setState(
         {
           params: {
@@ -725,7 +711,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
         ...params,
       },
     });
-    console.log("UHHHH", this.state.params)
   }
   findFilter = (variable: string) => {
     let aggFilter = this.state.params?.aggFilters;
@@ -738,19 +723,8 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     return response;
   };
   updateSearchParams = async (params) => {
-    // console.trace()
-    //@ts-ignore
-    console.log("About to Update Search Params")
-    // this.setState({
-    //   ...this.state,
-    //   params: { ...(this.state?.params || {}), ...params },
-    // });
-    console.log("State", this.state.params)
-    console.log("PARAMS", params)
     const variables = { ...this.state.params, ...params };
-    console.log("VARIABLES", variables)
     const { data } = await this.props.mutate({ variables });
-    console.log("DATA",data)
     const searchQueryString = new URLSearchParams(
       this.props.history.location.search
     );
@@ -917,7 +891,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
           value={{
             searchParams: this.state.params,
             updateSearchParams: (params) => {
-              console.log("5")
               this.setState({ params: { ...this.state.params, ...params } });
             },
           }}>
@@ -960,7 +933,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     }
 
     const hash = this.getHashFromLocation();
-    console.log("6")
     return (
       <SearchParamsContext.Provider
         value={{

--- a/front/src/containers/SearchPage/SearchPage.tsx
+++ b/front/src/containers/SearchPage/SearchPage.tsx
@@ -209,6 +209,7 @@ const changeFilter = (add: boolean) => (
 const addFilter = changeFilter(true);
 const removeFilter = changeFilter(false);
 const addFilters = (aggName: string, keys: string[], isCrowd?: boolean) => {
+  console.log("In add Filter")
   return (params: SearchParams) => {
     keys.forEach((k) => {
       params = addFilter(aggName, k, isCrowd)(params);
@@ -229,6 +230,7 @@ const removeFilters = (aggName: string, keys: string[], isCrowd?: boolean) => {
 };
 
 const addSearchTerm = (term: string) => (params: SearchParams) => {
+  console.log("In ADD search term")
   // have to check for empty string because if you press return two times it ends up putting it in the terms
   if (!term.replace(/\s/g, '').length) {
     return params;
@@ -415,6 +417,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
   };
 
   handleResetFilters = (view: SiteViewFragment) => () => {
+    console.log("reset")
     this.setState(
       {
         params: this.getDefaultParams(view, this.props.email),
@@ -444,6 +447,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
   };
 
   handleUpdateParams = (updater: (params: SearchParams) => SearchParams) => {
+    console.log("In handle Update Params")
     const params = updater(this.state.params!);
     this.previousSearchData = [];
     if (!equals(params.q, this.state.params && this.state.params.q)) {
@@ -451,7 +455,10 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
       // Therefore we close it to refresh later on open
       this.setState({ openedAgg: null });
     }
-    this.setState({ params }, () => this.updateSearchParams(this.state.params));
+    this.setState({ params }
+      //CHECKED
+      , 
+      () => this.updateSearchParams(this.state.params));
   };
 
   isWorkflow = () => {
@@ -498,7 +505,10 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
       !equals(searchAggs, this.state.searchAggs) ||
       !equals(searchCrowdAggs, this.state.searchCrowdAggs)
     ) {
-      this.setState({ searchAggs, searchCrowdAggs }, () =>
+      console.log("1")
+      this.setState({ searchAggs, searchCrowdAggs }, 
+        () =>
+    
         this.updateSearchParams(this.state.params)
       );
     }
@@ -602,6 +612,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
         ...this.state.params,
         page: this.state.params!.page + 1,
       };
+      console.log("2")
       this.setState({ params }, () =>
         this.updateSearchParams(this.state.params)
       );
@@ -625,6 +636,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
         key: 'AND',
         children: [{ children: [], key: searchTerm.getAll('q').toString() }],
       };
+      console.log("3")
       this.setState(
         {
           params: {
@@ -688,6 +700,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
   }
 
   updateStateFromHash(searchParams, view) {
+    console.log("Updating state from hash")
     const params: SearchParams = this.searchParamsFromQuery(searchParams, view);
     let searchTerm = new URLSearchParams(this.props.location?.search || '');
 
@@ -696,6 +709,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
         key: 'AND',
         children: [{ children: [], key: searchTerm.getAll('q').toString() }],
       };
+      console.log("4")
       this.setState(
         {
           params: {
@@ -711,6 +725,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
         ...params,
       },
     });
+    console.log("UHHHH", this.state.params)
   }
   findFilter = (variable: string) => {
     let aggFilter = this.state.params?.aggFilters;
@@ -723,12 +738,19 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     return response;
   };
   updateSearchParams = async (params) => {
-    this.setState({
-      ...this.state,
-      params: { ...(this.state?.params || {}), ...params },
-    });
+    // console.trace()
+    //@ts-ignore
+    console.log("About to Update Search Params")
+    // this.setState({
+    //   ...this.state,
+    //   params: { ...(this.state?.params || {}), ...params },
+    // });
+    console.log("State", this.state.params)
+    console.log("PARAMS", params)
     const variables = { ...this.state.params, ...params };
+    console.log("VARIABLES", variables)
     const { data } = await this.props.mutate({ variables });
+    console.log("DATA",data)
     const searchQueryString = new URLSearchParams(
       this.props.history.location.search
     );
@@ -895,6 +917,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
           value={{
             searchParams: this.state.params,
             updateSearchParams: (params) => {
+              console.log("5")
               this.setState({ params: { ...this.state.params, ...params } });
             },
           }}>
@@ -937,7 +960,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     }
 
     const hash = this.getHashFromLocation();
-
+    console.log("6")
     return (
       <SearchParamsContext.Provider
         value={{

--- a/front/src/containers/SearchPage/components/AggFilterInputUpdater.tsx
+++ b/front/src/containers/SearchPage/components/AggFilterInputUpdater.tsx
@@ -191,17 +191,29 @@ class AggFilterInputUpdater extends AbstractAggFilterInputUpdater {
       (x: AggFilterInput) => x.field !== this.agg,
       this.settings[this.grouping]
     );
+    console.log("Hit me")
     if (this.hasNoFilters()) {
+      console.log("1")
       this.updateSettings({
         [this.grouping as string]: allButThisAgg,
       });
     } else if (this.input?.includeMissingFields == false && this.input.values?.length == 0) {
+      console.log("2")
       this.updateSettings({
         [this.grouping as string]: allButThisAgg,
       });
     } else {
+      console.log("3", this.input, this.agg)
+      console.log("Grouping",this.grouping)
+      let newInput = {
+        field: this.input?.field,
+        values: this.input?.values,
+        gte: null,
+        lte: null,
+        includeMissingFields:null
+      }      
       this.updateSettings({
-        [this.grouping]: [...allButThisAgg, this.input],
+        [this.grouping]: [...allButThisAgg, newInput],
       });
     }
   }

--- a/front/src/containers/SearchPage/components/AggFilterInputUpdater.tsx
+++ b/front/src/containers/SearchPage/components/AggFilterInputUpdater.tsx
@@ -208,9 +208,9 @@ class AggFilterInputUpdater extends AbstractAggFilterInputUpdater {
       let newInput = {
         field: this.input?.field,
         values: this.input?.values,
-        gte: null,
-        lte: null,
-        includeMissingFields:null
+        gte: this.input?.gte || null,
+        lte: this.input?.lte || null,
+        includeMissingFields: this.input?.includeMissingFields || null
       }      
       this.updateSettings({
         [this.grouping]: [...allButThisAgg, newInput],

--- a/front/src/containers/SearchPage/components/AggFilterInputUpdater.tsx
+++ b/front/src/containers/SearchPage/components/AggFilterInputUpdater.tsx
@@ -191,20 +191,15 @@ class AggFilterInputUpdater extends AbstractAggFilterInputUpdater {
       (x: AggFilterInput) => x.field !== this.agg,
       this.settings[this.grouping]
     );
-    console.log("Hit me")
     if (this.hasNoFilters()) {
-      console.log("1")
       this.updateSettings({
         [this.grouping as string]: allButThisAgg,
       });
     } else if (this.input?.includeMissingFields == false && this.input.values?.length == 0) {
-      console.log("2")
       this.updateSettings({
         [this.grouping as string]: allButThisAgg,
       });
     } else {
-      console.log("3", this.input, this.agg)
-      console.log("Grouping",this.grouping)
       let newInput = {
         field: this.input?.field,
         values: this.input?.values,


### PR DESCRIPTION
Previously when you added a series of aggFilters you hadn't visited before results appeared to load twice.

This PR fixes that issue by checking the input for the fields previously missing (gte, lte, and includeMissingFields) are defined. If not it sets them to null, this get's rid of the mismatch when building state from hash getting rid of the double load.


