### PR TITLE
Remove Vagrant instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ You can use one of the following options to start ClinWiki on your own system:
 - [Docker Compose](#docker-compose) (easiest method)
 - [Locally in development mode](#run-locally)
 - [Locally in production mode](#run-locally-in-production-mode)
-- [Vagrant](#vagrant)
 
 ### Docker Compose
 
@@ -156,54 +155,6 @@ mode.
     ```bash
     export $(cat .env | xargs) && RAILS_ENV=production rails s
     ```
-
-### Vagrant
-
-Make sure you have a copy of `cw-app` located as a sibling of the root project
-directory.
-
-You can once you've installed [vagrant](https://www.vagrantup.com/),
-you can install the vagrant VM by running `vagrant up` from the project
-root directory.
-
-You can access the vagrant instance via `vagrant ssh`.
-
-The following scripts are available
-
-| Script                       | Function                                                      |
-| ---------------------------- | ------------------------------------------------------------- |
-| `./scripts/vagrant/server`   | runs the server through vagrant, serving the API at port 3000 |
-| `./scripts/vagrant/worker`   | runs the worker within the vagrant server                     |
-| `./scripts/vagrant/frontend` | runs a hot-reloading version of the frontend                  |
-
-#### Initializing Data
-
-We have already enqueued several tasks for the worker to run while
-provisioning Vagrant, but you will need to make sure to run the worker
-for those jobs to be handled.
-
-#### Running the Server
-
-In one vagrant SSH session, you will want to run the following:
-
-```bash
-cd /clinwki
-./scripts/server
-```
-
-This will expose `localhost:3000` to API requests.
-
-From another session, run the following:
-
-```bash
-cd /cw-app
-yarn start
-```
-
-This will run a hot-reloading session of the cw-app frontend.
-
-To make sure reindexing and the like are handled on save,
-make sure to run `./scripts/worker` in a separate session as well.
 
 ## Admin & Sites Setup
 


### PR DESCRIPTION
Removing Vagrant instructions from `README.md` as discussed with @rodctech and @Tonyynot14 . The project does not have a Vagrantfile so I'm assuming this was left in by accident.