### PR TITLE
allows a reaction click to either create or delete reaction

### DIFF
--- a/front/src/containers/StudyPage/components/StudyPageHeader.tsx
+++ b/front/src/containers/StudyPage/components/StudyPageHeader.tsx
@@ -10,8 +10,7 @@ import GithubSelector from '../../../components/GithubSelector/GithubSelector'
 import { StudyPageQuery, StudyPageQueryVariables } from 'types/StudyPageQuery';
 import CreateReactionMutation, {
 } from 'mutations/CreateReactionMutation';
-import DeleteReactionMutation, {
-} from 'mutations/DeleteReactionMutation';
+
 import { find, propEq, findLastIndex } from 'ramda';
 import StudyReactions from './StudyReaction'
 import { reactionIdFromCharacter, activeReactions, isReactionUnique } from '../../../utils/reactions/reactionKinds'
@@ -184,30 +183,7 @@ class StudyPageHeader extends React.Component<StudyPageHeaderProps, StudyPageHea
             </ReviewsWrapper>
         );
     };
-    handleEmojiSelect = (e, deleteReaction, reactions, refetch) => {
 
-        // console.log(e, this.props)
-        let reactionId = isReactionUnique(e, reactions)
-        if (reactionId !== undefined) {
-
-            deleteReaction({
-                variables: {
-                    //Need to define object type fields in isReactionUnique finction inside reactionKinds.ts
-                    //@ts-ignore
-                    id: reactionId.id
-                }
-            })
-            this.props.studyRefetch();
-            refetch();
-
-
-        } else {
-            console.log("Whoops, looks like something went wrong!")
-        }
-
-
-
-    }
     handleAddReaction = (e) => {
         this.setState({ showReactions: !this.state.showReactions })
 
@@ -270,19 +246,15 @@ class StudyPageHeader extends React.Component<StudyPageHeaderProps, StudyPageHea
                         <ReactionsContainer>
                             <LikesRow>
                                 <ThumbsRow>
-                                    <DeleteReactionMutation>
-                                        {deleteReaction => (
                                             <SlackCounter
                                                 currentUserAndStudy={reactions?.reactions}
                                                 reactions={this.state.counters}
                                                 user={this.props.user}
-                                                onSelect={(e) => this.handleEmojiSelect(e, deleteReaction, reactions?.reactions, refetch)}
                                                 onAdd={this.handleAddReaction}
                                                 nctId={this.props.nctId}
+                                                studyRefetch={this.props.studyRefetch}
+                                                refetch={refetch}
                                             />
-                                        )}
-                                    </DeleteReactionMutation>
-
                                     {this.state.showReactions == true ?
                                         <div className="selector" onClick={() => this.setState({ showReactions: false })}>
                                             <CreateReactionMutation>


### PR DESCRIPTION
Previously user couldn't click to increment a reaction if they hadn't reacted to that study with that reaction, but rather had to use the add reaction button

Currently if study is liked by other users only, not current user, clicking the like icon should add a like for the current user

![Screen Recording 2020-06-25 at 11 15 48 AM](https://user-images.githubusercontent.com/17464571/85758257-c5bcde80-b6d5-11ea-97ef-9568168f3f23.gif)
