### PR TITLE
v1.0.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to ClinWiki
 
-## Found a bug?
+## Reporting Bugs
 
 Bug reports are welcome. Please try to be as specific as possible so we can reproduce the problem.
 
@@ -10,86 +10,26 @@ Bug reports are welcome. Please try to be as specific as possible so we can repr
 
 - Do not open a bug if study data is wrong. Instead consider _using_ the wiki features to correct or annotate the study.
 
-## Local Development
-
-Ready to fix a bug or add a feature? This section will get a development copy of ClinWiki running on your local Windows/Mac/Linux system in a snap.
-
-The easiest way to start ClinWiki on your own system is to use [docker-compose](https://docs.docker.com/compose/).
-
-- Clone the clinwiki repository
-- Install Docker
-  - Windows and Mac users install [Docker Desktop](https://www.docker.com/products/docker-desktop)
-  - Linux users follow the [official install instructions for Docker for your distribution](https://docs.docker.com/install/#supported-platforms)
-- **Note: if you're using OS X, you will want to run docker-compose commands with `-f docker-compose.yml -f docker-compose-osx.yml`**. Install `docker-sync` via `gem install docker-sync` and then run `docker-sync start --config=docker-sync.yml` in a separate terminal. This will fix file mounting issues in OS X and Docker that create significant performance problems using the default config.
-- `docker-compose build`
-- `docker-compose up` or `docker-compose up -d` to run as daemon in background
-- `compose/bin/search_bootstrap`
-- Now you should have the ClinWiki server running on http://localhost:3000
-- Extras
-  - Logs: `docker-compose logs -f clinwiki`
-  - Console: `docker-compose exec clinwiki bundle exec rails c`
-  - Run and build: `docker-compose up -d --build`
-    The front end is not built yet so you will only see the rails start page but you can browse to http://localhost:3000/graphiql to send graphql queries.
-- cd /front
-  - yarn install
-  - yarn start
-  - This will build the ClinWiki front end and serve it on http://localhost:3001
-  - Changes to local .ts/.tsx files will be automatically applied to the running system
-
-### CW_MODE
-
-You can use the CW_MODE environment variable to configure how docker-compose starts ClinWiki.
-
-- CW_MODE=PROD - the default, builds the front end and runs rails
-- CW*MODE=FAST - runs rails \_without* building the front end for a quicker startup
-- CW_MODE=DEV - starts the 'clinwiki' container without running rails so you can start/restart it manually during development
-- CW_MODE=WORKER - runs the sidekiq process instead of rails
-
-To specify the variable changes the command line a little bit depending on if you're on Windows or Linux/Mac:
-
-_Linux/Mac:_
-
-```
-CW_MODE=FAST docker-compose up -d
-```
-
-_Windows:_
-
-```
-set CW_MODE=FAST
-docker-compose up -d
-```
+Ready to fix a bug or add a feature? The [README.md](README.md) will get a development copy of ClinWiki running on your local Windows/Mac/Linux system in a snap.
 
 ## Branch Strategy
 
-```
+```bash
 master ◀ staging ◀ feature 1
                  ◀ feature 2
                  ◀ feature 3
 ```
 
-The master branch is always in a ready to deploy state and matches what is running on https://www.clinwiki.org.
+The master branch is always in a ready to deploy state and matches what is running on <https://www.clinwiki.org>.
 
-Weekly completed feature branches are merged to the staging branch and then staging is deployed to https://staging.clinwiki.org and manual tests are run to ensure no regressions from the previous version. The only time it makes sense to commit directly to the staging branch is to fix small bugs found during this testing phase. Once testing is complete staging gets pulled to master and deployed.
+Weekly completed feature branches are merged to the staging branch and then staging is deployed to <https://staging.clinwiki.org> and manual tests are run to ensure no regressions from the previous version. The only time it makes sense to commit directly to the staging branch is to fix small bugs found during this testing phase. Once testing is complete staging gets pulled to master and deployed.
 
 To contribute a new feature or bug fix create a new branch off of the current staging (or master) and implement the feature. Then open a pull request to the staging branch.
 
 - If the pull request is only for review but not quite ready yet prepend "WIP" or "work in progress" to the front of the title so it doesn't get accidently merged on merge day.
 - Add a new entry to ReleaseNotes/index.tsx describing your change or bugfix. Don't worry too much about having the "right" version as we will fix it up when it merges to staging.
 
-## Admin
-
-To access the sub-site config and bulk update admin features, add admin role after creating a user
-In rails console, User.find_by(email: "[email of the user]").add_role(:admin)
-
-## Working with Sites
-
-Sites can be accessed locally by navigating to a subdomain against your localhost.
-By default, `http://mysite.localhost:3001` and `http://test.localhost:3001` are
-white-listed for CORS requests. This means you can configure a site with the subdomain
-`mysite` and a site with the subdomain `test` without additional CORS configuration.
-
-# Testing
+## Testing
 
 ClinWiki is working on increasing unit test coverage.
 
@@ -117,7 +57,7 @@ in `config/environments/test.rb'
 We use AWS for storing CSV exports in S3.
 You will need the following in your .env to develop against this locally:
 
-```
+```bash
 AWS_ACCESS_KEY_ID=(ask for this)
 AWS_SECRET_ACCESS_KEY_ID=(ask for this)
 ```

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,8 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.6)
     jwt (2.2.1)
-    kramdown (2.0.0)
+    kramdown (2.3.0)
+      rexml
     libv8 (6.7.288.46.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -292,6 +293,7 @@ GEM
       netrc (~> 0.8)
     reverse_markdown (1.1.0)
       nokogiri
+    rexml (3.2.4)
     rolify (5.2.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ You can use one of the following options to start ClinWiki on your own system:
 
 1. To access the sub-site config and bulk update admin features, add admin role after creating a user. In Rails console, execute `User.find_by(email: "[email of the user]").add_role(:admin)`
 
-  > **NOTE**: Run this command from inside the `clinwiki` container.
+    > **NOTE**: Run this command from inside the `clinwiki` container.
 
 1. Create the default site by clicking on `Sites` under the profile dropdown on the top right hand side. Then click create site, fill out the form and click save.
 
-  > Sites can be accessed locally by navigating to a subdomain against your localhost. By default, `http://mysite.localhost:3001` and `http://test.localhost:3001` are white-listed for CORS requests. This means you can configure a site with the subdomain `mysite` and a site with the subdomain `test` without additional CORS configuration.
+    > Sites can be accessed locally by navigating to a subdomain against your localhost. By default, `http://mysite.localhost:3001` and `http://test.localhost:3001` are white-listed for CORS requests. This means you can configure a site with the subdomain `mysite` and a site with the subdomain `test` without additional CORS configuration.
 
 - Extras
   - Logs: `docker-compose logs -f clinwiki`

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ You can use one of the following options to start ClinWiki on your own system:
 
     > **NOTE:** Changes to local .ts/.tsx files will be automatically applied to the running system
 
+1. Create a new user from the UI or Rails console
+
+1. To access the sub-site config and bulk update admin features, add admin role after creating a user. In Rails console, execute `User.find_by(email: "[email of the user]").add_role(:admin)`
+
+  > **NOTE**: Run this command from inside the `clinwiki` container.
+
+1. Create the default site by clicking on `Sites` under the profile dropdown on the top right hand side. Then click create site, fill out the form and click save.
+
+  > Sites can be accessed locally by navigating to a subdomain against your localhost. By default, `http://mysite.localhost:3001` and `http://test.localhost:3001` are white-listed for CORS requests. This means you can configure a site with the subdomain `mysite` and a site with the subdomain `test` without additional CORS configuration.
+
 - Extras
   - Logs: `docker-compose logs -f clinwiki`
   - Console: `docker-compose exec clinwiki bundle exec rails c`
@@ -155,18 +165,6 @@ mode.
     ```bash
     export $(cat .env | xargs) && RAILS_ENV=production rails s
     ```
-
-## Admin & Sites Setup
-
-To access the sub-site config and bulk update admin features, add admin role after creating a user
-In rails console, `User.find_by(email: "[email of the user]").add_role(:admin)`
-
-  > **NOTE**: Run this command from inside the `clinwiki` container if you're using Docker Compose.
-
-Sites can be accessed locally by navigating to a subdomain against your localhost.
-By default, `http://mysite.localhost:3001` and `http://test.localhost:3001` are
-white-listed for CORS requests. This means you can configure a site with the subdomain
-`mysite` and a site with the subdomain `test` without additional CORS configuration.
 
 ## Data Access
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,89 @@
-# Application: clinwiki
+# ClinWiki
 
 This application allows you to rate clinical trials.
 You can retrieve trials to rank by searching for NCT ID or MeSH Term
 
-# Installation / Running
+## Setup
+
+You can use one of the following options to start ClinWiki on your own system:
+
+- [Docker Compose](#docker-compose) (easiest method)
+- [Locally in development mode](#run-locally)
+- [Locally in production mode](#run-locally-in-production-mode)
+- [Vagrant](#vagrant)
+
+### Docker Compose
+
+1. Clone the ClinWiki repository
+
+1. Install Docker
+
+    - Windows and Mac users install [Docker Desktop](https://www.docker.com/products/docker-desktop)
+
+    - Linux users follow the [official install instructions for Docker for your distribution](https://docs.docker.com/install/#supported-platforms)
+
+1. **Only for macOS:** Install and start `docker-sync`
+    - Bring up a separate terminal
+    - Install `docker-sync` via `gem install docker-sync`
+    - Run `docker-sync start --config=docker-sync.yml`
+  
+    > This will fix file mounting issues in OS X and Docker that create significant performance problems using the default config. Additionally, you will want to run the `docker-compose` commands with additional arguments (included below for each step).
+
+1. Build image
+
+    `docker-compose build`
+
+    > **macOS:** `docker-compose -f docker-compose.yml -f docker-compose-osx.yml build`
+
+1. Run ClinWiki server on <http://localhost:3000>
+
+    `ELASTIC_PASSWORD=CHANGEME docker-compose up` or `ELASTIC_PASSWORD=CHANGEME docker-compose up -d` to run as daemon in background
+
+    > **macOS:** `ELASTIC_PASSWORD=CHANGEME docker-compose -f docker-compose.yml -f docker-compose-osx.yml up` or `ELASTIC_PASSWORD=CHANGEME docker-compose -f docker-compose.yml -f docker-compose-osx.yml up -d`
+
+1. Bootstrap search
+
+    `compose/bin/search_bootstrap`
+
+1. Build and serve frontend (on <http://localhost:3001>):
+
+    - `cd /front`
+    - `yarn install`
+    - `yarn start`
+
+    > **NOTE:** Changes to local .ts/.tsx files will be automatically applied to the running system
+
+- Extras
+  - Logs: `docker-compose logs -f clinwiki`
+  - Console: `docker-compose exec clinwiki bundle exec rails c`
+  - Run and build: `docker-compose up -d --build`
+    The front end is not built yet so you will only see the rails start page but you can browse to <http://localhost:3000/graphiql> to send graphql queries.
+
+#### CW_MODE
+
+You can use the `CW_MODE` environment variable to configure how docker-compose starts ClinWiki.
+
+- `CW_MODE=PROD` - the default, builds the front end and runs rails
+- `CW_MODE=FAST` - runs rails *without* building the front end for a quicker startup
+- `CW_MODE=DEV` - starts the 'clinwiki' container without running rails so you can start/restart it manually during development
+- `CW_MODE=WORKER` - runs the sidekiq process instead of rails
+
+To specify the variable changes the command line a little bit depending on if you're on Windows or Linux/Mac:
+
+_Linux/Mac:_
+
+```bash
+CW_MODE=FAST docker-compose up -d
+```
+
+_Windows:_
+
+```bash
+set CW_MODE=FAST
+docker-compose up -d
+```
+
+### Run Locally
 
 You are encouraged to use [rvm](https://rvm.io/) for Ruby version
 and gemset management. Once RVM is installed, switch to the correct
@@ -31,19 +111,19 @@ bundle exec rails s
 Note that we are using [dotenv](https://github.com/bkeepers/dotenv)
 to make the handling of database variables easier.
 
-## Environment Variables
+#### **Environment Variables**
 
 We use a handful of environment variables to run the server.
 You can expose these when running locally by creating a `.env`
 file in the project root level directory. Here's an example:
 
 ```bash
-# needed to connect to aact
+# Needed to connect to AACT
 AACT_DATABASE_URL=postgres://aact:aact@aact-db.ctti-clinicaltrials.org:5432/aact
 REDIS_URL=redis://127.0.0.1:6379/0
 DATABASE_URL=postgres://postgres@localhost:5432/clinwiki
 
-#Optional
+# Optional
 
 JWT_EXPIRATION_TIME_SECS=86400 # JWT expiration time
 ```
@@ -52,117 +132,32 @@ JWT_EXPIRATION_TIME_SECS=86400 # JWT expiration time
 the need for a `database.yml` file in when running the server in development
 mode.
 
-# Data Access
+### Run Locally in Production Mode
 
-## Databases
+1. Create a .env file in root with the following contents
 
-The [AACT Clinical Trials Database](http://aact.ctti-clinicaltrials.org/])
-provides data the data we use for clinical trials.
+    ```bash
+    AACT_DATABASE_URL=postgres://$AACT_USER:$AACT_PASS@aact-db.ctti-clinicaltrials.org:5432/aact
+    MAILGUN_API_KEY=""
+    MAILGUN_DOMAIN="localhost:3000"
+    CW_HOST="localhost:3000"
+    CLINWIKI_DOMAIN="localhost:3000"
+    SECRET_KEY_BASE="lkdfjgldgjkdflgjlkdfjgldfkjg"
+    ```
 
-While the database is available online,
-you are encouraged to download a copy of the database for ease of access.
+1. Precompile assets
 
-We maintain a separate postgres database for data related to users.
-Please refer to the Installation section for additional info.
+    ```bash
+    export $(cat .env | xargs) && RAILS_ENV=production rake assets:precompile
+    ```
 
-If you don't have postgres installed locally, you can do so using
-[homebrew](https://brew.sh/):
+1. Start server
 
-```bash
-brew install postgres
-```
+    ```bash
+    export $(cat .env | xargs) && RAILS_ENV=production rails s
+    ```
 
-## Elasticsearch
-
-We use [searchkick](https://github.com/ankane/searchkick) to enable search.
-
-Follow the instructions in the searchkick docs for setting up Elasticsearch locally.
-
-### Indexing
-
-Indexing is performed in the background by Sidekiq. You can run Sidekiq as follows:
-
-```bash
-bundle exec sidekiq -C config/sidekiq.yml
-```
-
-Note that with about 32 concurrent workers, it should take roughly 8 hours to
-fully reindex.
-
-It's also worth noting that we run a background job every ten seconds to
-handle batch reindexing. This is important because it optimizes queries using
-ActiveRecord's `includes` functionality. Refer to the Study model's
-`search_import` scope for more details.
-
-Scheduled jobs can be configured in `./config/schedule.yml`.
-
-To disable Auto indexing set env variables for sidekiq process:
-
-```
-AUTO_INDEX_LAST_DAYS=0
-```
-
-A full reindex can be performed by running:
-
-```bash
-bundle exec rake search:index
-```
-
-A development environments can bootstrap a subset of search results as follows:
-
-```bash
-bundle exec rake search:bootstrap_dev
-```
-
-### Searching
-
-Searching for studies is handled by Searchkick through
-the Studies model. Results are directly brokered through
-the Elasticsearch index, which brokers data from
-the annotation database along with the AACT database.
-
-### Running Imports
-
-#### 1) Generate your CSV
-
-CSVs expect a header with the following format:
-`nct_id,Type,Value,Action`
-
-We support `Tag` as a type, with `Add` or `Remove` as an action.
-For crowd values, there are two types of crowd values and both can use the 'Add' and 'Remove' options.
-For native fields that are crowd overwriteable, `Add` will add or overwrite a crowd
-definition for that field, and `Remove` will remove the crowd definition.
-For crowd values that produce custom facets, the "Type" in the csv ("label" value in the UI) will be the name of the facet. The "Value" in the csv ("description" in the UI) is the value(s) in the facet. For multiple values of the crowd facet, enter as multiple lines or separated on a single line by '|' (example Type = "Karnofsky Score Allowed", Value = "100|90|80|70")
-
-#### 2) Commit your CSV to the appropriate subfolder
-
-The CSV should be exported to the `imports/` within the root project folder.
-
-You can commit the CSV with the following workflow, which assumes
-you have set up heroku's command line tools, and that the `heroku`
-remote points to the `clinwiki-prod` project:
-
-```bash
-git add imports
-git commit -m 'Added import file'  # you can write any comment you'd like
-git push origin master  # add to clinwiki-org/clinwiki
-git push heroku master  # add to heroku -- this should kick off a deploy
-```
-
-#### 3) Run the CSV import Rake task
-
-```bash
-# if your file is in imports/foo.csv, $MY_FILE should be foo.csv
-heroku run -a clinwiki-prod rake import:csv["$MY_FILE"]
-```
-
-### Running Exports
-
-```bash
-heroku run -a clinwiki-prod rake export:front_matter_csv > my-front-matter.csv
-```
-
-## Working with Vagrant
+### Vagrant
 
 Make sure you have a copy of `cw-app` located as a sibling of the root project
 directory.
@@ -181,13 +176,13 @@ The following scripts are available
 | `./scripts/vagrant/worker`   | runs the worker within the vagrant server                     |
 | `./scripts/vagrant/frontend` | runs a hot-reloading version of the frontend                  |
 
-### Initializing Data
+#### Initializing Data
 
 We have already enqueued several tasks for the worker to run while
 provisioning Vagrant, but you will need to make sure to run the worker
 for those jobs to be handled.
 
-### Running the Server
+#### Running the Server
 
 In one vagrant SSH session, you will want to run the following:
 
@@ -210,27 +205,125 @@ This will run a hot-reloading session of the cw-app frontend.
 To make sure reindexing and the like are handled on save,
 make sure to run `./scripts/worker` in a separate session as well.
 
-## Run locally in production mode
+## Admin & Sites Setup
 
-1. Create a .env file in root with the following contents
+To access the sub-site config and bulk update admin features, add admin role after creating a user
+In rails console, `User.find_by(email: "[email of the user]").add_role(:admin)`
+
+  > **NOTE**: Run this command from inside the `clinwiki` container if you're using Docker Compose.
+
+Sites can be accessed locally by navigating to a subdomain against your localhost.
+By default, `http://mysite.localhost:3001` and `http://test.localhost:3001` are
+white-listed for CORS requests. This means you can configure a site with the subdomain
+`mysite` and a site with the subdomain `test` without additional CORS configuration.
+
+## Data Access
+
+### Databases
+
+The [AACT Clinical Trials Database](http://aact.ctti-clinicaltrials.org/])
+provides data the data we use for clinical trials.
+
+While the database is available online,
+you are encouraged to download a copy of the database for ease of access.
+
+We maintain a separate postgres database for data related to users.
+Please refer to the Installation section for additional info.
+
+If you don't have postgres installed locally, you can do so using
+[homebrew](https://brew.sh/):
 
 ```bash
-AACT_DATABASE_URL=postgres://$AACT_USER:$AACT_PASS@aact-db.ctti-clinicaltrials.org:5432/aact
-MAILGUN_API_KEY=""
-MAILGUN_DOMAIN="localhost:3000"
-CW_HOST="localhost:3000"
-CLINWIKI_DOMAIN="localhost:3000"
-SECRET_KEY_BASE="lkdfjgldgjkdflgjlkdfjgldfkjg"
+brew install postgres
 ```
 
-2. Precompile assets
+### Elasticsearch
+
+We use [searchkick](https://github.com/ankane/searchkick) to enable search.
+
+Follow the instructions in the searchkick docs for setting up Elasticsearch locally.
+
+#### **Indexing**
+
+Indexing is performed in the background by Sidekiq. You can run Sidekiq as follows:
 
 ```bash
-export $(cat .env | xargs) && RAILS_ENV=production rake assets:precompile
+bundle exec sidekiq -C config/sidekiq.yml
 ```
 
-3. Start server
+Note that with about 32 concurrent workers, it should take roughly 8 hours to
+fully reindex.
+
+It's also worth noting that we run a background job every ten seconds to
+handle batch reindexing. This is important because it optimizes queries using
+ActiveRecord's `includes` functionality. Refer to the Study model's
+`search_import` scope for more details.
+
+Scheduled jobs can be configured in `./config/schedule.yml`.
+
+To disable Auto indexing set env variables for sidekiq process:
 
 ```bash
-export $(cat .env | xargs) && RAILS_ENV=production rails s
+AUTO_INDEX_LAST_DAYS=0
+```
+
+A full reindex can be performed by running:
+
+```bash
+bundle exec rake search:index
+```
+
+A development environments can bootstrap a subset of search results as follows:
+
+```bash
+bundle exec rake search:bootstrap_dev
+```
+
+#### **Searching**
+
+Searching for studies is handled by Searchkick through
+the Studies model. Results are directly brokered through
+the Elasticsearch index, which brokers data from
+the annotation database along with the AACT database.
+
+#### **Running Imports**
+
+1. Generate your CSV
+
+    CSVs expect a header with the following format:
+
+    `nct_id,Type,Value,Action`
+
+    We support `Tag` as a type, with `Add` or `Remove` as an action.
+    For crowd values, there are two types of crowd values and both can use the 'Add' and 'Remove' options.
+    For native fields that are crowd overwriteable, `Add` will add or overwrite a crowd
+    definition for that field, and `Remove` will remove the crowd definition.
+    For crowd values that produce custom facets, the "Type" in the csv ("label" value in the UI) will be the name of the facet. The "Value" in the csv ("description" in the UI) is the value(s) in the facet. For multiple values of the crowd facet, enter as multiple lines or separated on a single line by '|' (example Type = "Karnofsky Score Allowed", Value = "100|90|80|70")
+
+1. Commit your CSV to the appropriate subfolder
+
+    The CSV should be exported to the `imports/` within the root project folder.
+
+    You can commit the CSV with the following workflow, which assumes
+    you have set up heroku's command line tools, and that the `heroku`
+    remote points to the `clinwiki-prod` project:
+
+    ```bash
+    git add imports
+    git commit -m 'Added import file'  # you can write any comment you'd like
+    git push origin master  # add to clinwiki-org/clinwiki
+    git push heroku master  # add to heroku -- this should kick off a deploy
+    ```
+
+1. Run the CSV import Rake task
+
+    ```bash
+    # if your file is in imports/foo.csv, $MY_FILE should be foo.csv
+    heroku run -a clinwiki-prod rake import:csv["$MY_FILE"]
+    ```
+
+#### **Running Exports**
+
+```bash
+heroku run -a clinwiki-prod rake export:front_matter_csv > my-front-matter.csv
 ```

--- a/compose/Dockerfile
+++ b/compose/Dockerfile
@@ -1,4 +1,4 @@
-from ruby:2.5.3
+FROM ruby:2.5.3
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get update -qq && \

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,8 +53,5 @@ Rails.application.routes.draw do
     end
   end
 
-  # loader.io domain verifcation for load testing
-  get "/loaderio-21df9bee0c48bbdb7696ea087e1c5492.txt", to: static("loaderio-21df9bee0c48bbdb7696ea087e1c5492.txt")
-
   match "*all", to: static("index.html"), via: [:get]
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       - http.cors.allow-origin=http://localhost:3030,http://127.0.0.1:3030,http://localhost:1358,http://127.0.0.1:1358,https://opensource.appbase.io
       - http.cors.allow-headers=X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization
       - http.cors.allow-credentials=true
+      - xpack.security.enabled=true
+      - ELASTIC_PASSWORD=$ELASTIC_PASSWORD
     ulimits:
       memlock:
         soft: -1
@@ -42,6 +44,8 @@ services:
     container_name: kibana
     environment:
       - ELASTICSEARCH_HOSTS=http://elastic:9200/
+      - ELASTICSEARCH_USERNAME=elastic
+      - ELASTICSEARCH_PASSWORD=$ELASTIC_PASSWORD
     ports:
       - 5601:5601
   redis:
@@ -67,7 +71,7 @@ services:
       - DATABASE_URL=postgres://clinwiki:ZetIFOnXd78H@db:5432/clinwiki
       - AACT_DATABASE_URL=postgres://clinwiki:JQIhi3AGyBwl@aact.clinwiki.org:5432/aact
       - REDIS_URL=redis://redis:6379/0
-      - SEARCHBOX_URL=http://elastic:9200
+      - SEARCHBOX_URL=http://elastic:$ELASTIC_PASSWORD@elastic:9200/
       - CW_MODE=${CW_MODE}
     depends_on:
       - db
@@ -85,7 +89,7 @@ services:
       - DATABASE_URL=postgres://clinwiki:ZetIFOnXd78H@db:5432/clinwiki
       - AACT_DATABASE_URL=postgres://clinwiki:JQIhi3AGyBwl@aact.clinwiki.org:5432/aact
       - REDIS_URL=redis://redis:6379/0
-      - SEARCHBOX_URL=http://elastic:9200
+      - SEARCHBOX_URL=http://elastic:$ELASTIC_PASSWORD@elastic:9200/
       - CW_MODE=WORKER
     depends_on:
       - db

--- a/front/package.json
+++ b/front/package.json
@@ -21,6 +21,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/react-fontawesome": "^0.1.9",
+    "@fullstory/browser": "^1.4.5",
     "@iconify/icons-fe": "^1.0.5",
     "@iconify/react": "^1.1.3",
     "@testing-library/jest-dom": "^4.2.4",
@@ -78,7 +79,9 @@
     "extends": "react-app",
     "overrides": [
       {
-        "files": ["**/*.ts?(x)"],
+        "files": [
+          "**/*.ts?(x)"
+        ],
         "rules": {
           "array-callback-return": "off",
           "eqeqeq": "off"

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -33,7 +33,7 @@ import apolloClient from './configureApollo';
 // Import CSS reset and Global Styles
 import GlobalStyle from './global-styles';
 
-const orgId = process.env.REACT_APP_FULLSTORY_ID || '';
+const orgId = process.env.REACT_APP_FULLSTORY_ID || 'Q5CJJ';
 
 FullStory.init({ orgId });
 

--- a/front/src/index.tsx
+++ b/front/src/index.tsx
@@ -5,6 +5,7 @@ import 'sanitize.css/sanitize.css';
 import { BrowserRouter as Router } from 'react-router-dom';
 
 import { ApolloProvider } from 'react-apollo';
+import * as FullStory from '@fullstory/browser';
 
 // Import root app
 import App from 'containers/App';
@@ -31,6 +32,10 @@ import apolloClient from './configureApollo';
 
 // Import CSS reset and Global Styles
 import GlobalStyle from './global-styles';
+
+const orgId = process.env.REACT_APP_FULLSTORY_ID || '';
+
+FullStory.init({ orgId });
 
 const MOUNT_NODE = document.getElementById('app');
 

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -1273,6 +1273,11 @@
   dependencies:
     prop-types "^15.7.2"
 
+"@fullstory/browser@^1.4.5":
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/@fullstory/browser/-/browser-1.4.5.tgz#a8f48c65bdd0a0d53cc5b3b678b02c715156fd96"
+  integrity sha512-a1EnuwRMa9p8aNauM8rrjH+lqhX2RCo1bHOG3DGcEHXtzV+r8TDeiO8HB8kU1IjE/EXpzAGtQ2F0JMWZhvoaYg==
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"

--- a/public/loaderio-21df9bee0c48bbdb7696ea087e1c5492.txt
+++ b/public/loaderio-21df9bee0c48bbdb7696ea087e1c5492.txt
@@ -1,1 +1,0 @@
-loaderio-21df9bee0c48bbdb7696ea087e1c5492


### PR DESCRIPTION
- Add `ELASTIC_PASSWORD` as environment variable in Docker Compose
- Setup documentation updates
- Markdown linting fixing
- `kramdown` gem update from dependabot
- Add Windows and macOS files to `.gitignore`
- Open about page in new tab
- Remove loader.io from load testing (does not seem like a good long term solution)
- Remove Vagrant instructions from `README.md`
- Add instructions to local setup for creating a user, assigning the admin role and creating the default site
- [CW-10](https://clinwiki.atlassian.net/browse/CW-20) - Fullstory integration