### PR TITLE
Add loader.io domain verification file for load testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,30 @@ node_modules
 entrypoint.lock
 .docker-sync
 tmp
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,5 +53,6 @@ Rails.application.routes.draw do
     end
   end
 
+  get "/loaderio-8d814a5de952773390cc25ce466a6b68.txt", to: static("loaderio-8d814a5de952773390cc25ce466a6b68.txt")
   match "*all", to: static("index.html"), via: [:get]
 end

--- a/public/loaderio-8d814a5de952773390cc25ce466a6b68.txt
+++ b/public/loaderio-8d814a5de952773390cc25ce466a6b68.txt
@@ -1,0 +1,1 @@
+loaderio-8d814a5de952773390cc25ce466a6b68


### PR DESCRIPTION
- Add loader.io domain verification file
- Add standard `.gitignore` files for macOS