### PR TITLE
Only loads requested facets

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -33,7 +33,7 @@ module Types
     end
 
     field :crowd_agg_facets, SearchResultSetType, null: false do
-      # argument :params, type: SearchInputType, required: false
+       argument :crowd_buckets_wanted, [String], required: false
     end
     field :health, HealthType, null: false
     field :site, SiteType, "If id is missing, returns current site. If id == 0, returns default site", null: true do
@@ -101,8 +101,10 @@ module Types
       )
     end
 
-    def crowd_agg_facets(search_hash: nil, params: nil)
+    def crowd_agg_facets(search_hash: nil, params: nil, crowd_buckets_wanted: nil)
       params = fetch_and_merge_search_params(search_hash: search_hash, params: params)
+
+      params[:crowd_buckets_wanted] = crowd_buckets_wanted
       params[:page_size] = 999999
       search_service = SearchService.new(params)
       Hashie::Mash.new(

--- a/app/services/search_service.rb
+++ b/app/services/search_service.rb
@@ -274,6 +274,7 @@ class SearchService
   def crowd_agg_facets(site:)
     params = self.params.deep_dup
     return {} if params.nil?
+  
 
     search_results = Study.search("*", aggs: [:front_matter_keys])
 
@@ -281,6 +282,9 @@ class SearchService
     keys = aggs[:front_matter_keys][:buckets]
       .map { |x| (x[:key]).to_s }
     facets = {}
+    if  self.params.dig(:crowd_buckets_wanted)
+      keys.select!{|key| self.params[:crowd_buckets_wanted]&.include?(key)}
+    end
     keys.each do |key|
       field_agg = agg_buckets_for_field(field: key, current_site: site, is_crowd_agg: true)
       field_agg.each do |name, agg|


### PR DESCRIPTION
Only load buckets for requested crowd agg facets. Originally crowd_agg_facets had params commented out I believe because SearchInputType requires so many different fields. I just added a new argument with a array that is processed inside of the search_service.rb file. 