### PR TITLE
CW-7  update client-side query to pass params to filter crowd facets

### DIFF
--- a/front/src/containers/WorkflowPage/SuggestedLabels.tsx
+++ b/front/src/containers/WorkflowPage/SuggestedLabels.tsx
@@ -35,8 +35,8 @@ interface SuggestedLabelsProps {
 }
 
 const QUERY = gql`
-  query SuggestedLabelsQuery($nctId: String!) {
-    crowdAggFacets {
+  query SuggestedLabelsQuery($nctId: String!, $crowdBucketsWanted: [String!]) {
+    crowdAggFacets(crowdBucketsWanted: $crowdBucketsWanted) { 
       aggs {
         name
         buckets {
@@ -152,6 +152,7 @@ class SuggestedLabels extends React.PureComponent<
         query={QUERY}
         variables={{
           nctId: this.props.nctId,
+          crowdBucketsWanted: this.props.allowedSuggestedLabels
         }}>
         {({ data, loading, error, refetch }) => {
           if (loading || error || !data) return null;

--- a/front/src/types/SuggestedLabelsQuery.ts
+++ b/front/src/types/SuggestedLabelsQuery.ts
@@ -47,4 +47,5 @@ export interface SuggestedLabelsQuery {
 
 export interface SuggestedLabelsQueryVariables {
   nctId: string;
+  crowdBucketsWanted: (string | null)[];
 }


### PR DESCRIPTION
completes #CW-7 adjusts client side to get needed crowd buckets values from state and adds the crowd buckets wanted as arguments to the query