### PR TITLE
682 requested changes

### DIFF
--- a/app/graphql/types/site_search_page_type.rb
+++ b/app/graphql/types/site_search_page_type.rb
@@ -4,6 +4,7 @@ module Types
     field :aggs, SiteAggSectionType, null: false
     field :crowd_aggs, SiteAggSectionType, null: false
     field :fields, [String], null: false
+    field :sortables, [String], null: false
     field :config, SiteConfigSectionType, null:false
     field :presearch ,SitePresearchPageType,null:false
     field :auto_suggest,SiteAutoSuggestSectionType ,null:false

--- a/app/models/site_view.rb
+++ b/app/models/site_view.rb
@@ -281,6 +281,7 @@ class SiteView < ApplicationRecord # rubocop:disable Metrics/ClassLength
           fields: crowd_aggs,
         },
         fields: %w[nct_id average_rating brief_title overall_status start_date completion_date],
+        sortables: %w[nct_id average_rating brief_title overall_status start_date completion_date],
         template:"\# {{briefTitle}}\n**{{nctId}}**  \nStatus: {{overallStatus}}  "
       },
     }

--- a/front/src/components/SiteForm/AggField.tsx
+++ b/front/src/components/SiteForm/AggField.tsx
@@ -448,7 +448,7 @@ class AggField extends React.Component<AggFieldProps, AggFieldState> {
         <>
           <StyledLabel>Sortable</StyledLabel>
           <Checkbox
-            name='set:search.fields'
+            name='set:search.sortables'
             checked={isSortable}
             onChange={this.handleCheckboxToggle(isSortable)}
           ></Checkbox>

--- a/front/src/components/SiteForm/SearchForm.tsx
+++ b/front/src/components/SiteForm/SearchForm.tsx
@@ -510,7 +510,7 @@ class SearchForm extends React.Component<SearchFormProps, SearchFormState> {
                   view={view}
                   configType="facetbar"
                   returnAll={true}
-                  sortables={view.search.fields}
+                  sortables={view.search.sortables}
                 />
               ))}
             </Col>
