### PR TITLE
Change loader.io domain verification key to the one for www subdomain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,28 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
   end
 
   # loader.io domain verifcation for load testing
-  get "/loaderio-f076138abbb7fbc078ad112a429b504f.txt", to: static("loaderio-f076138abbb7fbc078ad112a429b504f.txt")
+  get "/loaderio-21df9bee0c48bbdb7696ea087e1c5492.txt", to: static("loaderio-21df9bee0c48bbdb7696ea087e1c5492.txt")
 
   match "*all", to: static("index.html"), via: [:get]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,8 @@ Rails.application.routes.draw do
     end
   end
 
-  get "/loaderio-8d814a5de952773390cc25ce466a6b68.txt", to: static("loaderio-8d814a5de952773390cc25ce466a6b68.txt")
+  # loader.io domain verifcation for load testing
+  get "/loaderio-f076138abbb7fbc078ad112a429b504f.txt", to: static("loaderio-f076138abbb7fbc078ad112a429b504f.txt")
+
   match "*all", to: static("index.html"), via: [:get]
 end

--- a/public/loaderio-21df9bee0c48bbdb7696ea087e1c5492.txt
+++ b/public/loaderio-21df9bee0c48bbdb7696ea087e1c5492.txt
@@ -1,0 +1,1 @@
+loaderio-21df9bee0c48bbdb7696ea087e1c5492

--- a/public/loaderio-8d814a5de952773390cc25ce466a6b68.txt
+++ b/public/loaderio-8d814a5de952773390cc25ce466a6b68.txt
@@ -1,1 +1,0 @@
-loaderio-8d814a5de952773390cc25ce466a6b68

--- a/public/loaderio-f076138abbb7fbc078ad112a429b504f.txt
+++ b/public/loaderio-f076138abbb7fbc078ad112a429b504f.txt
@@ -1,1 +1,0 @@
-loaderio-f076138abbb7fbc078ad112a429b504f

--- a/public/loaderio-f076138abbb7fbc078ad112a429b504f.txt
+++ b/public/loaderio-f076138abbb7fbc078ad112a429b504f.txt
@@ -1,0 +1,1 @@
+loaderio-f076138abbb7fbc078ad112a429b504f


### PR DESCRIPTION
- Change loader.io domain verification key to the one for www subdomain
- Add standard `.gitignore` files for Windows