### PR TITLE
Reaction site config

### DIFF
--- a/app/graphql/mutations/create_site.rb
+++ b/app/graphql/mutations/create_site.rb
@@ -7,6 +7,7 @@ module Mutations
     argument :subdomain, String, required: true
     argument :skip_landing, Boolean, required: false
     argument :themes, String, required: false
+    argument :reactions_config, String, required: false
     argument :user_rank, String, required: false
     argument :editor_emails, [String], required: false
 

--- a/app/graphql/mutations/update_site.rb
+++ b/app/graphql/mutations/update_site.rb
@@ -6,6 +6,7 @@ module Mutations
     argument :id, Int, required: true
     argument :name, String, required: false
     argument :themes, String, required: false
+    argument :reactions_config, String, required: false
     argument :user_rank, String, required: false
     argument :skip_landing, Boolean, required: false
     argument :subdomain, String, required: false

--- a/app/graphql/types/site_type.rb
+++ b/app/graphql/types/site_type.rb
@@ -8,6 +8,7 @@ module Types
     field :editors, [UserType], null: false
     field :site_views, [SiteViewType], null: false
     field :themes, String, null: false
+    field :reactions_config, String, null: false
     field :site_view, SiteViewType, null: false do
       argument :url, type: String, required: false
     end

--- a/db/migrate/20200626152506_reaction_config.rb
+++ b/db/migrate/20200626152506_reaction_config.rb
@@ -1,0 +1,5 @@
+class ReactionConfig < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sites, :reactions_config, :text, default: ReactionKind.all.select(:name).as_json(except: :id).to_json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,23 +30,16 @@ ActiveRecord::Schema.define(version: 2020_06_26_152506) do
     t.integer "user_id"
   end
 
-  create_table "facility_locations", primary_key: ["name", "city", "state", "zip", "country"], force: :cascade do |t|
-    t.string "name", null: false
-    t.string "city", null: false
-    t.string "state", null: false
-    t.string "zip", null: false
-    t.string "country", null: false
+  create_table "facility_locations", force: :cascade do |t|
+    t.string "name"
+    t.string "city"
+    t.string "state"
+    t.string "zip"
+    t.string "country"
     t.float "latitude"
     t.float "longitude"
     t.string "status"
-  end
-
-  create_table "lists", force: :cascade do |t|
-    t.bigint "user_id"
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_lists_on_user_id"
+    t.index ["name", "city", "state", "zip", "country"], name: "facility_locations_idx", unique: true
   end
 
   create_table "locations", force: :cascade do |t|
@@ -64,7 +57,6 @@ ActiveRecord::Schema.define(version: 2020_06_26_152506) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "unicode"
   end
 
   create_table "reactions", force: :cascade do |t|
@@ -174,7 +166,6 @@ ActiveRecord::Schema.define(version: 2020_06_26_152506) do
     t.string "last_name"
     t.string "default_query_string"
     t.json "search_result_columns"
-    t.string "provider"
     t.string "picture_url"
     t.string "reset_token_url"
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_11_142633) do
+ActiveRecord::Schema.define(version: 2020_06_26_152506) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,16 +30,23 @@ ActiveRecord::Schema.define(version: 2020_06_11_142633) do
     t.integer "user_id"
   end
 
-  create_table "facility_locations", force: :cascade do |t|
-    t.string "name"
-    t.string "city"
-    t.string "state"
-    t.string "zip"
-    t.string "country"
+  create_table "facility_locations", primary_key: ["name", "city", "state", "zip", "country"], force: :cascade do |t|
+    t.string "name", null: false
+    t.string "city", null: false
+    t.string "state", null: false
+    t.string "zip", null: false
+    t.string "country", null: false
     t.float "latitude"
     t.float "longitude"
     t.string "status"
-    t.index ["name", "city", "state", "zip", "country"], name: "facility_locations_idx", unique: true
+  end
+
+  create_table "lists", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_lists_on_user_id"
   end
 
   create_table "locations", force: :cascade do |t|
@@ -57,6 +64,7 @@ ActiveRecord::Schema.define(version: 2020_06_11_142633) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "unicode"
   end
 
   create_table "reactions", force: :cascade do |t|
