### PR TITLE
changes masonry cards to a list view styled like masonry cards

### DIFF
--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -217,6 +217,11 @@ const SearchContainer = styled.div`
   margin-bottom: 1em;
   display: block;
   flex-direction: column;
+  .ReactVirtualized__Grid__innerScrollContainer{
+    display: flex;
+    flex-wrap: wrap
+  }
+
 `;
 
 interface SearchView2Props {
@@ -550,44 +555,19 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
   renderHelper = (data, loading, template, onPress, resultsType, recordsTotal) => {
     switch (resultsType) {
       case 'masonry':
-        return (
-          <AutoSizer>
-            {({ height, width }) => {
-              const columnCount = 3;
-              let columnWidth = (width * 0.85) / columnCount;
-              const defaultHeight = 350;
-              let defaultWidth = columnWidth;
-
-              // Default sizes help Masonry decide how many cells to batch-measure
-              const cache = new CellMeasurerCache({
-                defaultHeight,
-                defaultWidth,
-                fixedWidth: true,
-                fixedHeight: true,
-              });
-
-              // Our masonry layout will use 3 columns with a 10px gutter between
-              const cellPositioner = createMasonryCellPositioner({
-                cellMeasurerCache: cache,
-                columnCount,
-                columnWidth,
-                spacer: 25,
-              });
               return (
-                <MasonryCards
-                  data={data}
-                  loading={loading}
-                  template={template}
-                  defaultHeight={defaultHeight}
-                  defaultWidth={defaultWidth}
-                  containerWidth={width}
-                  cellPositioner={cellPositioner}
-                  cache={cache}
-                />
+                <AutoSizer>
+                {({ height, width }) => (
+                  <MasonryCards
+                    data={data}
+                    loading={loading}
+                    template={template}
+                    height={height}
+                    width={width}
+                  />
+                )}
+              </AutoSizer>
               );
-            }}
-          </AutoSizer>
-        );
       case 'list':
         return (
           <AutoSizer>

--- a/front/src/containers/SearchPage/components/MasonryCards.tsx
+++ b/front/src/containers/SearchPage/components/MasonryCards.tsx
@@ -1,28 +1,19 @@
-// import * as React from 'react';
-import React, { useEffect } from 'react';
+import * as React from 'react';
 import { Col } from 'react-bootstrap';
 import { PulseLoader } from 'react-spinners';
 import { SearchPageSearchQuery_search_studies } from 'types/SearchPageSearchQuery';
 import { MailMergeView } from 'components/MailMerge';
 import { SiteFragment_siteView } from 'types/SiteFragment';
-import {
-  CellMeasurer,
-  CellMeasurerCache,
-  createMasonryCellPositioner,
-  Masonry,
-} from 'react-virtualized';
+import { List } from 'react-virtualized';
 import withTheme, { Theme } from 'containers/ThemeProvider/ThemeProvider';
 
 interface MasonryCardsProps {
   data: SearchPageSearchQuery_search_studies[];
   loading: boolean;
   template: string;
-  defaultHeight: number;
-  defaultWidth: number;
-  containerWidth: number;
+  height: number;
+  width: number;
   theme: Theme;
-  cellPositioner: Function;
-  cache: object;
   // columns:any;
 }
 
@@ -30,16 +21,14 @@ interface MasonryCardsState {
   loading: boolean;
 }
 
-class MasonryCards extends React.Component<
-  MasonryCardsProps,
-  MasonryCardsState
-> {
+class MasonryCards extends React.Component<MasonryCardsProps, MasonryCardsState> {
   constructor(props: MasonryCardsProps) {
     super(props);
     this.state = { loading: this.props.loading };
   }
 
   componentDidUpdate() {
+    console.log(this.props.theme);
     if (this.state.loading !== this.props.loading) {
       this.setState({ loading: this.props.loading });
     }
@@ -54,59 +43,57 @@ class MasonryCards extends React.Component<
     cursor: 'pointer',
     height: '100%',
   };
+  someStyle: React.CSSProperties = {
+    display: "flex",
+    flexWrap: "wrap",
+  };
 
-  cache = new CellMeasurerCache({
-    defaultHeight: this.props.defaultHeight,
-    defaultWidth: this.props.defaultWidth,
-    fixedWidth: true,
-    fixedHeight: true,
-  });
-
-  cellRenderer = ({
-    index, // Index of item within the collection
-    isScrolling, // The Grid is currently being scrolled
-    key, // Unique key within array of cells
-    parent, // Reference to the parent Grid (instance)
-    style, // Style object to be applied to cell (to position it);
-    // This must be passed through to the rendered cell element.
+  rowRenderer = ({
+    key, // Unique key within array of rows
+    index, // Index of row within collection
+    isScrolling, // The List is currently being scrolled
+    isVisible, // This row is visible within the List (eg it is not an overscanned row)
+    style, // Style object to be applied to row (to position it)
   }) => {
     const listItems = this.props.data;
+    const newStyle = {
+      width: "30%",
+      height: "350px",
+      margin: "15px",
+    }
+
 
     return (
-      <CellMeasurer cache={this.cache} index={index} key={key} parent={parent}>
-        <div style={style} >
+
+        <div
+          key={key}
+          style={newStyle}
+        >
           <MailMergeView
             style={this.cardStyle}
             template={this.props.template}
             context={listItems[index]}
           />
         </div>
-      </CellMeasurer>
     );
   };
-  onRenderHelper = e => {
-    console.log('E', e);
-    if (e.stopIndex % 24 == 0) {
-    }
-  };
+
   render() {
-    console.log(this.props.cache);
-    console.log(this.cache);
     if (this.props.data) {
       const listItems = this.props.data;
-      let width = window.innerWidth * 0.95;
-
+      let rowHeight = 150;
+      let height = rowHeight * listItems.length;
       return (
-        <Masonry
-          cellCount={listItems.length}
-          cellMeasurerCache={this.props.cache}
-          cellPositioner={this.props.cellPositioner}
-          cellRenderer={this.cellRenderer}
-          height={800}
-          width={this.props.containerWidth}
-          onCellsRendered={e => this.onRenderHelper(e)}
-          onScroll={e => console.log(e)}
+
+        <List
+          className={"faux-masonry"}
+          width={this.props.width}
+          height={height}
+          rowCount={listItems.length}
+          rowHeight={rowHeight}
+          rowRenderer={this.rowRenderer}
         />
+
       );
     }
   }

--- a/front/src/global-styles.ts
+++ b/front/src/global-styles.ts
@@ -8,6 +8,8 @@ body {
 }
 body {
   font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  background-color: #eaedf4;
+
 }
 body.fontLoaded {
   font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;


### PR DESCRIPTION
Fix for bug while scrolling masonry cards, more of a workaround. 

Masonry does a bunch of additional work around cell measuring (which I believe might be part of the issue) which we don’t really leverage since we use a fixed height and width.
This solution uses the list component and style it to be sort of like a faux-masonry view.

![Screen Shot 2020-07-31 at 11 03 32 AM](https://user-images.githubusercontent.com/17464571/89053901-852c3280-d31d-11ea-8535-3baeffbd8f84.png)
