### PR TITLE
CW-45 Agg label bug

### DIFF
--- a/front/src/components/SiteForm/AggField.tsx
+++ b/front/src/components/SiteForm/AggField.tsx
@@ -218,7 +218,10 @@ class AggField extends React.Component<AggFieldProps, AggFieldState> {
             this.props.field.name,
             this.props.field.displayName
           )}
-          value={this.props.field.rank}
+          value={aggToField(
+            this.props.field.name,
+            this.props.field.displayName
+          )}
           onChange={this.props.onAddMutation}
         />
       </span>


### PR DESCRIPTION
Value field was incorrectly referencing the rank property of the agg. This fixes that and makes sure it is reading and referencing the displayName property which is what controls the Agg Label field