### PR TITLE
CW-38 - Added beat loader to page when loading

### DIFF
--- a/front/src/containers/WorkflowPage/SuggestedLabels.tsx
+++ b/front/src/containers/WorkflowPage/SuggestedLabels.tsx
@@ -20,6 +20,7 @@ import { bucketKeyStringIsMissing } from 'utils/aggs/bucketKeyIsMissing';
 // import { WorkSearch } from './WorkSearch';
 import FacetCard from 'components/FacetCard/FacetCard';
 import { WorkflowConfigFragment_suggestedLabelsConfig } from 'types/WorkflowConfigFragment';
+import { BeatLoader } from 'react-spinners';
 
 interface SuggestedLabelsProps {
   nctId: string;
@@ -155,7 +156,12 @@ class SuggestedLabels extends React.PureComponent<
           crowdBucketsWanted: this.props.allowedSuggestedLabels
         }}>
         {({ data, loading, error, refetch }) => {
-          if (loading || error || !data) return null;
+          
+          if (loading || error || !data){
+            return(
+              <BeatLoader/>
+            )
+          } 
           let meta: Record<string, string> = {};
           try {
             meta = JSON.parse(data.study?.wikiPage?.meta || '{}');

--- a/front/src/containers/WorkflowPage/SuggestedLabels.tsx
+++ b/front/src/containers/WorkflowPage/SuggestedLabels.tsx
@@ -21,6 +21,7 @@ import { bucketKeyStringIsMissing } from 'utils/aggs/bucketKeyIsMissing';
 import FacetCard from 'components/FacetCard/FacetCard';
 import { WorkflowConfigFragment_suggestedLabelsConfig } from 'types/WorkflowConfigFragment';
 import { BeatLoader } from 'react-spinners';
+import Error from 'components/Error';
 
 interface SuggestedLabelsProps {
   nctId: string;
@@ -157,11 +158,10 @@ class SuggestedLabels extends React.PureComponent<
         }}>
         {({ data, loading, error, refetch }) => {
           
-          if (loading || error || !data){
-            return(
-              <BeatLoader/>
-            )
-          } 
+          if (loading) return <BeatLoader />;
+          if (error) return <Error message={error.message} />;
+          if (!data) return null;
+
           let meta: Record<string, string> = {};
           try {
             meta = JSON.parse(data.study?.wikiPage?.meta || '{}');


### PR DESCRIPTION
Added the beat loader return on instead of null for suggested label query. This component actually loads the data. With a sleep timer on the rails side during the query the beat loader appeared on the page. Generally locally loads too fast. 