@@ -785,7 +785,7 @@ class SearchForm extends React.Component<SearchFormProps, SearchFormState> {
           </StyledPanelHeading>
         </Panel.Heading>
         <Panel.Body collapsible>
-          {view.search.results.type === 'table' ? (
+          {view.search.results.type === 'table' || view.search.results.type === 'table2'  ? (
             <>
               <h3>Fields</h3>
               <MultiInput
@@ -798,7 +798,7 @@ class SearchForm extends React.Component<SearchFormProps, SearchFormState> {
               />
             </>
           ) : null}
-          {view.search.results.type === 'table' ? (
+          {view.search.results.type === 'table' || view.search.results.type === 'table2'   ? (
             null
           ) : (<>
             <h3>Template</h3>

--- a/front/src/components/StudySummary/StudySummary.tsx
+++ b/front/src/components/StudySummary/StudySummary.tsx
@@ -34,7 +34,6 @@ class StudySummary extends React.PureComponent<StudySummaryProps> {
       conditions
       contacts
       createdAt
-      design
       detailedDescription
       dislikesCount
       dispositionFirstPostedDate

--- a/front/src/containers/SearchPage/SearchPage.tsx
+++ b/front/src/containers/SearchPage/SearchPage.tsx
@@ -733,6 +733,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
       this.props.history.location.search
     );
     const siteViewUrl = searchQueryString.getAll('sv').toString() || 'default';
+    const pageViewUrl = searchQueryString.getAll('pv').toString() || 'default';
     const userId = searchQueryString.getAll('uid').toString();
 
     if (data?.provisionSearchHash?.searchHash?.short) {
@@ -740,7 +741,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
         this.props.history.push(
           `/profile?hash=${
             data!.provisionSearchHash!.searchHash!.short
-          }&sv=${siteViewUrl}`
+          }&sv=${siteViewUrl}&pv=${pageViewUrl}`
         );
         return;
       } else if (userId) {
@@ -748,7 +749,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
         this.props.history.push(
           `/profile/user?hash=${
             data!.provisionSearchHash!.searchHash!.short
-          }&sv=${siteViewUrl}&uid=${userId}&username=${
+          }&sv=${siteViewUrl}&pv=${pageViewUrl}&uid=${userId}&username=${
             profile && profile.values.toString()
           }`
         );
@@ -758,14 +759,14 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
           //@ts-ignore
           `/intervention/${this.props.match.params.id}?hash=${
             data!.provisionSearchHash!.searchHash!.short
-          }&sv=intervention`
+          }&sv=intervention&pv=${pageViewUrl}`
         );
         return;
       } else {
         this.props.history.push(
           `/search?hash=${
             data!.provisionSearchHash!.searchHash!.short
-          }&sv=${siteViewUrl}`
+          }&sv=${siteViewUrl}&pv=${pageViewUrl}`
         );
         return;
       }

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -871,10 +871,8 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
             }}>
 
             {this.props.currentSiteView.search.sortables.map((field, index) => {
-              console.log(this.props)
               let sorts = [{ id: field, desc: false }]
               let params = this.props.params
-              console.log(params)
               return (
                 <MenuItem
                   key={field + index}

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -613,6 +613,7 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
                 loading={loading}
                 template={template}
                 width={width}
+                columnFields={this.props.currentSiteView.search.fields}
               />
             )}
           </AutoSizer>
@@ -870,7 +871,7 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
               background: this.props.theme.button,
             }}>
 
-            {this.props.currentSiteView.search.fields.map((field, index) => {
+            {this.props.currentSiteView.search.sortables.map((field, index) => {
               console.log(this.props)
               let sorts = [{ id: field, desc: false }]
               let params = this.props.params

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -849,7 +849,6 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
           })}
 
         </DropdownButton>
-        {this.props.params.sorts[0].desc}
         <div onClick={() => this.reverseSort()} style={{ display: 'flex', marginTop: 'auto', marginBottom: 'auto', cursor: 'pointer' }} >
           <FontAwesome
             name={'sort-amount-asc'}

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -200,7 +200,6 @@ const QueryComponent = (
     SearchPageSearchQueryVariables
   >
 ) => Query(props);
-
 const SearchWrapper = styled.div`
   .rt-tr {
     cursor: default;
@@ -227,7 +226,7 @@ padding: 0 30px;
     margin-top: 15px;
   }
   .headerRow{
-    background-color: #6BA5E6;
+    background-color: ${props=>props.theme.button};
     border-bottom: 1px solid #e0e0e0;
     pading: 58px;
     color: white;
@@ -245,7 +244,7 @@ padding: 0 30px;
     text-transform: none;
   }
 `;
-
+const ThemedSearchContainer = withTheme(SearchContainer)
 interface SearchView2Props {
   params: SearchParams;
   onBulkUpdate: (hash: string, siteViewUrl: string) => void;
@@ -825,10 +824,10 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
   }
   iconColor = (descIcon: boolean) => {
     if (descIcon == true && this.sortDesc() == true) {
-      return "#6ba5e6"
+      return this.props.theme.button
     }
     if (descIcon == false && this.sortDesc() == false) {
-      return "#6ba5e6"
+      return this.props.theme.button
     }
     return "#c0c3c5"
   }
@@ -914,10 +913,10 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
               // in the documentation but this appears to be by design.
               this.handleAggsUpdated(data);
               return (
-                <SearchContainer>
+                <ThemedSearchContainer>
                   {this.renderFilterDropDown()}
                   {this.renderSearch({ data, loading, error })}
-                </SearchContainer>
+                </ThemedSearchContainer>
               );
             }}
           </QueryComponent>

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -211,7 +211,7 @@ const SearchWrapper = styled.div`
 `;
 
 const SearchContainer = styled.div`
-  padding: 10px 30px;
+padding: 0 30px;
 
   color: black;
   margin-bottom: 1em;
@@ -795,8 +795,27 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
       }
       return " "
     }
+    const sortDesc = () => {
+      if (this.props.params.sorts.length > 0) {
+        return this.props.params.sorts[0].desc
+
+      }
+      return " "
+    }
+
+    let color =(descIcon:boolean)=>{
+      if(descIcon == true && sortDesc()==true){
+        return "#6ba5e6"
+      }
+      if(descIcon ==false && sortDesc()==false){
+        return "#6ba5e6"
+      }
+      return "#c0c3c5"
+    }
+
     return (
-      <div style={{ display: 'flex', flexDirection: 'row' }}>
+      <div style={{ display: 'flex', flexDirection: 'row', marginRight:'-30px'  }}>
+        <div style={{marginLeft:'auto', display: 'flex'}}>
         <DropdownButton
           bsStyle="default"
           title={`Sort by: ${sortField()}`}
@@ -824,15 +843,18 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
           })}
 
         </DropdownButton>
+        {this.props.params.sorts[0].desc}
         <div onClick={() => this.reverseSort()} style={{ display: 'flex', marginTop: 'auto', marginBottom: 'auto', cursor: 'pointer' }} >
           <FontAwesome
-            name={'sort'}
-            style={
-
-              { color: '#c0c3c5', fontSize: '26px' }
-            }
+            name={'sort-amount-asc'}
+            style={{ color: color(false), fontSize: '26px' }}
+          />
+          <FontAwesome
+            name={'sort-amount-desc'}
+            style={{ color: color(true), fontSize: '26px' }}
           />
         </div>
+      </div>
       </div>
     )
 

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -343,11 +343,11 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
 
   componentDidUpdate() {
     if (!this.props.showCards) {
-            //Needed for old table view
+      //Needed for old table view
       if (
         document.getElementsByClassName('ReactTable')[0] &&
         this.state.tableWidth !==
-          document.getElementsByClassName('ReactTable')[0].clientWidth
+        document.getElementsByClassName('ReactTable')[0].clientWidth
       ) {
         window.addEventListener('resize', this.updateState);
         this.setState({
@@ -363,22 +363,22 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
     }
   }
 
-  componentWillUnmount() {}
+  componentWillUnmount() { }
 
   // Functions for Old Table and Card view start here and end at line 492
   loadPaginator = (recordsTotal, loading, page, pagesTotal) => {
-      return (
-        <div className="right-align">
-          {page > 0 && !loading ? (
-            <FontAwesome
-              className="arrow-left"
-              name="arrow-left"
-              style={{ cursor: 'pointer', margin: '5px' }}
-              onClick={() =>
-                pipe(changePage, this.props.onUpdateParams)(page - 1)
-              }
-            />
-          ) : (
+    return (
+      <div className="right-align">
+        {page > 0 && !loading ? (
+          <FontAwesome
+            className="arrow-left"
+            name="arrow-left"
+            style={{ cursor: 'pointer', margin: '5px' }}
+            onClick={() =>
+              pipe(changePage, this.props.onUpdateParams)(page - 1)
+            }
+          />
+        ) : (
             <FontAwesome
               className="arrow-left"
               name="arrow-left"
@@ -386,39 +386,39 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
             />
           )}
           page{' '}
-          <b>
-            {loading ? (
-              <div id="divsononeline">
-                <PulseLoader color="#cccccc" size={8} />
-              </div>
-            ) : (
+        <b>
+          {loading ? (
+            <div id="divsononeline">
+              <PulseLoader color="#cccccc" size={8} />
+            </div>
+          ) : (
               `${Math.min(page + 1, pagesTotal)}/${pagesTotal}`
             )}{' '}
-          </b>
-          {page + 1 < pagesTotal && !loading ? (
-            <FontAwesome
-              className="arrow-right"
-              name="arrow-right"
-              style={{ cursor: 'pointer', margin: '5px' }}
-              onClick={() => {
-                pipe(changePage, this.props.onUpdateParams)(page + 1);
-              }}
-            />
-          ) : (
+        </b>
+        {page + 1 < pagesTotal && !loading ? (
+          <FontAwesome
+            className="arrow-right"
+            name="arrow-right"
+            style={{ cursor: 'pointer', margin: '5px' }}
+            onClick={() => {
+              pipe(changePage, this.props.onUpdateParams)(page + 1);
+            }}
+          />
+        ) : (
             <FontAwesome
               className="arrow-right"
               name="arrow-right"
               style={{ margin: '5px', color: 'gray' }}
             />
           )}
-          <div>{recordsTotal} results</div>
-          <div>
-            {recordsTotal > MAX_WINDOW_SIZE
-              ? `(showing first ${MAX_WINDOW_SIZE})`
-              : null}
-          </div>
+        <div>{recordsTotal} results</div>
+        <div>
+          {recordsTotal > MAX_WINDOW_SIZE
+            ? `(showing first ${MAX_WINDOW_SIZE})`
+            : null}
         </div>
-      );
+      </div>
+    );
   };
   updateState = () => {
     if (!this.props.showCards) {
@@ -540,21 +540,21 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
       Cell: !this.isStarColumn(name)
         ? null
         : // the stars and the number of reviews. css in global-styles.ts makes it so they're on one line
-          props => (
-            <div>
-              <div id="divsononeline">
-                <ReactStars
-                  count={5}
-                  color2={themedStarColor}
-                  edit={false}
-                  value={Number(props.original.averageRating)}
-                />
-              </div>
-              <div id="divsononeline">
-                &nbsp;({props.original.reviewsCount})
-              </div>
+        props => (
+          <div>
+            <div id="divsononeline">
+              <ReactStars
+                count={5}
+                color2={themedStarColor}
+                edit={false}
+                value={Number(props.original.averageRating)}
+              />
             </div>
-          ),
+            <div id="divsononeline">
+              &nbsp;({props.original.reviewsCount})
+              </div>
+          </div>
+        ),
       width: getColumnWidth(),
     };
   };
@@ -577,19 +577,19 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
   renderHelper = (data, loading, template, onPress, resultsType, recordsTotal) => {
     switch (resultsType) {
       case 'masonry':
-              return (
-                <AutoSizer>
-                {({ height, width }) => (
-                  <MasonryCards
-                    data={data}
-                    loading={loading}
-                    template={template}
-                    height={height}
-                    width={width}
-                  />
-                )}
-              </AutoSizer>
-              );
+        return (
+          <AutoSizer>
+            {({ height, width }) => (
+              <MasonryCards
+                data={data}
+                loading={loading}
+                template={template}
+                height={height}
+                width={width}
+              />
+            )}
+          </AutoSizer>
+        );
       case 'list':
         return (
           <AutoSizer>
@@ -651,10 +651,10 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
         const { currentSiteView } = this.props;
         // Block that sets the recordsTotal to state based on data response
         let pagesTotal = 1;
-          pagesTotal = Math.min(
-            Math.ceil(recordsTotal / this.props.params.pageSize),
-            Math.ceil(MAX_WINDOW_SIZE / this.props.params.pageSize)
-          );
+        pagesTotal = Math.min(
+          Math.ceil(recordsTotal / this.props.params.pageSize),
+          Math.ceil(MAX_WINDOW_SIZE / this.props.params.pageSize)
+        );
 
         const showResults = currentSiteView.search.config.fields.showResults;
 
@@ -775,13 +775,13 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
 
     return showResults
       ? this.renderHelper(
-          searchData,
-          loading,
-          currentSiteView.search.template,
-          this.cardPressed,
-          resultsType,
-          recordsTotal
-        )
+        searchData,
+        loading,
+        currentSiteView.search.template,
+        this.cardPressed,
+        resultsType,
+        recordsTotal
+      )
       : null;
   };
   cardPressed = card => {
@@ -815,6 +815,36 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
     this.props.onUpdateParams(changeSorted(newSort))
 
   }
+  sortDesc = () => {
+    if (this.props.params.sorts.length > 0) {
+      return this.props.params.sorts[0].desc
+
+    }
+    return " "
+  }
+  iconColor = (descIcon: boolean) => {
+    if (descIcon == true && this.sortDesc() == true) {
+      return "#6ba5e6"
+    }
+    if (descIcon == false && this.sortDesc() == false) {
+      return "#6ba5e6"
+    }
+    return "#c0c3c5"
+  }
+  renderSortIcons = () => {
+    return (
+      <div onClick={() => this.reverseSort()} style={{ display: 'flex', marginTop: 'auto', marginBottom: 'auto', cursor: 'pointer' }} >
+        <FontAwesome
+          name={'sort-amount-asc'}
+          style={{ color: this.iconColor(false), fontSize: '26px' }}
+        />
+        <FontAwesome
+          name={'sort-amount-desc'}
+          style={{ color: this.iconColor(true), fontSize: '26px' }}
+        />
+      </div>
+    )
+  }
   renderFilterDropDown = () => {
     const sortField = () => {
       if (this.props.params.sorts.length > 0) {
@@ -823,65 +853,43 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
       }
       return " "
     }
-    const sortDesc = () => {
-      if (this.props.params.sorts.length > 0) {
-        return this.props.params.sorts[0].desc
 
-      }
-      return " "
-    }
 
-    let color =(descIcon:boolean)=>{
-      if(descIcon == true && sortDesc()==true){
-        return "#6ba5e6"
-      }
-      if(descIcon ==false && sortDesc()==false){
-        return "#6ba5e6"
-      }
-      return "#c0c3c5"
-    }
+
 
     return (
-      <div style={{ display: 'flex', flexDirection: 'row', marginRight:'-30px'  }}>
-        <div style={{marginLeft:'auto', display: 'flex'}}>
-        <DropdownButton
-          bsStyle="default"
-          title={`Sort by: ${sortField()}`}
-          key="default"
-          id="dropdown-basic-default"
-          style={{
-            margin: '1em 1em 1em 0',
-            background: this.props.theme.button,
-          }}>
+      <div style={{ display: 'flex', flexDirection: 'row', marginRight: '-30px' }}>
+        <div style={{ marginLeft: 'auto', display: 'flex' }}>
+          <DropdownButton
+            bsStyle="default"
+            title={`Sort by: ${sortField()}`}
+            key="default"
+            id="dropdown-basic-default"
+            style={{
+              margin: '1em 1em 1em 0',
+              background: this.props.theme.button,
+            }}>
 
-          {this.props.currentSiteView.search.fields.map((field, index) => {
-            console.log(this.props)
-            let sorts = [{ id: field, desc: false }]
-            let params = this.props.params
-            console.log(params)
-            return (
-              <MenuItem
-                key={field + index}
-                name={field}
-                onClick={() => this.sortHelper(sorts, params)}>
-                {aggToField(field, field)}
-              </MenuItem>
-            )
+            {this.props.currentSiteView.search.fields.map((field, index) => {
+              console.log(this.props)
+              let sorts = [{ id: field, desc: false }]
+              let params = this.props.params
+              console.log(params)
+              return (
+                <MenuItem
+                  key={field + index}
+                  name={field}
+                  onClick={() => this.sortHelper(sorts, params)}>
+                  {aggToField(field, field)}
+                </MenuItem>
+              )
 
-          })}
+            })}
 
-        </DropdownButton>
-        <div onClick={() => this.reverseSort()} style={{ display: 'flex', marginTop: 'auto', marginBottom: 'auto', cursor: 'pointer' }} >
-          <FontAwesome
-            name={'sort-amount-asc'}
-            style={{ color: color(false), fontSize: '26px' }}
-          />
-          <FontAwesome
-            name={'sort-amount-desc'}
-            style={{ color: color(true), fontSize: '26px' }}
-          />
+          </DropdownButton>
+          {sortField() !== " " ? this.renderSortIcons() : null}
+
         </div>
-      </div>
       </div>
     )
 

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -222,6 +222,28 @@ padding: 0 30px;
     flex-wrap: wrap
   }
 
+  .Table {
+    width: 100%;
+    margin-top: 15px;
+  }
+  .headerRow{
+    background-color: #6BA5E6;
+    border-bottom: 1px solid #e0e0e0;
+    pading: 58px;
+    color: white;
+    padding: 25px;
+    font-weight: 400;
+  }
+  .evenRow,
+  .oddRow {
+    border-bottom: 1px solid #e0e0e0;
+  }
+  .oddRow {
+    background-color: #fafafa;
+  }
+  .headerColumn {
+    text-transform: none;
+  }
 `;
 
 interface SearchView2Props {

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -604,19 +604,6 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
         ) as number;
         const { page, pageSize, sorts } = this.props.params;
 
-        if (this.state.prevResults !== this.state.totalResults) {
-          this.setState(
-            prev => {
-              return {
-                totalResults: totalRecords,
-                prevResults: prev.totalResults,
-              };
-            },
-            () => {
-              this.props.getTotalResults(this.state.totalResults);
-            }
-          );
-        }
         const totalPages = Math.min(
           Math.ceil(totalRecords / this.props.params.pageSize),
           Math.ceil(MAX_WINDOW_SIZE / this.props.params.pageSize)
@@ -743,6 +730,25 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
     }
     if (!data) {
       return null;
+    }
+    const totalRecords = pathOr(
+      0,
+      ['search', 'recordsTotal'],
+      data
+    ) as number;
+
+    if (this.state.prevResults !== this.state.totalResults) {
+      this.setState(
+        prev => {
+          return {
+            totalResults: totalRecords,
+            prevResults: prev.totalResults,
+          };
+        },
+        () => {
+          this.props.getTotalResults(this.state.totalResults);
+        }
+      );
     }
 
     return showResults

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -217,6 +217,11 @@ const SearchContainer = styled.div`
   margin-bottom: 1em;
   display: block;
   flex-direction: column;
+  .ReactVirtualized__Grid__innerScrollContainer{
+    display: flex;
+    flex-wrap: wrap
+  }
+
 `;
 
 interface SearchView2Props {
@@ -550,44 +555,19 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
   renderHelper = (data, loading, template, onPress, resultsType, recordsTotal) => {
     switch (resultsType) {
       case 'masonry':
-        return (
-          <AutoSizer>
-            {({ height, width }) => {
-              const columnCount = 3;
-              let columnWidth = (width * 0.85) / columnCount;
-              const defaultHeight = 350;
-              let defaultWidth = columnWidth;
-
-              // Default sizes help Masonry decide how many cells to batch-measure
-              const cache = new CellMeasurerCache({
-                defaultHeight,
-                defaultWidth,
-                fixedWidth: true,
-                fixedHeight: true,
-              });
-
-              // Our masonry layout will use 3 columns with a 10px gutter between
-              const cellPositioner = createMasonryCellPositioner({
-                cellMeasurerCache: cache,
-                columnCount,
-                columnWidth,
-                spacer: 25,
-              });
               return (
-                <MasonryCards
-                  data={data}
-                  loading={loading}
-                  template={template}
-                  defaultHeight={defaultHeight}
-                  defaultWidth={defaultWidth}
-                  containerWidth={width}
-                  cellPositioner={cellPositioner}
-                  cache={cache}
-                />
+                <AutoSizer>
+                {({ height, width }) => (
+                  <MasonryCards
+                    data={data}
+                    loading={loading}
+                    template={template}
+                    height={height}
+                    width={width}
+                  />
+                )}
+              </AutoSizer>
               );
-            }}
-          </AutoSizer>
-        );
       case 'list':
         return (
           <AutoSizer>

--- a/front/src/containers/SearchPage/components/CrumbsBar.tsx
+++ b/front/src/containers/SearchPage/components/CrumbsBar.tsx
@@ -31,7 +31,6 @@ const CrumbsBarStyleWrappper = styled.div`
   border: solid white 1px;
   background-color: #f2f2f2;
   color: black;
-  margin-bottom: 1em;
   margin-left: 15px;
   margin-right: 15px;
   display: flex;

--- a/front/src/containers/SearchPage/components/ListCards.tsx
+++ b/front/src/containers/SearchPage/components/ListCards.tsx
@@ -40,7 +40,6 @@ class ListCards extends React.Component<ListCardsProps, ListCardsState> {
     borderStyle: 'solid',
     borderRadius: '5px',
     background: '#ffffff',
-    cursor: 'pointer',
     height: '100%',
   };
 

--- a/front/src/containers/SearchPage/components/MasonryCards.tsx
+++ b/front/src/containers/SearchPage/components/MasonryCards.tsx
@@ -40,7 +40,6 @@ class MasonryCards extends React.Component<MasonryCardsProps, MasonryCardsState>
     borderStyle: 'solid',
     borderRadius: '5px',
     background: '#ffffff',
-    cursor: 'pointer',
     height: '100%',
   };
   someStyle: React.CSSProperties = {

--- a/front/src/containers/SearchPage/components/MasonryCards.tsx
+++ b/front/src/containers/SearchPage/components/MasonryCards.tsx
@@ -28,7 +28,6 @@ class MasonryCards extends React.Component<MasonryCardsProps, MasonryCardsState>
   }
 
   componentDidUpdate() {
-    console.log(this.props.theme);
     if (this.state.loading !== this.props.loading) {
       this.setState({ loading: this.props.loading });
     }

--- a/front/src/containers/SearchPage/components/MasonryCards.tsx
+++ b/front/src/containers/SearchPage/components/MasonryCards.tsx
@@ -1,28 +1,19 @@
-// import * as React from 'react';
-import React, { useEffect } from 'react';
+import * as React from 'react';
 import { Col } from 'react-bootstrap';
 import { PulseLoader } from 'react-spinners';
 import { SearchPageSearchQuery_search_studies } from 'types/SearchPageSearchQuery';
 import { MailMergeView } from 'components/MailMerge';
 import { SiteFragment_siteView } from 'types/SiteFragment';
-import {
-  CellMeasurer,
-  CellMeasurerCache,
-  createMasonryCellPositioner,
-  Masonry,
-} from 'react-virtualized';
+import { List } from 'react-virtualized';
 import withTheme, { Theme } from 'containers/ThemeProvider/ThemeProvider';
 
 interface MasonryCardsProps {
   data: SearchPageSearchQuery_search_studies[];
   loading: boolean;
   template: string;
-  defaultHeight: number;
-  defaultWidth: number;
-  containerWidth: number;
+  height: number;
+  width: number;
   theme: Theme;
-  cellPositioner: Function;
-  cache: object;
   // columns:any;
 }
 
@@ -30,16 +21,14 @@ interface MasonryCardsState {
   loading: boolean;
 }
 
-class MasonryCards extends React.Component<
-  MasonryCardsProps,
-  MasonryCardsState
-> {
+class MasonryCards extends React.Component<MasonryCardsProps, MasonryCardsState> {
   constructor(props: MasonryCardsProps) {
     super(props);
     this.state = { loading: this.props.loading };
   }
 
   componentDidUpdate() {
+    console.log(this.props.theme);
     if (this.state.loading !== this.props.loading) {
       this.setState({ loading: this.props.loading });
     }
@@ -54,59 +43,57 @@ class MasonryCards extends React.Component<
     cursor: 'pointer',
     height: '100%',
   };
+  someStyle: React.CSSProperties = {
+    display: "flex",
+    flexWrap: "wrap",
+  };
 
-  cache = new CellMeasurerCache({
-    defaultHeight: this.props.defaultHeight,
-    defaultWidth: this.props.defaultWidth,
-    fixedWidth: true,
-    fixedHeight: true,
-  });
-
-  cellRenderer = ({
-    index, // Index of item within the collection
-    isScrolling, // The Grid is currently being scrolled
-    key, // Unique key within array of cells
-    parent, // Reference to the parent Grid (instance)
-    style, // Style object to be applied to cell (to position it);
-    // This must be passed through to the rendered cell element.
+  rowRenderer = ({
+    key, // Unique key within array of rows
+    index, // Index of row within collection
+    isScrolling, // The List is currently being scrolled
+    isVisible, // This row is visible within the List (eg it is not an overscanned row)
+    style, // Style object to be applied to row (to position it)
   }) => {
     const listItems = this.props.data;
+    const newStyle = {
+      width: "30%",
+      height: "350px",
+      margin: "15px",
+    }
+
 
     return (
-      <CellMeasurer cache={this.cache} index={index} key={key} parent={parent}>
-        <div style={style} >
+
+        <div
+          key={key}
+          style={newStyle}
+        >
           <MailMergeView
             style={this.cardStyle}
             template={this.props.template}
             context={listItems[index]}
           />
         </div>
-      </CellMeasurer>
     );
   };
-  onRenderHelper = e => {
-    console.log('E', e);
-    if (e.stopIndex % 24 == 0) {
-    }
-  };
+
   render() {
-    console.log(this.props.cache);
-    console.log(this.cache);
     if (this.props.data) {
       const listItems = this.props.data;
-      let width = window.innerWidth * 0.95;
-
+      let rowHeight = 150;
+      let height = rowHeight * listItems.length;
       return (
-        <Masonry
-          cellCount={listItems.length}
-          cellMeasurerCache={this.props.cache}
-          cellPositioner={this.props.cellPositioner}
-          cellRenderer={this.cellRenderer}
-          height={800}
-          width={this.props.containerWidth}
-          onCellsRendered={e => this.onRenderHelper(e)}
-          onScroll={e => console.log(e)}
+
+        <List
+          className={"faux-masonry"}
+          width={this.props.width}
+          height={height}
+          rowCount={listItems.length}
+          rowHeight={rowHeight}
+          rowRenderer={this.rowRenderer}
         />
+
       );
     }
   }

--- a/front/src/containers/SearchPage/components/TableRV.tsx
+++ b/front/src/containers/SearchPage/components/TableRV.tsx
@@ -8,6 +8,7 @@ import { Column, Table, SortDirection, AutoSizer } from 'react-virtualized';
 import _ from 'lodash';
 import 'react-virtualized/styles.css';
 import styled from 'styled-components';
+import { camelCase, sentanceCase } from 'utils/helpers';
 
 const MainContainer = styled.div`
   .Table {
@@ -56,6 +57,7 @@ interface TableRVProps {
   loading: boolean;
   template: string;
   width: number;
+  columnFields: string[];
   // columns:any;
 }
 
@@ -110,26 +112,15 @@ class TableRV extends React.Component<TableRVProps, TableRVState> {
           rowCount={listItems.length}
           rowClassName={this._rowClassName}
           rowGetter={({ index }) => listItems[index]}
-          // sortDirection={SortDirection.ASC}
-          // sortBy={'nctId'}
-          >
-          <Column label="NCTID" dataKey="nctId" width={width * 0.15} />
-          <Column
-            label="Brief Title:"
-            dataKey="briefTitle"
-            width={width * 0.35}
-          />
-
-          <Column
-            label="Overall Status:"
-            dataKey="overallStatus"
-            width={width * 0.25}
-          />
-          <Column
-            label="Completion Date:"
-            dataKey="completionDate"
-            width={width * 0.25}
-          />
+        // sortDirection={SortDirection.ASC}
+        // sortBy={'nctId'}
+        >
+          {this.props.columnFields.map((field) => {
+        //need to find a way to make column width more dynamic
+            return (
+              <Column label={sentanceCase(field)} dataKey={camelCase(field)} width={width / this.props.columnFields.length} />
+            )
+          })}
         </Table>
       );
     }

--- a/front/src/containers/SearchPage/components/TableRV.tsx
+++ b/front/src/containers/SearchPage/components/TableRV.tsx
@@ -10,55 +10,12 @@ import 'react-virtualized/styles.css';
 import styled from 'styled-components';
 import { camelCase, sentanceCase } from 'utils/helpers';
 
-const MainContainer = styled.div`
-  .Table {
-    width: 100%;
-    margin-top: 15px;
-  }
-  .headerRow,
-  .evenRow,
-  .oddRow {
-    border-bottom: 1px solid #e0e0e0;
-  }
-  .oddRow {
-    background-color: #fafafa;
-  }
-  .headerColumn {
-    text-transform: none;
-  }
-  .exampleColumn {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .checkboxLabel {
-    margin-left: 0.5rem;
-  }
-  .checkboxLabel:first-of-type {
-    margin-left: 0;
-  }
-
-  .noRows {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1em;
-    color: #bdbdbd;
-  }
-`;
 interface TableRVProps {
   data: SearchPageSearchQuery_search_studies[];
   loading: boolean;
   template: string;
   width: number;
   columnFields: string[];
-  // columns:any;
 }
 
 interface TableRVState {

--- a/front/src/containers/SearchPage/components/TableRV.tsx
+++ b/front/src/containers/SearchPage/components/TableRV.tsx
@@ -85,26 +85,6 @@ class TableRV extends React.Component<TableRVProps, TableRVState> {
     height: '100%',
   };
 
-  //  rowRenderer=({
-  //   key, // Unique key within array of rows
-  //   index, // Index of row within collection
-  //   isScrolling, // The List is currently being scrolled
-  //   isVisible, // This row is visible within the List (eg it is not an overscanned row)
-  //   style, // Style object to be applied to row (to position it)
-  // })=> {
-  //        const listItems = this.props.data
-
-  //   return (
-  //       <div key={key} style={style} onClick={()=>this.props.onPress(listItems[index])}>
-  //         <MailMergeView
-  //           style={this.cardStyle}
-  //           template={this.props.template}
-  //           context={listItems[index]}
-  //           />
-  //       </div>
-
-  //     );
-  // }
 
   _rowClassName({ index }) {
     if (index < 0) {
@@ -120,7 +100,6 @@ class TableRV extends React.Component<TableRVProps, TableRVState> {
       let rowHeight = 250;
       let width = this.props.width;
       let height = 500;
-      console.log('WIDTH', width);
 
       return (
         <Table
@@ -131,8 +110,9 @@ class TableRV extends React.Component<TableRVProps, TableRVState> {
           rowCount={listItems.length}
           rowClassName={this._rowClassName}
           rowGetter={({ index }) => listItems[index]}
-          sortDirection={SortDirection.ASC}
-          sortBy={'nctId'}>
+          // sortDirection={SortDirection.ASC}
+          // sortBy={'nctId'}
+          >
           <Column label="NCTID" dataKey="nctId" width={width * 0.15} />
           <Column
             label="Brief Title:"

--- a/front/src/containers/SiteProvider/SiteProvider.tsx
+++ b/front/src/containers/SiteProvider/SiteProvider.tsx
@@ -185,7 +185,7 @@ export const SITE_VIEW_FRAGMENT = gql`
         }
         instructions
       }
-
+      sortables
       fields
       config {
         fields {

--- a/front/src/global-styles.ts
+++ b/front/src/global-styles.ts
@@ -8,6 +8,8 @@ body {
 }
 body {
   font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  background-color: #eaedf4;
+
 }
 body.fontLoaded {
   font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;

--- a/front/src/types/CopySiteViewMutation.ts
+++ b/front/src/types/CopySiteViewMutation.ts
@@ -349,6 +349,7 @@ export interface CopySiteViewMutation_copySiteView_siteView_search {
   autoSuggest: CopySiteViewMutation_copySiteView_siteView_search_autoSuggest;
   results: CopySiteViewMutation_copySiteView_siteView_search_results;
   presearch: CopySiteViewMutation_copySiteView_siteView_search_presearch;
+  sortables: string[];
   fields: string[];
   config: CopySiteViewMutation_copySiteView_siteView_search_config;
   aggs: CopySiteViewMutation_copySiteView_siteView_search_aggs;

--- a/front/src/types/CreateSiteMutation.ts
+++ b/front/src/types/CreateSiteMutation.ts
@@ -365,6 +365,7 @@ export interface CreateSiteMutation_createSite_site_siteView_search {
   autoSuggest: CreateSiteMutation_createSite_site_siteView_search_autoSuggest;
   results: CreateSiteMutation_createSite_site_siteView_search_results;
   presearch: CreateSiteMutation_createSite_site_siteView_search_presearch;
+  sortables: string[];
   fields: string[];
   config: CreateSiteMutation_createSite_site_siteView_search_config;
   aggs: CreateSiteMutation_createSite_site_siteView_search_aggs;
@@ -722,6 +723,7 @@ export interface CreateSiteMutation_createSite_site_siteViews_search {
   autoSuggest: CreateSiteMutation_createSite_site_siteViews_search_autoSuggest;
   results: CreateSiteMutation_createSite_site_siteViews_search_results;
   presearch: CreateSiteMutation_createSite_site_siteViews_search_presearch;
+  sortables: string[];
   fields: string[];
   config: CreateSiteMutation_createSite_site_siteViews_search_config;
   aggs: CreateSiteMutation_createSite_site_siteViews_search_aggs;

--- a/front/src/types/CreateSiteViewMutation.ts
+++ b/front/src/types/CreateSiteViewMutation.ts
@@ -349,6 +349,7 @@ export interface CreateSiteViewMutation_createSiteView_siteView_search {
   autoSuggest: CreateSiteViewMutation_createSiteView_siteView_search_autoSuggest;
   results: CreateSiteViewMutation_createSiteView_siteView_search_results;
   presearch: CreateSiteViewMutation_createSiteView_siteView_search_presearch;
+  sortables: string[];
   fields: string[];
   config: CreateSiteViewMutation_createSiteView_siteView_search_config;
   aggs: CreateSiteViewMutation_createSiteView_siteView_search_aggs;

--- a/front/src/types/CrowdPageQuery.ts
+++ b/front/src/types/CrowdPageQuery.ts
@@ -39,7 +39,6 @@ export interface CrowdPageQuery_study {
   conditions: string | null;
   contacts: string;
   createdAt: any;
-  design: string;
   detailedDescription: string | null;
   dislikesCount: number;
   dispositionFirstPostedDate: string | null;

--- a/front/src/types/EditReviewQuery.ts
+++ b/front/src/types/EditReviewQuery.ts
@@ -62,7 +62,6 @@ export interface EditReviewQuery_study {
   conditions: string | null;
   contacts: string;
   createdAt: any;
-  design: string;
   detailedDescription: string | null;
   dislikesCount: number;
   dispositionFirstPostedDate: string | null;

--- a/front/src/types/InterventionsPageQuery.ts
+++ b/front/src/types/InterventionsPageQuery.ts
@@ -50,7 +50,6 @@ export interface InterventionsPageQuery_study {
   conditions: string | null;
   contacts: string;
   createdAt: any;
-  design: string;
   detailedDescription: string | null;
   dislikesCount: number;
   dispositionFirstPostedDate: string | null;

--- a/front/src/types/SiteFragment.ts
+++ b/front/src/types/SiteFragment.ts
@@ -365,6 +365,7 @@ export interface SiteFragment_siteView_search {
   autoSuggest: SiteFragment_siteView_search_autoSuggest;
   results: SiteFragment_siteView_search_results;
   presearch: SiteFragment_siteView_search_presearch;
+  sortables: string[];
   fields: string[];
   config: SiteFragment_siteView_search_config;
   aggs: SiteFragment_siteView_search_aggs;
@@ -722,6 +723,7 @@ export interface SiteFragment_siteViews_search {
   autoSuggest: SiteFragment_siteViews_search_autoSuggest;
   results: SiteFragment_siteViews_search_results;
   presearch: SiteFragment_siteViews_search_presearch;
+  sortables: string[];
   fields: string[];
   config: SiteFragment_siteViews_search_config;
   aggs: SiteFragment_siteViews_search_aggs;

--- a/front/src/types/SiteProviderQuery.ts
+++ b/front/src/types/SiteProviderQuery.ts
@@ -365,6 +365,7 @@ export interface SiteProviderQuery_site_siteView_search {
   autoSuggest: SiteProviderQuery_site_siteView_search_autoSuggest;
   results: SiteProviderQuery_site_siteView_search_results;
   presearch: SiteProviderQuery_site_siteView_search_presearch;
+  sortables: string[];
   fields: string[];
   config: SiteProviderQuery_site_siteView_search_config;
   aggs: SiteProviderQuery_site_siteView_search_aggs;
@@ -722,6 +723,7 @@ export interface SiteProviderQuery_site_siteViews_search {
   autoSuggest: SiteProviderQuery_site_siteViews_search_autoSuggest;
   results: SiteProviderQuery_site_siteViews_search_results;
   presearch: SiteProviderQuery_site_siteViews_search_presearch;
+  sortables: string[];
   fields: string[];
   config: SiteProviderQuery_site_siteViews_search_config;
   aggs: SiteProviderQuery_site_siteViews_search_aggs;

--- a/front/src/types/SiteViewFragment.ts
+++ b/front/src/types/SiteViewFragment.ts
@@ -349,6 +349,7 @@ export interface SiteViewFragment_search {
   autoSuggest: SiteViewFragment_search_autoSuggest;
   results: SiteViewFragment_search_results;
   presearch: SiteViewFragment_search_presearch;
+  sortables: string[];
   fields: string[];
   config: SiteViewFragment_search_config;
   aggs: SiteViewFragment_search_aggs;

--- a/front/src/types/StudyPagePrefetchQuery.ts
+++ b/front/src/types/StudyPagePrefetchQuery.ts
@@ -184,7 +184,6 @@ export interface StudyPagePrefetchQuery_study {
   conditions: string | null;
   contacts: string;
   createdAt: any;
-  design: string;
   detailedDescription: string | null;
   dislikesCount: number;
   dispositionFirstPostedDate: string | null;

--- a/front/src/types/StudyPageQuery.ts
+++ b/front/src/types/StudyPageQuery.ts
@@ -30,7 +30,6 @@ export interface StudyPageQuery_study {
   conditions: string | null;
   contacts: string;
   createdAt: any;
-  design: string;
   detailedDescription: string | null;
   dislikesCount: number;
   dispositionFirstPostedDate: string | null;

--- a/front/src/types/StudySummaryFragment.ts
+++ b/front/src/types/StudySummaryFragment.ts
@@ -30,7 +30,6 @@ export interface StudySummaryFragment {
   conditions: string | null;
   contacts: string;
   createdAt: any;
-  design: string;
   detailedDescription: string | null;
   dislikesCount: number;
   dispositionFirstPostedDate: string | null;

--- a/front/src/types/TagsPageQuery.ts
+++ b/front/src/types/TagsPageQuery.ts
@@ -39,7 +39,6 @@ export interface TagsPageQuery_study {
   conditions: string | null;
   contacts: string;
   createdAt: any;
-  design: string;
   detailedDescription: string | null;
   dislikesCount: number;
   dispositionFirstPostedDate: string | null;

--- a/front/src/types/UpdateSiteMutation.ts
+++ b/front/src/types/UpdateSiteMutation.ts
@@ -365,6 +365,7 @@ export interface UpdateSiteMutation_updateSite_site_siteView_search {
   autoSuggest: UpdateSiteMutation_updateSite_site_siteView_search_autoSuggest;
   results: UpdateSiteMutation_updateSite_site_siteView_search_results;
   presearch: UpdateSiteMutation_updateSite_site_siteView_search_presearch;
+  sortables: string[];
   fields: string[];
   config: UpdateSiteMutation_updateSite_site_siteView_search_config;
   aggs: UpdateSiteMutation_updateSite_site_siteView_search_aggs;
@@ -722,6 +723,7 @@ export interface UpdateSiteMutation_updateSite_site_siteViews_search {
   autoSuggest: UpdateSiteMutation_updateSite_site_siteViews_search_autoSuggest;
   results: UpdateSiteMutation_updateSite_site_siteViews_search_results;
   presearch: UpdateSiteMutation_updateSite_site_siteViews_search_presearch;
+  sortables: string[];
   fields: string[];
   config: UpdateSiteMutation_updateSite_site_siteViews_search_config;
   aggs: UpdateSiteMutation_updateSite_site_siteViews_search_aggs;

--- a/front/src/types/UpdateSiteViewMutation.ts
+++ b/front/src/types/UpdateSiteViewMutation.ts
@@ -349,6 +349,7 @@ export interface UpdateSiteViewMutation_updateSiteView_siteView_search {
   autoSuggest: UpdateSiteViewMutation_updateSiteView_siteView_search_autoSuggest;
   results: UpdateSiteViewMutation_updateSiteView_siteView_search_results;
   presearch: UpdateSiteViewMutation_updateSiteView_siteView_search_presearch;
+  sortables: string[];
   fields: string[];
   config: UpdateSiteViewMutation_updateSiteView_siteView_search_config;
   aggs: UpdateSiteViewMutation_updateSiteView_siteView_search_aggs;


### PR DESCRIPTION
handles the first section of items of #682. 

Changes to sort:
placement, desc/asc icons, padding, etc.
Also shows working Recor count in breadcrumbs
![Screen Shot 2020-07-31 at 1 12 52 PM](https://user-images.githubusercontent.com/17464571/89079764-d0116e80-d34c-11ea-8c3e-904205e1f793.png)

RV Table: 
![Screen Shot 2020-07-31 at 4 06 13 PM](https://user-images.githubusercontent.com/17464571/89079846-00590d00-d34d-11ea-895b-6cefd76dae3f.png)

RV Table config:
![Screen Shot 2020-07-31 at 4 06 33 PM](https://user-images.githubusercontent.com/17464571/89079868-0c44cf00-d34d-11ea-8f9a-1cc0ea254236.png)