@@ -129,6 +137,7 @@ ActiveRecord::Schema.define(version: 2020_06_11_142633) do
     t.boolean "skip_landing"
     t.text "themes", default: "{\"primaryColor\":\"#6BA5D6\",\"secondaryColor\":\"#1b2a38\",\"lightTextColor\":\"#eee\",\"secondaryTextColor\":\"#333\",\"backgroundColor\":\"#4D5863\",\"primaryAltColor\":\"#5786AD\",\"authHeaderColor\":\"#5786AD\",\"sideBarColor\":\"#4d5762\"} "
     t.text "user_rank", default: "[{\"rank\":\"default\",\"gte\":0},{\"rank\":\"bronze\",\"gte\":26},{\"rank\":\"silver\",\"gte\":51},{\"rank\":\"gold\",\"gte\":75},{\"rank\":\"platinum\",\"gte\":101}] "
+    t.text "reactions_config", default: "[{\"name\":\"like\"},{\"name\":\"dislike\"},{\"name\":\"heart\"},{\"name\":\"skull_and_cross_bones\"}]"
     t.index ["subdomain"], name: "index_sites_on_subdomain", unique: true
   end
 
@@ -165,6 +174,7 @@ ActiveRecord::Schema.define(version: 2020_06_11_142633) do
     t.string "last_name"
     t.string "default_query_string"
     t.json "search_result_columns"
