### PR TITLE
fix for buttons search results

### DIFF
--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -417,6 +417,7 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
     const buttonsArray = currentSiteView.search.results.buttons.items.filter(
       button => button.target.length > 0 && button.icon.length > 0
     );
+    console.log("BUTTONS ARRAY", buttonsArray);
     return (
       <SiteProvider>
         {site => {
@@ -562,6 +563,15 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
     switch (resultsType) {
       case 'masonry':
         return (
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    justifyContent: 'flex-end',
+                  }}>
+                {this.renderViewDropdown()}
+              </div>
           <AutoSizer>
             {({ height, width }) => (
               <MasonryCards
@@ -573,9 +583,19 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
               />
             )}
           </AutoSizer>
+            </div>
         );
       case 'list':
         return (
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    justifyContent: 'flex-end',
+                  }}>
+                {this.renderViewDropdown()}
+              </div>
           <AutoSizer>
             {({ height, width }) => (
               <ListCards
@@ -587,9 +607,19 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
               />
             )}
           </AutoSizer>
+            </div>
         );
       case 'table2':
         return (
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    justifyContent: 'flex-emd',
+                  }}>
+                {this.renderViewDropdown()}
+              </div>
           <AutoSizer>
             {({ height, width }) => (
               <TableRV
@@ -601,6 +631,7 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
               />
             )}
           </AutoSizer>
+            </div>
         );
       default:
         //Everything in this default case is to handle the old table view and card view

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -417,7 +417,6 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
     const buttonsArray = currentSiteView.search.results.buttons.items.filter(
       button => button.target.length > 0 && button.icon.length > 0
     );
-    console.log("BUTTONS ARRAY", buttonsArray);
     return (
       <SiteProvider>
         {site => {
@@ -425,11 +424,13 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
             return (
               <ButtonGroup>
                 {buttonsArray.map((button, index) => (
-                  <ThemedButton
-                    href={`/search?hash=${this.props.searchHash}&sv=${button.target}`}
-                    key={button.target + index}>
-                    {this.renderViewButton(button.icon)}
-                  </ThemedButton>
+                  <a href={`/search?hash=${this.props.searchHash}&sv=${button.target}`}
+                     key={button.target + index}
+                  >
+                    <ThemedButton>
+                      {this.renderViewButton(button.icon)}
+                    </ThemedButton>
+                  </a>
                 ))}
               </ButtonGroup>
             );

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -422,17 +422,19 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
         {site => {
           if (site.siteViews.length > 0 && buttonsArray.length > 0) {
             return (
-              <ButtonGroup>
-                {buttonsArray.map((button, index) => (
-                  <a href={`/search?hash=${this.props.searchHash}&sv=${button.target}`}
-                     key={button.target + index}
-                  >
-                    <ThemedButton>
-                      {this.renderViewButton(button.icon)}
-                    </ThemedButton>
-                  </a>
-                ))}
-              </ButtonGroup>
+              <div style={{ marginLeft: "auto", marginBottom: "1rem" }}  >
+                <ButtonGroup>
+                  {buttonsArray.map((button, index) => (
+                    <a href={`/search?hash=${this.props.searchHash}&sv=${button.target}`}
+                       key={button.target + index}
+                    >
+                      <ThemedButton>
+                        {this.renderViewButton(button.icon)}
+                      </ThemedButton>
+                    </a>
+                  ))}
+                </ButtonGroup>
+              </div>
             );
           }
           return null;


### PR DESCRIPTION
resolves #657. Search results renders the configured buttons to the different site views, button destination target links are working now and style consistent in all views w/ buttons located on top right side.
