### PR TITLE
fix issue #701

### DIFF
--- a/front/src/containers/SearchPage/components/MasonryCards.tsx
+++ b/front/src/containers/SearchPage/components/MasonryCards.tsx
@@ -79,7 +79,7 @@ class MasonryCards extends React.Component<MasonryCardsProps, MasonryCardsState>
   render() {
     if (this.props.data) {
       const listItems = this.props.data;
-      let rowHeight = 150;
+      let rowHeight = listItems.length < 3 ? 400 : 150;
       let height = rowHeight * listItems.length;
       return (
 


### PR DESCRIPTION
fixes #701  card(row) height bug when there's only 1 or 2 cards in search results.

![701-CardHeight](https://user-images.githubusercontent.com/45049806/90282826-acfaba80-de34-11ea-9646-90c55ee14489.gif)
