### PR TITLE
627 crowd label

### DIFF
--- a/front/src/components/FacetCard/FacetCard.tsx
+++ b/front/src/components/FacetCard/FacetCard.tsx
@@ -166,7 +166,12 @@ class FacetCard extends React.PureComponent<FacetCardProps, FacetCardState> {
     meta: {},
     upsertLabelMutation: UpsertMutationFn
   ) => {
+    console.log("In submit existing")
+    // console.trace()
     if (this.props.nctId) {
+      console.log("key: ", key)
+      console.log("value",  value)
+      console.log("meta",meta)
       CrowdPage.addLabel(
         key,
         value,
@@ -174,7 +179,8 @@ class FacetCard extends React.PureComponent<FacetCardProps, FacetCardState> {
         this.props.nctId,
         upsertLabelMutation
       );
-      if (this.props.refetch) this.props.refetch();
+      console.log("About to refetch")
+      if (this.props.refetch) (this.props.refetch());
     }
   };
 
@@ -211,10 +217,11 @@ class FacetCard extends React.PureComponent<FacetCardProps, FacetCardState> {
     );
   };
 
-  onSuggestionSelected = (
+  onSuggestionSelected = (e, 
     { suggestionValue },
     upsertLabelMutation
   ) => {
+    // console.log("Onsuggestion selected",e,  suggestionValue)
     this.setState({
       textFieldActive: false,
       existingField: '',
@@ -359,12 +366,12 @@ class FacetCard extends React.PureComponent<FacetCardProps, FacetCardState> {
                                 apolloClient
                               ),
                           }}
-                          onSuggestionSelected={(
+                          onSuggestionSelected={(e,
                             {
                               suggestionValue,
-                            }
+                            },
                           ) =>
-                            this.onSuggestionSelected(
+                            this.onSuggestionSelected(e,
                               {
                                 suggestionValue,
                               },

--- a/front/src/components/FacetCard/FacetCard.tsx
+++ b/front/src/components/FacetCard/FacetCard.tsx
@@ -166,12 +166,7 @@ class FacetCard extends React.PureComponent<FacetCardProps, FacetCardState> {
     meta: {},
     upsertLabelMutation: UpsertMutationFn
   ) => {
-    console.log("In submit existing")
-    // console.trace()
     if (this.props.nctId) {
-      console.log("key: ", key)
-      console.log("value",  value)
-      console.log("meta",meta)
       CrowdPage.addLabel(
         key,
         value,
@@ -179,7 +174,6 @@ class FacetCard extends React.PureComponent<FacetCardProps, FacetCardState> {
         this.props.nctId,
         upsertLabelMutation
       );
-      console.log("About to refetch")
       if (this.props.refetch) (this.props.refetch());
     }
   };
@@ -221,7 +215,6 @@ class FacetCard extends React.PureComponent<FacetCardProps, FacetCardState> {
     { suggestionValue },
     upsertLabelMutation
   ) => {
-    // console.log("Onsuggestion selected",e,  suggestionValue)
     this.setState({
       textFieldActive: false,
       existingField: '',

--- a/front/src/containers/CrowdPage/AddCrowdLabel.tsx
+++ b/front/src/containers/CrowdPage/AddCrowdLabel.tsx
@@ -54,7 +54,6 @@ class AddCrowdLabel extends React.Component<
         prevForceAddLabel: props.forceAddLabel,
       };
     }
-
     return { ...state, prevForceAddLabel: props.forceAddLabel };
   };
 

--- a/front/src/containers/CrowdPage/CrowdPage.tsx
+++ b/front/src/containers/CrowdPage/CrowdPage.tsx
@@ -210,11 +210,9 @@ class Crowd extends React.Component<CrowdProps, CrowdState> {
     nctId: string,
     upsertLabelMutation: UpsertMutationFn
   ) => {
-    // console.log("IN add label", key, value, meta, nctId)
     if (!value) return;
     let val = value;
     if (meta[key]) {
-      // console.log(meta[key]);
       const oldVal = meta[key];
       const entries = oldVal.split('|').filter((x) => x !== val);
       entries.push(value);
@@ -358,7 +356,7 @@ class Crowd extends React.Component<CrowdProps, CrowdState> {
           <CurrentUser>
             {(user) =>
               user &&
-              !this.props.workflowView && (
+              // !this.props.workflowView && (
                 <AddCrowdLabel
                   onAddLabel={(key, value) =>
                     this.handleAddLabel(key, value, meta, upsertLabelMutation)
@@ -366,7 +364,7 @@ class Crowd extends React.Component<CrowdProps, CrowdState> {
                   forceAddLabel={this.state.forceAddLabel}
                   showAnimation={this.props.showAnimation}
                 />
-              )
+              // )
             }
           </CurrentUser>
         </tbody>

--- a/front/src/containers/CrowdPage/CrowdPage.tsx
+++ b/front/src/containers/CrowdPage/CrowdPage.tsx
@@ -210,6 +210,7 @@ class Crowd extends React.Component<CrowdProps, CrowdState> {
     nctId: string,
     upsertLabelMutation: UpsertMutationFn
   ) => {
+    // console.log("IN add label", key, value, meta, nctId)
     if (!value) return;
     let val = value;
     if (meta[key]) {


### PR DESCRIPTION
In workflow sections previously the add label functionality was not working

       -When adding a label from the "+" in the cards nothing would be added. This has been fixed and the value is now added.
         However you dont see the value until you reload. 
       - The add button in the All Crowd Labels section was also not working, there was a conditional block surrounding where 
         the input box renders preventing it from rendering on a workFlow. Was this intentional? Should the circled input field (image below)  not 
         be accessible in the workflow section?
![Screen Shot 2020-07-06 at 2 15 04 PM](https://user-images.githubusercontent.com/17464571/86631280-86bf4080-bf93-11ea-9842-0d90a2fbf4c7.png)

Video of working add label from Cards:

https://slack-files.com/THRL5NEB0-F016YM6KE0G-86978f2a00

Post refresh of above video:

https://slack-files.com/THRL5NEB0-F01624GP51U-fda98bcc29