### PR TITLE
drop skull reaction from default seed

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -129,7 +129,7 @@ ActiveRecord::Schema.define(version: 2020_06_26_152506) do
     t.boolean "skip_landing"
     t.text "themes", default: "{\"primaryColor\":\"#6BA5D6\",\"secondaryColor\":\"#1b2a38\",\"lightTextColor\":\"#eee\",\"secondaryTextColor\":\"#333\",\"backgroundColor\":\"#4D5863\",\"primaryAltColor\":\"#5786AD\",\"authHeaderColor\":\"#5786AD\",\"sideBarColor\":\"#4d5762\"} "
     t.text "user_rank", default: "[{\"rank\":\"default\",\"gte\":0},{\"rank\":\"bronze\",\"gte\":26},{\"rank\":\"silver\",\"gte\":51},{\"rank\":\"gold\",\"gte\":75},{\"rank\":\"platinum\",\"gte\":101}] "
-    t.text "reactions_config", default: "[{\"name\":\"like\"},{\"name\":\"dislike\"},{\"name\":\"heart\"},{\"name\":\"skull_and_cross_bones\"}]"
+    t.text "reactions_config", default: "[{\"name\":\"like\"},{\"name\":\"dislike\"},{\"name\":\"heart\"}]"
     t.index ["subdomain"], name: "index_sites_on_subdomain", unique: true
   end
 


### PR DESCRIPTION
sites reaction_config changed to drop skull

@Tonyynot14 making sure that dropping the skull from the seed file won't break anything. Would prefer that be the default.