### PR TITLE
682 requested changes cont'd

### DIFF
--- a/front/src/components/MailMerge/MailMergeHelpers.ts
+++ b/front/src/components/MailMerge/MailMergeHelpers.ts
@@ -1,5 +1,5 @@
 import Handlebars from 'handlebars';
-import useUrlParams from 'utils/UrlParamsProvider';
+import useUrlParams, { queryStringAll } from 'utils/UrlParamsProvider';
 import { link } from 'fs';
 
 export function registerHandlebarsHelpers() {
@@ -34,15 +34,7 @@ export function registerHandlebarsHelpers() {
         return linkAttributes.q
       case 'ALL':
         console.log(linkAttributes)
-        let queryString = "?"
-
-        for (const [key, value] of Object.entries(linkAttributes)) {
-          if(value){
-            queryString= queryString.concat(`${key}=${value}&`)
-          }
-        }
-
-        return queryString
+        return queryStringAll(linkAttributes)
       default:
         return value
     }

--- a/front/src/components/MailMerge/MailMergeHelpers.ts
+++ b/front/src/components/MailMerge/MailMergeHelpers.ts
@@ -1,5 +1,6 @@
 import Handlebars from 'handlebars';
 import useUrlParams from 'utils/UrlParamsProvider';
+import { link } from 'fs';
 
 export function registerHandlebarsHelpers() {
   Handlebars.registerHelper('stars', (value: number) => {
@@ -26,11 +27,22 @@ export function registerHandlebarsHelpers() {
       case 'hash':
         return linkAttributes.hash;
       case 'siteViewUrl':
-        return linkAttributes.siteViewUrl;
+        return linkAttributes.sv;
       case 'pageViewUrl':
-        return linkAttributes.pageViewUrl
+        return linkAttributes.pv
       case 'q':
         return linkAttributes.q
+      case 'ALL':
+        console.log(linkAttributes)
+        let queryString = "?"
+
+        for (const [key, value] of Object.entries(linkAttributes)) {
+          if(value){
+            queryString= queryString.concat(`${key}=${value}&`)
+          }
+        }
+
+        return queryString
       default:
         return value
     }

--- a/front/src/components/MailMerge/MailMergeView.tsx
+++ b/front/src/components/MailMerge/MailMergeView.tsx
@@ -86,7 +86,7 @@ function tokensToGraphQLOb(tags: string[]) {
       pushScope(scopeName);
       scope[propName] = 'x';
       popScope();
-    }else if(name == "hash" || name == "siteViewUrl" || name == "pageViewUrl" || name == "q"){
+    }else if(name == "hash" || name == "siteViewUrl" || name == "pageViewUrl" || name == "q" || name == 'ALL'){
 
       scope[name] ={param: name}
     }else {
@@ -186,7 +186,7 @@ function applyTemplate(
   context?: object
 ) {
   try {
-    context = {...context, hash: 'hash', siteViewUrl: "siteViewUrl", pageViewUrl: 'pageViewUrl', q: 'q'}
+    context = {...context, hash: 'hash', siteViewUrl: "siteViewUrl", pageViewUrl: 'pageViewUrl', q: 'q', ALL: 'ALL'}
     return template(context);
   } catch (e) {
     return `#Template apply error:\n   ${e}`;

--- a/front/src/components/StyledComponents/index.ts
+++ b/front/src/components/StyledComponents/index.ts
@@ -71,6 +71,7 @@ const MainContainer = styled(Col)`
   padding-top: 20px;
   padding-bottom: 20px;
   flex: 1;
+  overflow:scroll;
   @media (max-width: 768px) {
     flex-direction: column;
   }

--- a/front/src/containers/GenericPage/GenericPage.tsx
+++ b/front/src/containers/GenericPage/GenericPage.tsx
@@ -24,8 +24,8 @@ export default function GenericPage(props: Props) {
     if(props.url){
       return props.url
     }
-    if(params.pageViewUrl && pageViewsData){
-      const defaultPageView= find(propEq('url', params.pageViewUrl))(pageViewsData?.site?.pageViews)
+    if(params.pv && pageViewsData){
+      const defaultPageView= find(propEq('url', params.pv))(pageViewsData?.site?.pageViews)
       if (defaultPageView){
         return defaultPageView.url
       }

--- a/front/src/containers/Islands/NavigationIsland.tsx
+++ b/front/src/containers/Islands/NavigationIsland.tsx
@@ -8,7 +8,7 @@ import { BeatLoader, PulseLoader } from 'react-spinners';
 import StudyPageCounter from '../StudyPage/components/StudyPageCounter'
 import { path, pathOr } from 'ramda';
 import { trimPath } from 'utils/helpers';
-import useUrlParams from 'utils/UrlParamsProvider';
+import useUrlParams, {queryStringAll} from 'utils/UrlParamsProvider';
 
 
 interface Props {
@@ -87,23 +87,23 @@ export default function NavigationIsland(props: Props) {
       const updatedPath = url.substring(0, url.lastIndexOf('/')); 
     nextLink =
       nextId &&
-      `${updatedPath}/${nextId}?hash=${variables.hash}&sv=${siteViewUrl}`;
+      `${updatedPath}/${nextId}${queryStringAll(params)}`;
     prevLink =
       prevId &&
-      `${updatedPath}/${prevId}?hash=${variables.hash}&sv=${siteViewUrl}`;
+      `${updatedPath}/${prevId}${queryStringAll(params)}`;
 
     // just so that there isn't a first button if there isn't a prev button
     // likewise for the last button
     if (prevLink != null) {
       firstLink =
         firstId &&
-        `${updatedPath}/${firstId}?hash=${variables.hash}&sv=${siteViewUrl}`;
+        `${updatedPath}/${firstId}${queryStringAll(params)}`;
       // firstId && `/search/${variables.hash}/study/${firstId}`;
     }
     if (nextLink != null && counterIndex != null) {
       lastLink =
         lastId &&
-        `${updatedPath}/${lastId}?hash=${variables.hash}&sv=${siteViewUrl}`;
+        `${updatedPath}/${lastId}${queryStringAll(params)}`;
     }
   return (
     <div className="navigation-island">

--- a/front/src/containers/Islands/NavigationIsland.tsx
+++ b/front/src/containers/Islands/NavigationIsland.tsx
@@ -22,7 +22,7 @@ export default function NavigationIsland(props: Props) {
 
   const params = useUrlParams()
   const hash = params.hash
-  const siteViewUrl = params.siteViewUrl
+  const siteViewUrl = params.sv
   const variables = {
     hash: hash,
     id: nctId,

--- a/front/src/containers/Islands/NavigationIsland.tsx
+++ b/front/src/containers/Islands/NavigationIsland.tsx
@@ -106,7 +106,7 @@ export default function NavigationIsland(props: Props) {
         `${updatedPath}/${lastId}?hash=${variables.hash}&sv=${siteViewUrl}`;
     }
   return (
-    <div className="container">
+    <div className="navigation-island">
       <div id="navbuttonsonstudypage">
         {renderNavButton(
           '❮❮ First',

--- a/front/src/containers/Islands/ReviewsIsland.tsx
+++ b/front/src/containers/Islands/ReviewsIsland.tsx
@@ -78,9 +78,6 @@ export default function ReviewsIsland(props: Props) {
   const [deleteReviewMutation] = useMutation(DELETE_REVIEW_MUTATION, {
     refetchQueries: [{ query: QUERY, variables: { nctId } }],
   });
-  // const [deleteMutation] = useMutation(DELETE_LABEL_MUTATION, {
-  //   refetchQueries: [{ query: QUERY, variables: { nctId } }],
-  // });
 
   const { currentSiteView } = useSite();
   const user = useCurrentUser()?.data?.me;
@@ -165,37 +162,7 @@ export default function ReviewsIsland(props: Props) {
                     onClick={() => handleEditReview(review.id, hash, siteViewUrl)}>
                     Edit
                 </ThemedButton>
-                  {/* <DeleteReviewMutationComponent
-                  mutation={DELETE_REVIEW_MUTATION}
-                  update={cache => {
-                    const id = dataIdFromObject({
-                      id: this.props.match.params.nctId,
-                      __typename: 'Study',
-                    });
 
-                    const study = cache.readFragment<
-                      ReviewsPageStudyFragment
-                      // tslint:disable-next-line
-                    >({
-                      id,
-                      fragment: STUDY_FRAGMENT,
-                      fragmentName: 'ReviewsPageStudyFragment',
-                    });
-                    const reviewsLens = lensPath(['reviews']);
-                    const newStudy = over(
-                      reviewsLens,
-                      reject(propEq('id', review.id)),
-                      study
-                    );
-
-                    cache.writeFragment({
-                      id,
-                      fragment: STUDY_FRAGMENT,
-                      fragmentName: 'ReviewsPageStudyFragment',
-                      data: newStudy,
-                    });
-                  }}> */}
-                  {/* {deleteReview => ( */}
                   <ThemedButton
                     onClick={handleDeleteReview(
                       deleteReviewMutation,
@@ -225,7 +192,7 @@ export default function ReviewsIsland(props: Props) {
     return (
 
       <>
-        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <div style={{ display: 'flex' }}>
           <WriteReviewButton onClick={() => handleWriteReview(hash, siteViewUrl)}>
             Write a review
                 </WriteReviewButton>
@@ -246,7 +213,6 @@ export default function ReviewsIsland(props: Props) {
         <Route
           path={`${match.path}/new`}
           render={() => {
-            // this.props.onLoaded && this.props.onLoaded();
             return (
               <ReviewForm
                 theme={theme}
@@ -259,9 +225,7 @@ export default function ReviewsIsland(props: Props) {
         <Route
           path={`${match.path}/:id/edit`}
           render={props => {
-            console.log("PROPS", props)
             let newProps = { ...props, nctId: nctId }
-            console.log("NEWNEW", newProps)
             return (
               <EditReview {...newProps} onLoaded={() => console.log("Loaded")} />//this.props.onLoaded} />
             );
@@ -270,14 +234,7 @@ export default function ReviewsIsland(props: Props) {
         <Route render={() => renderReviews(reviewData!.study!.reviews)} />
       </Switch>
     );
-    // return (
-    //   <div>
-    //     <h3>Reviews</h3>
-    //     <StyledPanel>
 
-    //     </StyledPanel>
-    //   </div>
-    // );
   }
   return (
     <BeatLoader></BeatLoader>

--- a/front/src/containers/Islands/WikiPageIsland.tsx
+++ b/front/src/containers/Islands/WikiPageIsland.tsx
@@ -61,7 +61,7 @@ export default function WikiPageIsland(props: Props) {
   const user = useCurrentUser()?.data?.me;
   const params = useUrlParams()
   const hash = params.hash
-  const siteViewUrl = params.siteViewUrl
+  const siteViewUrl = params.sv
 
   // TODO: This query should be pushed up as a fragment to the Page
   const { data: studyData } = useQuery<WikiPageQuery>(QUERY, {

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -824,26 +824,24 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
     }
     return " "
   }
-  iconColor = (descIcon: boolean) => {
-    if (descIcon == true && this.sortDesc() == true) {
-      return this.props.theme.button
-    }
-    if (descIcon == false && this.sortDesc() == false) {
-      return this.props.theme.button
-    }
-    return "#c0c3c5"
-  }
   renderSortIcons = () => {
+    let isDesc = this.props.params.sorts[0].desc
     return (
+
       <div onClick={() => this.reverseSort()} style={{ display: 'flex', marginTop: 'auto', marginBottom: 'auto', cursor: 'pointer' }} >
-        <FontAwesome
-          name={'sort-amount-asc'}
-          style={{ color: this.iconColor(false), fontSize: '26px' }}
-        />
-        <FontAwesome
-          name={'sort-amount-desc'}
-          style={{ color: this.iconColor(true), fontSize: '26px' }}
-        />
+        {isDesc ? (
+          <FontAwesome
+            name={'sort-amount-desc'}
+            style={{ color: this.props.theme.button, fontSize: '26px' }}
+          />) : (
+            <FontAwesome
+              name={'sort-amount-asc'}
+              style={{ color: this.props.theme.button, fontSize: '26px' }}
+            />
+          )
+        }
+
+
       </div>
     )
   }
@@ -855,9 +853,6 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
       }
       return " "
     }
-
-
-
 
     return (
       <div style={{ display: 'flex', flexDirection: 'row', marginRight: '-30px' }}>

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -232,10 +232,12 @@ padding: 0 30px;
     color: white;
     padding: 25px;
     font-weight: 400;
+    display: flex;
   }
   .evenRow,
   .oddRow {
     border-bottom: 1px solid #e0e0e0;
+    display: flex;
   }
   .oddRow {
     background-color: #fafafa;

--- a/front/src/containers/SearchPage/components/TableRV.tsx
+++ b/front/src/containers/SearchPage/components/TableRV.tsx
@@ -4,9 +4,8 @@ import { PulseLoader } from 'react-spinners';
 import { SearchPageSearchQuery_search_studies } from 'types/SearchPageSearchQuery';
 import { MailMergeView } from 'components/MailMerge';
 import { SiteFragment_siteView } from 'types/SiteFragment';
-import { Column, Table, SortDirection, AutoSizer } from 'react-virtualized';
+import { Column, Table, SortDirection, WindowScroller } from 'react-virtualized';
 import _ from 'lodash';
-import 'react-virtualized/styles.css';
 import styled from 'styled-components';
 import { camelCase, sentanceCase } from 'utils/helpers';
 
@@ -34,16 +33,6 @@ class TableRV extends React.Component<TableRVProps, TableRVState> {
     }
   }
 
-  cardStyle: React.CSSProperties = {
-    borderWidth: 2,
-    borderColor: 'rgb(85, 184, 141)',
-    borderStyle: 'solid',
-    borderRadius: '5px',
-    background: '#ffffff',
-    cursor: 'pointer',
-    height: '100%',
-  };
-
 
   _rowClassName({ index }) {
     if (index < 0) {
@@ -56,12 +45,13 @@ class TableRV extends React.Component<TableRVProps, TableRVState> {
   render() {
     if (this.props.data) {
       const listItems = this.props.data;
-      let rowHeight = 250;
       let width = this.props.width;
-      let height = 500;
 
       return (
+      <WindowScroller>
+        {({ height, isScrolling, onChildScroll, scrollTop }) => (
         <Table
+          autoHeight
           width={width}
           height={height}
           headerHeight={20}
@@ -69,6 +59,9 @@ class TableRV extends React.Component<TableRVProps, TableRVState> {
           rowCount={listItems.length}
           rowClassName={this._rowClassName}
           rowGetter={({ index }) => listItems[index]}
+          isScrolling={isScrolling}
+          onScroll={onChildScroll}
+          scrollTop={scrollTop}
         // sortDirection={SortDirection.ASC}
         // sortBy={'nctId'}
         >
@@ -79,6 +72,8 @@ class TableRV extends React.Component<TableRVProps, TableRVState> {
             )
           })}
         </Table>
+    )}
+    </WindowScroller>
       );
     }
   }

--- a/front/src/utils/UrlParamsProvider.ts
+++ b/front/src/utils/UrlParamsProvider.ts
@@ -3,10 +3,10 @@ export default function useUrlParams() {
     hash: new URLSearchParams(window.location.search)
       .getAll('hash')
       ?.toString(),
-    siteViewUrl: new URLSearchParams(window.location.search)
+    sv: new URLSearchParams(window.location.search)
       .getAll('sv')
       ?.toString(),
-    pageViewUrl: new URLSearchParams(window.location.search)
+    pv: new URLSearchParams(window.location.search)
       .getAll('pv')
       ?.toString(),  
     q: new URLSearchParams(window.location.search)

--- a/front/src/utils/UrlParamsProvider.ts
+++ b/front/src/utils/UrlParamsProvider.ts
@@ -15,3 +15,13 @@ export default function useUrlParams() {
 
   };
 }
+
+export const queryStringAll =(params)=>{
+  let queryString="?"
+  for (const [key, value] of Object.entries(params)) {
+    if(value){
+      queryString= queryString.concat(`${key}=${value}&`)
+    }
+  }
+  return queryString
+}


### PR DESCRIPTION
-implements querystring ALL
-removes header formatting left over in some islands
-fixes navigation bug  that dropped pv value from querystring 
-adds rv table to use window scroller 
querystring ALL:
config
![Screen Shot 2020-08-02 at 4 22 51 PM](https://user-images.githubusercontent.com/17464571/89133738-1816c980-d4e4-11ea-87a5-9a62731dddcf.png)
result: 
![Screen Shot 2020-08-02 at 4 23 17 PM](https://user-images.githubusercontent.com/17464571/89133774-75ab1600-d4e4-11ea-80da-ce60ca98d6da.png)


RV Table windowscroller:
![Screen Shot 2020-08-02 at 5 21 26 PM](https://user-images.githubusercontent.com/17464571/89133796-abe89580-d4e4-11ea-9f23-006d19a05c85.png)

Heading format removal:
![Screen Shot 2020-08-02 at 5 23 38 PM](https://user-images.githubusercontent.com/17464571/89133825-f833d580-d4e4-11ea-99fa-ce40ed10ac94.png)

