### PR TITLE
Open about us in new tab

### DIFF
--- a/front/src/components/AuthHeader/AuthHeader.tsx
+++ b/front/src/components/AuthHeader/AuthHeader.tsx
@@ -80,7 +80,7 @@ export class AuthHeader extends React.PureComponent<AuthHeaderProps> {
                 href="https://home.clinwiki.org/make-a-donation/">
                 Donate
               </NavItem>
-              <NavItem eventKey={1} href="https://home.clinwiki.org/">
+              <NavItem eventKey={1} href="https://home.clinwiki.org/" target="_blank">
                 About ClinWiki
               </NavItem>
               <Row>


### PR DESCRIPTION
@awestermann Since the about page isn't part of the application really, I think it makes sense to open it in a new tab even if the app is not inside an iframe.