### PR TITLE
CW-17 - Bring back history button

### DIFF
--- a/front/src/components/Edits/Edit.tsx
+++ b/front/src/components/Edits/Edit.tsx
@@ -13,7 +13,7 @@ const Edit = (props: EditProps) => {
   const { edit } = props;
 
   return (
-    <tr key={edit.id} style={{ padding: '10px' }}>
+    <tr style={{ padding: '10px' }}>
       <td>
         <ExpansionContext.Consumer>
           {({ historyExpanded, toggleEditVisibility }) => {

--- a/front/src/components/Edits/Edit.tsx
+++ b/front/src/components/Edits/Edit.tsx
@@ -1,7 +1,6 @@
-import * as React from 'react';
+import React, { useState } from 'react';
 import { Row, Col } from 'react-bootstrap';
 import { WikiPageEditFragment } from 'types/WikiPageEditFragment';
-import ExpansionContext from 'containers/WikiPage/ExpansionContext';
 import EditBlurb from './EditBlurb';
 import ExpandedEdit from './ExpandedEdit';
 
@@ -10,37 +9,27 @@ interface EditProps {
 }
 
 const Edit = (props: EditProps) => {
+  const [expanded, setExpanded] = useState(false);
   const { edit } = props;
 
   return (
-    <tr style={{ padding: '10px' }}>
-      <td>
-        <ExpansionContext.Consumer>
-          {({ historyExpanded, toggleEditVisibility }) => {
-            const expanded = historyExpanded[edit.id];
-            const nodes = [
+          <tr style={{ padding: '10px' }}>
+            <td>
               <EditBlurb
                 edit={edit}
                 expanded={expanded}
-                setExpanded={toggleEditVisibility(edit.id)}
-              />,
-            ];
-
-            if (expanded) {
-              nodes.push(
+                setExpanded={setExpanded}
+              />
+              {expanded ? (
                 <Row style={{ padding: '10px', marginBottom: '10px' }}>
                   <Col md={12}>
                     <ExpandedEdit edit={edit} />
                   </Col>
                 </Row>
-              );
-            }
-            return nodes;
-          }}
-        </ExpansionContext.Consumer>
-      </td>
-    </tr>
-  );
+              ) : null}
+            </td>
+          </tr>
+        );
 }
 
 export default Edit;

--- a/front/src/components/Edits/Edit.tsx
+++ b/front/src/components/Edits/Edit.tsx
@@ -9,40 +9,38 @@ interface EditProps {
   edit: WikiPageEditFragment;
 }
 
-class Edit extends React.Component<EditProps> {
-  render() {
-    const { edit } = this.props;
+const Edit = (props: EditProps) => {
+  const { edit } = props;
 
-    return (
-      <tr key={edit.id} style={{ padding: '10px' }}>
-        <td>
-          <ExpansionContext.Consumer>
-            {({ historyExpanded, toggleEditVisibility }) => {
-              const expanded = historyExpanded[edit.id];
-              const nodes = [
-                <EditBlurb
-                  edit={edit}
-                  expanded={expanded}
-                  setExpanded={toggleEditVisibility(edit.id)}
-                />,
-              ];
+  return (
+    <tr key={edit.id} style={{ padding: '10px' }}>
+      <td>
+        <ExpansionContext.Consumer>
+          {({ historyExpanded, toggleEditVisibility }) => {
+            const expanded = historyExpanded[edit.id];
+            const nodes = [
+              <EditBlurb
+                edit={edit}
+                expanded={expanded}
+                setExpanded={toggleEditVisibility(edit.id)}
+              />,
+            ];
 
-              if (expanded) {
-                nodes.push(
-                  <Row style={{ padding: '10px', marginBottom: '10px' }}>
-                    <Col md={12}>
-                      <ExpandedEdit edit={edit} />
-                    </Col>
-                  </Row>
-                );
-              }
-              return nodes;
-            }}
-          </ExpansionContext.Consumer>
-        </td>
-      </tr>
-    );
-  }
+            if (expanded) {
+              nodes.push(
+                <Row style={{ padding: '10px', marginBottom: '10px' }}>
+                  <Col md={12}>
+                    <ExpandedEdit edit={edit} />
+                  </Col>
+                </Row>
+              );
+            }
+            return nodes;
+          }}
+        </ExpansionContext.Consumer>
+      </td>
+    </tr>
+  );
 }
 
 export default Edit;

--- a/front/src/components/Edits/EditBlurb.tsx
+++ b/front/src/components/Edits/EditBlurb.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Row, Col } from 'react-bootstrap';
 import {
   WikiPageEditFragment,

--- a/front/src/components/Edits/EditBlurb.tsx
+++ b/front/src/components/Edits/EditBlurb.tsx
@@ -12,14 +12,16 @@ interface EditBlurbProps {
   setExpanded: any;
 }
 
-class EditBlurb extends React.Component<EditBlurbProps> {
-  getUserIdentity() {
+const EditBlurb = (props: EditBlurbProps) => {
+  const getUserIdentity = () => {
     const {
       edit: { user },
-    } = this.props;
+    } = props;
+
     if (!user) {
       return 'Anonymous';
     }
+
     if (user.firstName) {
       const userName = `${user.firstName} ${user.lastName && user.lastName[0]}`;
       return (
@@ -29,6 +31,7 @@ class EditBlurb extends React.Component<EditBlurbProps> {
         </Link>
       );
     }
+
     return (
       <Link
         to={`/profile/${user.email}?sv=user&uid=${user.id}&username=${user.email}`}>
@@ -37,12 +40,12 @@ class EditBlurb extends React.Component<EditBlurbProps> {
     );
   }
 
-  getBlurb() {
+  const getBlurb = () => {
     const {
       edit: {
         changeSet: { bodyChanged, frontMatterChanged },
       },
-    } = this.props;
+    } = props;
     if (!bodyChanged && !frontMatterChanged) {
       return 'made the first edit.';
     }
@@ -55,32 +58,31 @@ class EditBlurb extends React.Component<EditBlurbProps> {
     return 'made a change.';
   }
 
-  render() {
-    const { edit, expanded, setExpanded } = this.props;
-    return (
-      <Row style={{ marginBottom: '10px', padding: '10px' }}>
-        <Col md={8}>
-          <span className="diff-actor">{this.getUserIdentity()}</span>
-          <span>{' ' + this.getBlurb()}</span>
-        </Col>
-        <Col md={2}>
-          <small>{new Date(edit.createdAt).toLocaleDateString('en-US')}</small>
-        </Col>
-        <Col md={2} className="text-right">
-          {expanded && (
-            <ThemedButton onClick={() => setExpanded(false)}>
-              View Less
-            </ThemedButton>
-          )}
-          {!expanded && (
-            <ThemedButton onClick={() => setExpanded(true)}>
-              View More
-            </ThemedButton>
-          )}
-        </Col>
-      </Row>
-    );
-  }
+  const { edit, expanded, setExpanded } = props;
+
+  return (
+    <Row style={{ marginBottom: '10px', padding: '10px' }}>
+      <Col md={8}>
+        <span className="diff-actor">{getUserIdentity()}</span>
+        <span>{' ' + getBlurb()}</span>
+      </Col>
+      <Col md={2}>
+        <small>{new Date(edit.createdAt).toLocaleDateString('en-US')}</small>
+      </Col>
+      <Col md={2} className="text-right">
+        {expanded && (
+          <ThemedButton onClick={() => setExpanded(false)}>
+            View Less
+          </ThemedButton>
+        )}
+        {!expanded && (
+          <ThemedButton onClick={() => setExpanded(true)}>
+            View More
+          </ThemedButton>
+        )}
+      </Col>
+    </Row>
+  );
 }
 
 export default EditBlurb;

--- a/front/src/components/Edits/Edits.tsx
+++ b/front/src/components/Edits/Edits.tsx
@@ -7,19 +7,18 @@ interface EditsProps {
   edits: WikiPageEditFragment[];
 }
 
-class Edits extends React.Component<EditsProps> {
-  render() {
-    const { edits } = this.props;
-    return (
-      <StyleWrapper striped bordered>
-        <tbody>
-          {edits.map((edit, i) => (
-            <Edit key={i} edit={edit} />
-          ))}
-        </tbody>
-      </StyleWrapper>
-    );
-  }
+const Edits = (props: EditsProps) => {
+  const { edits } = props;
+
+  return (
+    <StyleWrapper striped bordered>
+      <tbody>
+        {edits.map((edit, i) => (
+          <Edit key={i} edit={edit} />
+        ))}
+      </tbody>
+    </StyleWrapper>
+  );
 }
 
 export default Edits;

--- a/front/src/components/Edits/ExpandedEdit/ExpandedAsRawDiff.tsx
+++ b/front/src/components/Edits/ExpandedEdit/ExpandedAsRawDiff.tsx
@@ -6,17 +6,15 @@ interface EditProps {
   edit: WikiPageEditFragment;
 }
 
-class ExpandedAsRawDiff extends React.Component<EditProps> {
-  render() {
-    const { edit } = this.props;
-    return (
-      <div
-        dangerouslySetInnerHTML={{
-          __html: edit.diffHtml || '<p></p>',
-        }}
-      />
-    );
-  }
+const ExpandedAsRawDiff = (props: EditProps) => {
+  const { edit } = props;
+  return (
+    <div
+      dangerouslySetInnerHTML={{
+        __html: edit.diffHtml || '<p></p>',
+      }}
+    />
+  );
 }
 
 export default ExpandedAsRawDiff;

--- a/front/src/components/Edits/ExpandedEdit/ExpandedEdit.tsx
+++ b/front/src/components/Edits/ExpandedEdit/ExpandedEdit.tsx
@@ -8,9 +8,8 @@ interface EditProps {
   edit: WikiPageEditFragment;
 }
 
-class ExpandedEdit extends React.Component<EditProps> {
-  render() {
-    const { edit } = this.props;
+const ExpandedEdit = (props: EditProps) => {
+    const { edit } = props;
     const {
       changeSet: { bodyChanged, frontMatterChanged },
     } = edit;
@@ -23,7 +22,6 @@ class ExpandedEdit extends React.Component<EditProps> {
     }
 
     return <ExpandedAsRawDiff edit={edit} />;
-  }
 }
 
 export default ExpandedEdit;

--- a/front/src/components/Edits/ExpandedEdit/FrontMatterExpandedEdit.tsx
+++ b/front/src/components/Edits/ExpandedEdit/FrontMatterExpandedEdit.tsx
@@ -6,59 +6,57 @@ interface EditProps {
   edit: WikiPageEditFragment;
 }
 
-class FrontMatterExpandedEdit extends React.Component<EditProps> {
-  render() {
-    const {
-      edit: {
-        changeSet: { editLines },
-      },
-    } = this.props;
-    const fmLines = editLines.filter(
-      ({ frontMatter, content }) => frontMatter && content !== '---'
-    );
-    const inserts = fmLines.filter(({ status }) => status === 'INS');
-    const deletes = fmLines.filter(({ status }) => status === 'DEL');
+const FrontMatterExpandedEdit = (props: EditProps) => {
+  const {
+    edit: {
+      changeSet: { editLines },
+    },
+  } = props;
+  const fmLines = editLines.filter(
+    ({ frontMatter, content }) => frontMatter && content !== '---'
+  );
+  const inserts = fmLines.filter(({ status }) => status === 'INS');
+  const deletes = fmLines.filter(({ status }) => status === 'DEL');
 
-    const nodes: any[] = [];
-    // this only accommodates a single diff right now!
-    if (deletes.length > 0) {
-      const [fieldName, former] = deletes[0].content.split(/:(.+)/);
-      nodes.push(
-        <tr className="del" key={`${fieldName}-delete`}>
-          <td>-</td>
-          <td>{fieldName}</td>
-          <td>{former}</td>
-        </tr>
-      );
-    }
-    if (inserts.length > 0) {
-      const [fieldName, current] = inserts[0].content.split(/:(.+)/);
-      nodes.push(
-        <tr className="ins" key={`${fieldName}-insert`}>
-          <td>+</td>
-          <td>{fieldName}</td>
-          <td>{current}</td>
-        </tr>
-      );
-    }
-
-    return (
-      <Row>
-        <Col md={12}>
-          <Table className="crowd-diff">
-            <thead>
-              <tr>
-                <th></th>
-                <th>Field</th>
-                <th>Value</th>
-              </tr>
-            </thead>
-            <tbody>{nodes}</tbody>
-          </Table>
-        </Col>
-      </Row>
+  const nodes: any[] = [];
+  // this only accommodates a single diff right now!
+  if (deletes.length > 0) {
+    const [fieldName, former] = deletes[0].content.split(/:(.+)/);
+    nodes.push(
+      <tr className="del" key={`${fieldName}-delete`}>
+        <td>-</td>
+        <td>{fieldName}</td>
+        <td>{former}</td>
+      </tr>
     );
   }
+  if (inserts.length > 0) {
+    const [fieldName, current] = inserts[0].content.split(/:(.+)/);
+    nodes.push(
+      <tr className="ins" key={`${fieldName}-insert`}>
+        <td>+</td>
+        <td>{fieldName}</td>
+        <td>{current}</td>
+      </tr>
+    );
+  }
+
+  return (
+    <Row>
+      <Col md={12}>
+        <Table className="crowd-diff">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Field</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>{nodes}</tbody>
+        </Table>
+      </Col>
+    </Row>
+  );
 }
 
 export default FrontMatterExpandedEdit;

--- a/front/src/containers/Islands/WikiPageIsland.tsx
+++ b/front/src/containers/Islands/WikiPageIsland.tsx
@@ -113,14 +113,14 @@ export default function WikiPageIsland(props: Props) {
     Object.keys(historyExpanded).forEach(key => {
       historyExpanded[key] = true;
     });
-    setHistoryExpanded(historyExpanded)
+    setHistoryExpanded(historyExpanded);
   };
 
   const minimizeAllEdits = () => {
     Object.keys(historyExpanded).forEach(key => {
       historyExpanded[key] = false;
     });
-    setHistoryExpanded(historyExpanded)
+    setHistoryExpanded(historyExpanded);
   };
 
   const renderMarkdownButton = () => {

--- a/front/src/containers/Islands/WikiPageIsland.tsx
+++ b/front/src/containers/Islands/WikiPageIsland.tsx
@@ -1,14 +1,11 @@
 import React, { useState, useEffect, useContext } from 'react';
 import RichTextEditor, { EditorValue } from 'react-rte';
 import { partition, toPairs } from 'ramda';
-import { useWorkflowsView } from 'containers/WorkflowsViewProvider/WorkflowsViewProvider';
 import { WikiPageQuery, WikiPageQueryVariables } from 'types/WikiPageQuery';
 import {
   UPDATE_CONTENT_MUTATION,
-  UpdateContentMutationFn,
 } from 'mutations/WikiPageUpdateContentMutation';
 import {
-  WikiPageUpdateContentMutation,
   WikiPageUpdateContentMutationVariables,
 } from 'types/WikiPageUpdateContentMutation';
 import styled from 'styled-components';
@@ -22,12 +19,10 @@ import { useHistory, useLocation, useRouteMatch } from "react-router-dom";
 import CrowdPage from 'containers/CrowdPage';
 import { BeatLoader } from 'react-spinners';
 import  { Switch, Route } from 'react-router';
-import { UserFragment } from 'types/UserFragment';
 import { trimPath } from 'utils/helpers';
 import ThemedButton from 'components/StyledComponents/index';
 import * as FontAwesome from 'react-fontawesome';
-import ExpansionContext from '../WikiPage/ExpansionContext';
-import Edits, { WikiPageEditFragment } from 'components/Edits';
+import Edits from 'components/Edits';
 import { CurrentUserQuery_me } from 'types/CurrentUserQuery'
 
 interface Props {
@@ -82,11 +77,6 @@ export default function WikiPageIsland(props: Props) {
       );
     }
     return plainEditorText;
-  };
-
-  const toggleEditVisibility = (editId: string) => value => {
-    historyExpanded[editId] = value;
-    setHistoryExpanded(historyExpanded);
   };
 
   const handlePreview = () => {
@@ -351,11 +341,6 @@ export default function WikiPageIsland(props: Props) {
           <Route
             path={historyPath}
             render={() => (
-              <ExpansionContext.Provider
-                value={{
-                  historyExpanded,
-                  toggleEditVisibility: toggleEditVisibility,
-                }}>
                 <Edits
                   edits={
                     (studyData &&
@@ -365,7 +350,6 @@ export default function WikiPageIsland(props: Props) {
                     []
                   }
                 />
-              </ExpansionContext.Provider>
             )}
           />
         </div>

--- a/front/src/containers/Islands/WikiPageIsland.tsx
+++ b/front/src/containers/Islands/WikiPageIsland.tsx
@@ -70,13 +70,8 @@ export default function WikiPageIsland(props: Props) {
   });
 
   const readOnly = !location.pathname.includes('/wiki/edit');
-
-
-
-  const editPath = () => `${trimPath(match.path)}/wiki/edit`;
-
-  const historyPath = () => `${trimPath(match.path)}/wiki/history`;
-
+  const editPath = `${trimPath(match.path)}/wiki/edit`;
+  const historyPath = `${trimPath(match.path)}/wiki/history`;
 
   const getEditorText = () => {
     if (editorState === 'rich') {
@@ -88,18 +83,17 @@ export default function WikiPageIsland(props: Props) {
     }
     return plainEditorText;
   };
-  const toggleEditVisibility = (editId: string) => value => {
 
+  const toggleEditVisibility = (editId: string) => value => {
     historyExpanded[editId] = value;
     setHistoryExpanded(historyExpanded);
   };
+
   const handlePreview = () => {
     if (editorState === 'plain') {
       const text = getEditorText() || '';
-
       setEditorState('rich')
       setRichEditorText(RichTextEditor.createValueFromString(text, 'markdown'))
-
     }
 
     history.push(
@@ -107,10 +101,10 @@ export default function WikiPageIsland(props: Props) {
     );
   };
 
-
   const handleRichEditorChange = (richEditorText: EditorValue) => {
     setRichEditorText(richEditorText);
   };
+
   const handlePlainEditorChange = (e: any) => {
     setplainEditorText(e.currentTarget.value);
   };
@@ -121,12 +115,14 @@ export default function WikiPageIsland(props: Props) {
     });
     setHistoryExpanded(historyExpanded)
   };
+
   const minimizeAllEdits = () => {
     Object.keys(historyExpanded).forEach(key => {
       historyExpanded[key] = false;
     });
     setHistoryExpanded(historyExpanded)
   };
+
   const renderMarkdownButton = () => {
     if (editorState === 'plain') {
       return (
@@ -145,11 +141,9 @@ export default function WikiPageIsland(props: Props) {
   const handleMarkdownToggle = () => {
     const text = getEditorText() || '';
     const editorStateTemp = editorState === 'rich' ? 'plain' : 'rich';
-    // this.setState({
     setEditorState(editorStateTemp)
     setplainEditorText(text)
     setRichEditorText(RichTextEditor.createValueFromString(text, 'markdown'))
-    // });
   };
 
   const handleEdit = () => {
@@ -159,6 +153,7 @@ export default function WikiPageIsland(props: Props) {
       )}/wiki/edit${queryStringAll(params)}`
     );
   };
+
   const handleHistory = () => {
     history.push(
       `${trimPath(
@@ -166,17 +161,18 @@ export default function WikiPageIsland(props: Props) {
       )}/wiki/history${queryStringAll(params)}`
     );
   };
+
   const handleView = () => {
     history.push(
       `${trimPath(match.url)}${queryStringAll(params)}`
     );
   };
+
   const handleEditSubmit = (
     updateWikiContent: (vars: {
       variables: WikiPageUpdateContentMutationVariables;
     }) => void
   ) => {
-    // this.props.showAnimation()
     updateWikiContent({
       variables: {
         nctId: nctId,
@@ -193,16 +189,15 @@ export default function WikiPageIsland(props: Props) {
       data.study && data.study.wikiPage && data.study.wikiPage.content;
 
     return (
-
       <ThemedButton
         onClick={() => handleEditSubmit(updateContentMutation)}
         disabled={editorTextState === editorTextData}
         style={{ marginLeft: '10px' }}>
         Submit <FontAwesome name="pencil" />
       </ThemedButton>
-
     );
   };
+
   const renderEditButton = (
     isAuthenticated: boolean,
   ) => {
@@ -217,6 +212,7 @@ export default function WikiPageIsland(props: Props) {
       </ThemedButton>
     );
   };
+
   const renderToolbar = (
     data: WikiPageQuery,
     user: CurrentUserQuery_me | null | undefined,
@@ -232,7 +228,7 @@ export default function WikiPageIsland(props: Props) {
       <Toolbar>
         <Switch>
           <Route
-            path={editPath()}
+            path={editPath}
             render={() => (
               <>
                 {renderMarkdownButton()}{' '}
@@ -247,8 +243,43 @@ export default function WikiPageIsland(props: Props) {
             )}
           />
           <Route
+            path={historyPath}
             render={() => (
               <>
+                {minimized.length > 0 && (
+                  <ThemedButton
+                    type="button"
+                    onClick={expandAllEdits}
+                    style={{ marginLeft: '10px' }}>
+                    Expand History <FontAwesome name="expand" />
+                  </ThemedButton>
+                )}
+                {maximized.length > 0 && (
+                  <ThemedButton
+                    type="button"
+                    onClick={minimizeAllEdits}
+                    style={{ marginLeft: '10px' }}>
+                    Minimize History <FontAwesome name="compress" />
+                  </ThemedButton>
+                )}
+                {renderEditButton(isAuthenticated)}{' '}
+                <ThemedButton
+                  type="button"
+                  onClick={handleView}
+                  style={{ marginLeft: '10px' }}>
+                  View <FontAwesome name="photo" />
+                </ThemedButton>
+              </>
+            )}
+          />
+          <Route
+            render={() => (
+              <>
+                <ThemedButton
+                  type="button"
+                  onClick={handleHistory}>
+                  History <FontAwesome name="history" />
+                </ThemedButton>
                 {renderEditButton(isAuthenticated)}
                 {renderSubmitButton(data, isAuthenticated, readOnly)}
               </>
@@ -315,10 +346,28 @@ export default function WikiPageIsland(props: Props) {
     <div>
       <StyledPanel>
         <div>
-          <Switch>
-            <Route render={() => renderEditor(studyData)} />
-          </Switch>
+          <Route render={() => renderEditor(studyData)} />
           {renderToolbar(studyData, user, readOnly)}
+          <Route
+            path={historyPath}
+            render={() => (
+              <ExpansionContext.Provider
+                value={{
+                  historyExpanded,
+                  toggleEditVisibility: toggleEditVisibility,
+                }}>
+                <Edits
+                  edits={
+                    (studyData &&
+                      studyData.study &&
+                      studyData.study.wikiPage &&
+                      studyData.study.wikiPage.edits) ||
+                    []
+                  }
+                />
+              </ExpansionContext.Provider>
+            )}
+          />
         </div>
       </StyledPanel>
     </div>


### PR DESCRIPTION
[CW-17](https://clinwiki.atlassian.net/browse/CW-17) - Bring back history button

- Changed all components related to edit history to functional components
- Removed `ExpansionContext` since it was only being used by `EditBlurb` and `ExpandedEdit` so it doesn't make sense to re-render the whole `WikiPageIsland` component (from what I can see)
- Also seems to make more sense to keep the state management of each `Edit` component self-contained since it is not dependent on the state of other `Edit` components