### PR TITLE
CW-35 Fix for issues with 'Default' and 'Clear' buttons

### DIFF
--- a/front/src/containers/SearchPage/SearchPage.tsx
+++ b/front/src/containers/SearchPage/SearchPage.tsx
@@ -416,23 +416,11 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
   };
 
   handleResetFilters = (view: SiteViewFragment) => () => {
-    this.setState(
-      {
-        params: this.getDefaultParams(view, this.props.email),
-        removeSelectAll: true,
-      },
-      () => this.updateSearchParams(this.state.params)
-    );
+    this.updateSearchParams(this.getDefaultParams(view, this.props.email))
   };
 
   handleClearFilters = () => {
-    this.setState(
-      {
-        params: DEFAULT_PARAMS,
-        removeSelectAll: true,
-      },
-      () => this.updateSearchParams(this.state.params)
-    );
+    this.updateSearchParams(DEFAULT_PARAMS)
   };
 
   resetSelectAll = () => {


### PR DESCRIPTION
As stated in the spike in issue #699 there was redundancy in how state was being updated. Solution was to consolidate those calls in a manner that made sense. The updateSearchParams  function in itself updates state so made sense to only call updateSearchParams  and remove the redundant setState.

![clear-default-bug](https://user-images.githubusercontent.com/17464571/92643304-2a381480-f2a7-11ea-87f4-f10182e206d1.gif)