+    t.string "provider"
     t.string "picture_url"
     t.string "reset_token_url"
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/front/src/components/SiteForm/MainForm.tsx
+++ b/front/src/components/SiteForm/MainForm.tsx
@@ -90,7 +90,7 @@ class MainForm extends React.Component<MainFormProps, MainFormState> {
 
   handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.currentTarget;
-    if (name === 'themes' || name === 'userRank') {
+    if (name === 'themes' || name === 'userRank' || name === 'reactionsConfig') {
       try {
         let parseResponse = JSON.parse(value);
         if (parseResponse && parseResponse.error)
@@ -211,6 +211,16 @@ class MainForm extends React.Component<MainFormProps, MainFormState> {
               placeholder={this.props.form.userRank}
               //@ts-ignore
               value={this.props.form.userRank}
+              onChange={this.handleInputChange}
+            />
+            <h3>Reaction Configuration</h3>
+            <StyledFormInput
+              componentClass="textarea"
+              name="reactionsConfig"
+              //@ts-ignore
+              placeholder={this.props.form.reactionsConfig}
+              //@ts-ignore
+              value={this.props.form.reactionsConfig}
               onChange={this.handleInputChange}
             />
           </Col>

--- a/front/src/components/SiteForm/MainForm.tsx
+++ b/front/src/components/SiteForm/MainForm.tsx
@@ -217,9 +217,7 @@ class MainForm extends React.Component<MainFormProps, MainFormState> {
             <StyledFormInput
               componentClass="textarea"
               name="reactionsConfig"
-              //@ts-ignore
               placeholder={this.props.form.reactionsConfig}
-              //@ts-ignore
               value={this.props.form.reactionsConfig}
               onChange={this.handleInputChange}
             />

--- a/front/src/components/SiteForm/SiteForm.tsx
+++ b/front/src/components/SiteForm/SiteForm.tsx
@@ -72,6 +72,7 @@ class SiteForm extends React.Component<SiteFormProps, SiteFormState> {
       subdomain
       skipLanding
       userRank
+      reactionsConfig
       editors {
         email
       }
@@ -89,6 +90,7 @@ class SiteForm extends React.Component<SiteFormProps, SiteFormState> {
       editors,
       themes,
       userRank,
+      reactionsConfig
     } = props.site;
     const editorEmails = editors.map(prop('email')) as string[];
     const form = {
@@ -98,6 +100,7 @@ class SiteForm extends React.Component<SiteFormProps, SiteFormState> {
       editorEmails,
       themes,
       userRank,
+      reactionsConfig
     };
     if (form && !equals(form, state.prevForm as any)) {
       return { ...state, form, prevForm: form };

--- a/front/src/containers/SiteProvider/SiteProvider.tsx
+++ b/front/src/containers/SiteProvider/SiteProvider.tsx
@@ -266,6 +266,7 @@ const SITE_FRAGMENT = gql`
     skipLanding
     subdomain
     themes
+    reactionsConfig
     userRank
     owners {
       email

--- a/front/src/containers/StudyPage/StudyPage.tsx
+++ b/front/src/containers/StudyPage/StudyPage.tsx
@@ -415,6 +415,7 @@ class StudyPage extends React.Component<StudyPageProps, StudyPageState> {
                           user={this.props.user}
                           data={data?.study}
                           theme={this.props.theme}
+                          site={site}
                           nctId={this.props.match.params.nctId}
                           studyRefetch={refetch}
                           userRefetch={this.props.userRefetch}

--- a/front/src/containers/StudyPage/components/StudyPageHeader.tsx
+++ b/front/src/containers/StudyPage/components/StudyPageHeader.tsx
@@ -13,7 +13,7 @@ import CreateReactionMutation, {
 
 import { find, propEq, findLastIndex } from 'ramda';
 import StudyReactions from './StudyReaction'
-import { reactionIdFromCharacter, activeReactions, isReactionUnique } from '../../../utils/reactions/reactionKinds'
+import { reactionIdFromCharacter, activeReactions, isReactionUnique, reactionCharacterFromName } from '../../../utils/reactions/reactionKinds'
 interface StudyPageHeaderProps {
 
     navButtonClick: any;
@@ -24,6 +24,7 @@ interface StudyPageHeaderProps {
     nctId: any;
     studyRefetch: any;
     userRefetch: any;
+    site?: any;
 }
 interface StudyPageHeaderState {
     likesArray: any[];
@@ -135,15 +136,22 @@ class StudyPageHeader extends React.Component<StudyPageHeaderProps, StudyPageHea
     };
 
     componentDidMount = () => {
-        let reactions = activeReactions
+        let reactions = activeReactions(this.props.site.reactionsConfig)
 
         this.setState({ reactions: reactions })
     }
     componentDidUpdate = (prevProps) => {
         // console.log("DATA", this.props.data)
         if (this.props.data && prevProps !== this.props) {
-
-            this.setState({ counters: this.props.data.reactionsCount })
+            let activeCount: any[] = []
+            this.props.data.reactionsCount.map((reaction) => {
+                let configArray = JSON.parse(this.props.site.reactionsConfig)
+                let isActive = find(propEq('name', reaction.name))(configArray)
+                if (isActive) {
+                    activeCount.push(reaction)
+                }
+            })
+            this.setState({ counters: activeCount })
 
 
         }
@@ -211,9 +219,9 @@ class StudyPageHeader extends React.Component<StudyPageHeaderProps, StudyPageHea
 
             }
         })
-        .then(()=>this.props.studyRefetch())
-        .then(()=>refetch())
-        
+            .then(() => this.props.studyRefetch())
+            .then(() => refetch())
+
 
     }
     render() {
@@ -246,15 +254,15 @@ class StudyPageHeader extends React.Component<StudyPageHeaderProps, StudyPageHea
                         <ReactionsContainer>
                             <LikesRow>
                                 <ThumbsRow>
-                                            <SlackCounter
-                                                currentUserAndStudy={reactions?.reactions}
-                                                reactions={this.state.counters}
-                                                user={this.props.user}
-                                                onAdd={this.handleAddReaction}
-                                                nctId={this.props.nctId}
-                                                studyRefetch={this.props.studyRefetch}
-                                                refetch={refetch}
-                                            />
+                                    <SlackCounter
+                                        currentUserAndStudy={reactions?.reactions}
+                                        reactions={this.state.counters}
+                                        user={this.props.user}
+                                        onAdd={this.handleAddReaction}
+                                        nctId={this.props.nctId}
+                                        studyRefetch={this.props.studyRefetch}
+                                        refetch={refetch}
+                                    />
                                     {this.state.showReactions == true ?
                                         <div className="selector" onClick={() => this.setState({ showReactions: false })}>
                                             <CreateReactionMutation>

--- a/front/src/types/CreateSiteMutation.ts
+++ b/front/src/types/CreateSiteMutation.ts
@@ -761,6 +761,7 @@ export interface CreateSiteMutation_createSite_site {
   skipLanding: boolean | null;
   subdomain: string;
   themes: string;
+  reactionsConfig: string;
   userRank: string;
   owners: CreateSiteMutation_createSite_site_owners[];
   siteView: CreateSiteMutation_createSite_site_siteView;

--- a/front/src/types/SiteFragment.ts
+++ b/front/src/types/SiteFragment.ts
@@ -761,6 +761,7 @@ export interface SiteFragment {
   skipLanding: boolean | null;
   subdomain: string;
   themes: string;
+  reactionsConfig: string;
   userRank: string;
   owners: SiteFragment_owners[];
   siteView: SiteFragment_siteView;

--- a/front/src/types/SiteProviderQuery.ts
+++ b/front/src/types/SiteProviderQuery.ts
@@ -761,6 +761,7 @@ export interface SiteProviderQuery_site {
   skipLanding: boolean | null;
   subdomain: string;
   themes: string;
+  reactionsConfig: string;
   userRank: string;
   owners: SiteProviderQuery_site_owners[];
   siteView: SiteProviderQuery_site_siteView;

--- a/front/src/types/UpdateSiteMutation.ts
+++ b/front/src/types/UpdateSiteMutation.ts
@@ -761,6 +761,7 @@ export interface UpdateSiteMutation_updateSite_site {
   skipLanding: boolean | null;
   subdomain: string;
   themes: string;
+  reactionsConfig: string;
   userRank: string;
   owners: UpdateSiteMutation_updateSite_site_owners[];
   siteView: UpdateSiteMutation_updateSite_site_siteView;

--- a/front/src/types/globalTypes.ts
+++ b/front/src/types/globalTypes.ts
@@ -95,6 +95,7 @@ export interface CreateSiteInput {
   subdomain: string;
   skipLanding?: boolean | null;
   themes?: string | null;
+  reactionsConfig?: string | null;
   userRank?: string | null;
   editorEmails?: string[] | null;
   clientMutationId?: string | null;
@@ -242,6 +243,7 @@ export interface UpdateSiteInput {
   id: number;
   name?: string | null;
   themes?: string | null;
+  reactionsConfig?: string | null;
   userRank?: string | null;
   skipLanding?: boolean | null;
   subdomain?: string | null;

--- a/front/src/utils/reactions/reactionKinds.ts
+++ b/front/src/utils/reactions/reactionKinds.ts
@@ -29,19 +29,14 @@ export const reactionIdFromCharacter = (val: string |undefined): number | undefi
             return undefined;
     }
 };
-// export const activeReactions: string[]=['👍', '👎', '❤️', '☠️']
 export const activeReactions =(reactionsConfig)=>{
-    console.log("In active reactions",reactionsConfig)
     let obj = JSON.parse(reactionsConfig)
-    console.log("OBJ",obj)
     let activeArray: any[]=[]
     obj.map((reaction)=>{
        activeArray.push( reactionCharacterFromName(reaction.name))
     })
-    console.log("Active",activeArray)
     return activeArray
 }
-//: string[]=['👍', '👎', '❤️', '☠️']
 
 export const isReactionUnique = (val: string |undefined, valArray: any[]): object | undefined=>{
     let reactionId = reactionIdFromCharacter(val)

--- a/front/src/utils/reactions/reactionKinds.ts
+++ b/front/src/utils/reactions/reactionKinds.ts
@@ -29,7 +29,19 @@ export const reactionIdFromCharacter = (val: string |undefined): number | undefi
             return undefined;
     }
 };
-export const activeReactions: string[]=['👍', '👎', '❤️', '☠️']
+// export const activeReactions: string[]=['👍', '👎', '❤️', '☠️']
+export const activeReactions =(reactionsConfig)=>{
+    console.log("In active reactions",reactionsConfig)
+    let obj = JSON.parse(reactionsConfig)
+    console.log("OBJ",obj)
+    let activeArray: any[]=[]
+    obj.map((reaction)=>{
+       activeArray.push( reactionCharacterFromName(reaction.name))
+    })
+    console.log("Active",activeArray)
+    return activeArray
+}
+//: string[]=['👍', '👎', '❤️', '☠️']
 
 export const isReactionUnique = (val: string |undefined, valArray: any[]): object | undefined=>{
     let reactionId = reactionIdFromCharacter(val)


### PR DESCRIPTION
Allows for configuration of what reactions to display.

reactionsConfig at the site level holds a json string with an array of objects of the reactions we want to display. 

By default will display all (depicted by screenshot below)
![Screen Shot 2020-06-26 at 4 59 51 PM](https://user-images.githubusercontent.com/17464571/85904596-cb4a1f80-b7ce-11ea-9e97-30fff3fe91ca.png)

This screenshot displays how I configured my site after
![Screen Shot 2020-06-26 at 4 52 13 PM](https://user-images.githubusercontent.com/17464571/85904628-df8e1c80-b7ce-11ea-8458-f3b76da9c603.png)

Followed by the output

![Screen Shot 2020-06-26 at 4 45 41 PM](https://user-images.githubusercontent.com/17464571/85904656-ec127500-b7ce-11ea-87ad-15b23ffd94cf.png)


