### PR TITLE
682 Changes continued

### DIFF
--- a/front/src/components/MailMerge/MailMergeHelpers.ts
+++ b/front/src/components/MailMerge/MailMergeHelpers.ts
@@ -33,7 +33,6 @@ export function registerHandlebarsHelpers() {
       case 'q':
         return linkAttributes.q
       case 'ALL':
-        console.log(linkAttributes)
         return queryStringAll(linkAttributes)
       default:
         return value

--- a/front/src/containers/Islands/ReviewsIsland.tsx
+++ b/front/src/containers/Islands/ReviewsIsland.tsx
@@ -10,7 +10,7 @@ import QUERY from 'queries/ReviewPageQuery';
 import { useQuery, useMutation } from 'react-apollo';
 import { useSite } from 'containers/SiteProvider/SiteProvider';
 import { useCurrentUser } from 'containers/CurrentUser/CurrentUser';
-import useUrlParams from 'utils/UrlParamsProvider';
+import useUrlParams,{queryStringAll} from 'utils/UrlParamsProvider';
 import { BeatLoader } from 'react-spinners';
 import { Switch, Route, match } from 'react-router-dom';
 import { useHistory, useLocation, useRouteMatch } from "react-router-dom";
@@ -69,7 +69,7 @@ export default function ReviewsIsland(props: Props) {
   const location = useLocation();
   const match = useRouteMatch();
   const theme = useTheme();
-
+  const params = useUrlParams()
   // TODO: This query should be pushed up as a fragment to the Page
   const { data: reviewData } = useQuery<ReviewPageQuery>(QUERY, {
     variables: { nctId },
@@ -86,11 +86,11 @@ export default function ReviewsIsland(props: Props) {
   margin-bottom: 10px;
 `;
 
-  const handleWriteReview = (hash: string, siteViewUrl: string) => {
-    history.push(`${trimPath(match.url)}/new?hash=${hash}&sv=${siteViewUrl} `);
+  const handleWriteReview = () => {
+    history.push(`${trimPath(match.url)}/new${queryStringAll(params)}`);
   };
-  const handleEditReview = (id: number, hash: string, siteViewUrl: string) => {
-    history.push(`${trimPath(match.url)}/${id}/edit?hash=${hash}&sv=${siteViewUrl}`);
+  const handleEditReview = (id: number) => {
+    history.push(`${trimPath(match.url)}/${id}/edit${queryStringAll(params)}`);
   };
   const handleDeleteReview = (
     deleteReview: DeleteMutationFn,
@@ -122,7 +122,7 @@ export default function ReviewsIsland(props: Props) {
     }
 
   };
-  const renderReview = (user: CurrentUserQuery_me | null | undefined, hash: string, siteViewUrl: string) => (
+  const renderReview = () => (
     review: ReviewsPageFragment
   ) => {
     let meta = {};
@@ -159,7 +159,7 @@ export default function ReviewsIsland(props: Props) {
                 <ButtonsWrapper>
                   <ThemedButton
                     style={{ marginRight: 10 }}
-                    onClick={() => handleEditReview(review.id, hash, siteViewUrl)}>
+                    onClick={() => handleEditReview(review.id)}>
                     Edit
                 </ThemedButton>
 
@@ -183,22 +183,16 @@ export default function ReviewsIsland(props: Props) {
   };
 
   const renderReviews = (reviews: ReviewsPageFragment[]) => {
-    const hash = new URLSearchParams(history.location.search)
-      .getAll('hash')
-      .toString();
-    const siteViewUrl = new URLSearchParams(history.location.search)
-      .getAll('sv')
-      .toString();
     return (
 
       <>
         <div style={{ display: 'flex' }}>
-          <WriteReviewButton onClick={() => handleWriteReview(hash, siteViewUrl)}>
+          <WriteReviewButton onClick={() => handleWriteReview()}>
             Write a review
                 </WriteReviewButton>
         </div>
         <Table striped bordered>
-          <tbody>{reviews.map(renderReview(user, hash, siteViewUrl))}</tbody>
+          <tbody>{reviews.map(renderReview())}</tbody>
         </Table>
       </>
 

--- a/front/src/containers/Islands/WikiPageIsland.tsx
+++ b/front/src/containers/Islands/WikiPageIsland.tsx
@@ -17,7 +17,7 @@ import QUERY from 'queries/WikiPageQuery';
 import { useQuery, useMutation } from 'react-apollo';
 import { useSite } from 'containers/SiteProvider/SiteProvider';
 import { useCurrentUser } from 'containers/CurrentUser/CurrentUser';
-import useUrlParams from 'utils/UrlParamsProvider';
+import useUrlParams, {queryStringAll} from 'utils/UrlParamsProvider';
 import { useHistory, useLocation, useRouteMatch } from "react-router-dom";
 import CrowdPage from 'containers/CrowdPage';
 import { BeatLoader } from 'react-spinners';
@@ -60,9 +60,6 @@ export default function WikiPageIsland(props: Props) {
   const { currentSiteView } = useSite();
   const user = useCurrentUser()?.data?.me;
   const params = useUrlParams()
-  const hash = params.hash
-  const siteViewUrl = params.sv
-
   // TODO: This query should be pushed up as a fragment to the Page
   const { data: studyData } = useQuery<WikiPageQuery>(QUERY, {
     variables: { nctId },
@@ -96,7 +93,7 @@ export default function WikiPageIsland(props: Props) {
     historyExpanded[editId] = value;
     setHistoryExpanded(historyExpanded);
   };
-  const handlePreview = (hash: string, siteViewUrl: string) => {
+  const handlePreview = () => {
     if (editorState === 'plain') {
       const text = getEditorText() || '';
 
@@ -106,7 +103,7 @@ export default function WikiPageIsland(props: Props) {
     }
 
     history.push(
-      `${match.url}?hash=${hash}&sv=${siteViewUrl}`
+      `${match.url}${queryStringAll(params)}`
     );
   };
 
@@ -155,23 +152,23 @@ export default function WikiPageIsland(props: Props) {
     // });
   };
 
-  const handleEdit = (hash: string, siteViewUrl: string) => {
+  const handleEdit = () => {
     history.push(
       `${trimPath(
         match.url
-      )}/wiki/edit?hash=${hash}&sv=${siteViewUrl}`
+      )}/wiki/edit${queryStringAll(params)}`
     );
   };
-  const handleHistory = (hash: string, siteViewUrl: string) => {
+  const handleHistory = () => {
     history.push(
       `${trimPath(
         match.url
-      )}/wiki/history?hash=${hash}&sv=${siteViewUrl}`
+      )}/wiki/history${queryStringAll(params)}`
     );
   };
-  const handleView = (hash: string, siteViewUrl: string) => {
+  const handleView = () => {
     history.push(
-      `${trimPath(match.url)}?hash=${hash}&sv=${siteViewUrl}`
+      `${trimPath(match.url)}${queryStringAll(params)}`
     );
   };
   const handleEditSubmit = (
@@ -208,15 +205,13 @@ export default function WikiPageIsland(props: Props) {
   };
   const renderEditButton = (
     isAuthenticated: boolean,
-    hash: string,
-    siteViewUrl: string
   ) => {
     if (!isAuthenticated) return null;
 
     return (
       <ThemedButton
         type="button"
-        onClick={() => handleEdit(hash, siteViewUrl)}
+        onClick={() => handleEdit()}
         style={{ marginLeft: '10px' }}>
         Edit <FontAwesome name="edit" />
       </ThemedButton>
@@ -225,8 +220,6 @@ export default function WikiPageIsland(props: Props) {
   const renderToolbar = (
     data: WikiPageQuery,
     user: CurrentUserQuery_me | null | undefined,
-    hash: string,
-    siteViewUrl: string,
     readOnly: boolean
   ) => {
     const isAuthenticated = user !== null;
@@ -245,7 +238,7 @@ export default function WikiPageIsland(props: Props) {
                 {renderMarkdownButton()}{' '}
                 <ThemedButton
                   type="button"
-                  onClick={() => handlePreview(hash, siteViewUrl)}
+                  onClick={() => handlePreview()}
                   style={{ marginLeft: '10px' }}>
                   Preview <FontAwesome name="photo" />
                 </ThemedButton>
@@ -256,7 +249,7 @@ export default function WikiPageIsland(props: Props) {
           <Route
             render={() => (
               <>
-                {renderEditButton(isAuthenticated, hash, siteViewUrl)}
+                {renderEditButton(isAuthenticated)}
                 {renderSubmitButton(data, isAuthenticated, readOnly)}
               </>
             )}
@@ -325,7 +318,7 @@ export default function WikiPageIsland(props: Props) {
           <Switch>
             <Route render={() => renderEditor(studyData)} />
           </Switch>
-          {renderToolbar(studyData, user, hash, siteViewUrl, readOnly)}
+          {renderToolbar(studyData, user, readOnly)}
         </div>
       </StyledPanel>
     </div>

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -824,26 +824,24 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
     }
     return " "
   }
-  iconColor = (descIcon: boolean) => {
-    if (descIcon == true && this.sortDesc() == true) {
-      return this.props.theme.button
-    }
-    if (descIcon == false && this.sortDesc() == false) {
-      return this.props.theme.button
-    }
-    return "#c0c3c5"
-  }
   renderSortIcons = () => {
+    let isDesc = this.props.params.sorts[0].desc
     return (
+
       <div onClick={() => this.reverseSort()} style={{ display: 'flex', marginTop: 'auto', marginBottom: 'auto', cursor: 'pointer' }} >
-        <FontAwesome
-          name={'sort-amount-asc'}
-          style={{ color: this.iconColor(false), fontSize: '26px' }}
-        />
-        <FontAwesome
-          name={'sort-amount-desc'}
-          style={{ color: this.iconColor(true), fontSize: '26px' }}
-        />
+        {isDesc ? (
+          <FontAwesome
+            name={'sort-amount-desc'}
+            style={{ color: this.props.theme.button, fontSize: '26px' }}
+          />) : (
+            <FontAwesome
+              name={'sort-amount-asc'}
+              style={{ color: this.props.theme.button, fontSize: '26px' }}
+            />
+          )
+        }
+
+
       </div>
     )
   }
@@ -855,9 +853,6 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
       }
       return " "
     }
-
-
-
 
     return (
       <div style={{ display: 'flex', flexDirection: 'row', marginRight: '-30px' }}>


### PR DESCRIPTION
-Previously refactored navigation to use a new querystring all function to build the querystring wherever we need to push to a new link. This also implements on additional islands(wikipage, reviews) who also use the querystring. 
-additionally adds a new css class that can be accessed in the MM component to render certain islands in one line. See screenshots to see how to implement

![Screen Shot 2020-08-04 at 3 36 08 PM](https://user-images.githubusercontent.com/17464571/89344526-a2d60080-d66b-11ea-98b4-9b9a8a9f412c.png)
