### PR TITLE
710 additional icons

### DIFF
--- a/front/src/components/SiteForm/SearchForm.tsx
+++ b/front/src/components/SiteForm/SearchForm.tsx
@@ -383,7 +383,7 @@ class SearchForm extends React.Component<SearchFormProps, SearchFormState> {
   };
 
   renderResultsButtons = view => {
-    let ICONS = ['table', 'card', 'search'];
+    let ICONS = ['table', 'card', 'search', 'list', 'small masonry', 'large masonry'];
     let buttonsArray = view.search.results.buttons.items;
     let siteViews = this.props.siteViews;
     let thisSiteView =

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -450,6 +450,15 @@ class SearchView2 extends React.Component<SearchView2Props, SearchView2State> {
         return <TableIcon />;
       case 'search':
         return <FontAwesome name="search" />;
+      case 'list':
+        return <FontAwesome name="th-list"
+                            style={{ fontSize: '1.8rem' }} />;
+      case 'small masonry':
+        return <FontAwesome name="th"
+                            style={{ fontSize: '1.8rem' }} />;
+      case 'large masonry':
+        return <FontAwesome name="th-large"
+                            style={{ fontSize: '1.8rem' }} />;
       default:
         return null;
     }


### PR DESCRIPTION
resolves #710 , adds additional icon choices for results view buttons; list, small masonry and large masonry cards

list, small masonry and large masonry cards icons in order.
![image](https://user-images.githubusercontent.com/45049806/91096385-910ccb00-e623-11ea-8e18-949d92bcda76.png)
