### PR TITLE
703 and 657 Page view fragment in site provider & pv in querystring

### DIFF
--- a/front/src/containers/SearchPage/SearchPage.tsx
+++ b/front/src/containers/SearchPage/SearchPage.tsx
@@ -723,17 +723,23 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     return response;
   };
   updateSearchParams = async (params) => {
-    this.setState({	
-      ...this.state,	
-      params: { ...(this.state?.params || {}), ...params },	
+    this.setState({
+      ...this.state,
+      params: { ...(this.state?.params || {}), ...params },
     });
     const variables = { ...this.state.params, ...params };
     const { data } = await this.props.mutate({ variables });
     const searchQueryString = new URLSearchParams(
       this.props.history.location.search
     );
+    //console.log("SITE PARAMS", this.props.site);
     const siteViewUrl = searchQueryString.getAll('sv').toString() || 'default';
-    const pageViewUrl = searchQueryString.getAll('pv').toString() || 'default';
+    // This assumes that the site provider is not the passing a url into the page
+    // view fragment portion of the query otherwise we would need to call the
+    //  page view query without passing the url into it to retrieve the default url
+    // @ts-ignored
+    const defaultPageView = this.props.site.pageView.url;
+    const pageViewUrl = searchQueryString.getAll('pv').toString() || defaultPageView;
     const userId = searchQueryString.getAll('uid').toString();
 
     if (data?.provisionSearchHash?.searchHash?.short) {
@@ -950,7 +956,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
             component={SearchStudyPage}
           />
           <Route
-            path={`/bulk`}	
+            path={`/bulk`}
             component={BulkEditPage}
           /> */}
           <Route

--- a/front/src/containers/SearchPage/SearchPage.tsx
+++ b/front/src/containers/SearchPage/SearchPage.tsx
@@ -732,13 +732,11 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     const searchQueryString = new URLSearchParams(
       this.props.history.location.search
     );
-    //console.log("SITE PARAMS", this.props.site);
     const siteViewUrl = searchQueryString.getAll('sv').toString() || 'default';
-    // This assumes that the site provider is not the passing a url into the page
+    // This assumes that the site provider is not passing a url into the page
     // view fragment portion of the query otherwise we would need to call the
     //  page view query without passing the url into it to retrieve the default url
-    // @ts-ignored
-    const defaultPageView = this.props.site.pageView.url;
+    const defaultPageView = this.props.site.pageView!.url;
     const pageViewUrl = searchQueryString.getAll('pv').toString() || defaultPageView;
     const userId = searchQueryString.getAll('uid').toString();
 

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -52,6 +52,7 @@ import {
   Masonry,
 } from 'react-virtualized';
 import aggToField from 'utils/aggs/aggToField';
+import useUrlParams from "../../utils/UrlParamsProvider";
 
 const QUERY = gql`
   query SearchPageSearchQuery(
@@ -417,6 +418,7 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
     const buttonsArray = currentSiteView.search.results.buttons.items.filter(
       button => button.target.length > 0 && button.icon.length > 0
     );
+    const queryString = useUrlParams();
     return (
       <SiteProvider>
         {site => {
@@ -425,7 +427,7 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
               <div style={{ marginLeft: "auto", marginBottom: "1rem" }}  >
                 <ButtonGroup>
                   {buttonsArray.map((button, index) => (
-                    <a href={`/search?hash=${this.props.searchHash}&sv=${button.target}`}
+                    <a href={`/search?hash=${this.props.searchHash}&sv=${button.target}&pv=${queryString.pv}`}
                        key={button.target + index}
                     >
                       <ThemedButton>

--- a/front/src/containers/SiteProvider/SiteProvider.tsx
+++ b/front/src/containers/SiteProvider/SiteProvider.tsx
@@ -257,6 +257,17 @@ export const SITE_VIEW_FRAGMENT = gql`
   ${SITE_STUDY_PAGE_FRAGMENT}
 `;
 
+
+export const PAGE_VIEW_FRAGMENT = gql`
+  fragment PageViewFragment on PageView {
+    id
+    url
+    title
+    default
+    template
+    pageType
+  }
+`;
 export const SITE_FRAGMENT = gql`
   fragment SiteFragment on Site {
     id
@@ -278,9 +289,13 @@ export const SITE_FRAGMENT = gql`
     siteViews {
       ...SiteViewFragment
     }
+    pageView{
+      ...PageViewFragment
+    }
   }
 
   ${SITE_VIEW_FRAGMENT}
+  ${PAGE_VIEW_FRAGMENT}
 `;
 
 const QUERY = gql`

--- a/front/src/types/CreateSiteMutation.ts
+++ b/front/src/types/CreateSiteMutation.ts
@@ -741,6 +741,16 @@ export interface CreateSiteMutation_createSite_site_siteViews {
   search: CreateSiteMutation_createSite_site_siteViews_search;
 }
 
+export interface CreateSiteMutation_createSite_site_pageView {
+  __typename: "PageView";
+  id: number;
+  pageType: string;
+  template: string;
+  title: string;
+  url: string;
+  default: boolean;
+}
+
 export interface CreateSiteMutation_createSite_site {
   __typename: "Site";
   id: number;
@@ -754,6 +764,7 @@ export interface CreateSiteMutation_createSite_site {
   owners: CreateSiteMutation_createSite_site_owners[];
   siteView: CreateSiteMutation_createSite_site_siteView;
   siteViews: CreateSiteMutation_createSite_site_siteViews[];
+  pageView: CreateSiteMutation_createSite_site_pageView | null;
 }
 
 export interface CreateSiteMutation_createSite {

--- a/front/src/types/SiteFragment.ts
+++ b/front/src/types/SiteFragment.ts
@@ -741,6 +741,16 @@ export interface SiteFragment_siteViews {
   search: SiteFragment_siteViews_search;
 }
 
+export interface SiteFragment_pageView {
+  __typename: "PageView";
+  id: number;
+  pageType: string;
+  template: string;
+  title: string;
+  url: string;
+  default: boolean;
+}
+
 export interface SiteFragment {
   __typename: "Site";
   id: number;
@@ -754,4 +764,5 @@ export interface SiteFragment {
   owners: SiteFragment_owners[];
   siteView: SiteFragment_siteView;
   siteViews: SiteFragment_siteViews[];
+  pageView: SiteFragment_pageView | null;
 }

--- a/front/src/types/SiteProviderQuery.ts
+++ b/front/src/types/SiteProviderQuery.ts
@@ -741,6 +741,16 @@ export interface SiteProviderQuery_site_siteViews {
   search: SiteProviderQuery_site_siteViews_search;
 }
 
+export interface SiteProviderQuery_site_pageView {
+  __typename: "PageView";
+  id: number;
+  pageType: string;
+  template: string;
+  title: string;
+  url: string;
+  default: boolean;
+}
+
 export interface SiteProviderQuery_site {
   __typename: "Site";
   id: number;
@@ -754,6 +764,7 @@ export interface SiteProviderQuery_site {
   owners: SiteProviderQuery_site_owners[];
   siteView: SiteProviderQuery_site_siteView;
   siteViews: SiteProviderQuery_site_siteViews[];
+  pageView: SiteProviderQuery_site_pageView | null;
 }
 
 export interface SiteProviderQuery {

--- a/front/src/types/UpdateSiteMutation.ts
+++ b/front/src/types/UpdateSiteMutation.ts
@@ -741,6 +741,16 @@ export interface UpdateSiteMutation_updateSite_site_siteViews {
   search: UpdateSiteMutation_updateSite_site_siteViews_search;
 }
 
+export interface UpdateSiteMutation_updateSite_site_pageView {
+  __typename: "PageView";
+  id: number;
+  pageType: string;
+  template: string;
+  title: string;
+  url: string;
+  default: boolean;
+}
+
 export interface UpdateSiteMutation_updateSite_site {
   __typename: "Site";
   id: number;
@@ -754,6 +764,7 @@ export interface UpdateSiteMutation_updateSite_site {
   owners: UpdateSiteMutation_updateSite_site_owners[];
   siteView: UpdateSiteMutation_updateSite_site_siteView;
   siteViews: UpdateSiteMutation_updateSite_site_siteViews[];
+  pageView: UpdateSiteMutation_updateSite_site_pageView | null;
 }
 
 export interface UpdateSiteMutation_updateSite {


### PR DESCRIPTION
Page view fragment in site provider, page view is pulled from page view query instead of hardcoded
 related to 657 button is now using the current page’s querystring to keep same pv= after navigating to the target site view.