### PR TITLE
Remove staging database password from Docker Compose file and fix database volume persistence issue 

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,4 +1,3 @@
-# ONLY for production
 # ONLY for production and staging
 RAILS_ENV='production'
 
@@ -10,7 +9,8 @@ CW_MODE='FAST' # Defaults to 'PROD' if omitted (see README for more details)
 
 # Common
 CW_HOST='clinwiki.org'
-DATABASE_URL='postgres://$DB_USER:$DB_PASSWORD@DB_HOST:5432/DB_NAME'
+POSTGRES_USER='CHANGEME'
+POSTGRES_PASSWORD='CHANGEME'
 AACT_DATABASE_URL='postgres://$AACT_DB_USER:$AACT_DB_PASSWORD@DB_HOST:5432/AACT_DB_NAME'
 AWS_ACCESS_KEY_ID='CHANGEME'
 AWS_SECRET_ACCESS_KEY='CHANGEME'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - 15432:5432
     volumes:
-      - cw-data:/var/lib/postgresq/data
+      - cw-data:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=$POSTGRES_USER
       - POSTGRES_PASSWORD=$POSTGRES_PASSWORD

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,7 @@ services:
     env_file:
       - .env
     environment:
+      - DATABASE_URL=postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@db:5432
       - REDIS_URL=redis://redis:6379/0
       - SEARCHBOX_URL=http://elastic:$ELASTIC_PASSWORD@elastic:9200/
     depends_on:
@@ -85,6 +86,7 @@ services:
     env_file:
       - .env
     environment:
+      - DATABASE_URL=postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@db:5432
       - REDIS_URL=redis://redis:6379/0
       - SEARCHBOX_URL=http://elastic:$ELASTIC_PASSWORD@elastic:9200/
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,11 @@ services:
     container_name: clinwiki-db
     ports:
       - 15432:5432
-    environment:
-      - POSTGRES_USER=clinwiki
-      - POSTGRES_PASSWORD=ZetIFOnXd78H
     volumes:
       - cw-data:/var/lib/postgresq/data
+    environment:
+      - POSTGRES_USER=$POSTGRES_USER
+      - POSTGRES_PASSWORD=$POSTGRES_PASSWORD
   elastic:
     image: elasticsearch:6.8.8
     container_name: elastic
@@ -51,8 +51,6 @@ services:
   redis:
     image: redis:5.0.5
     container_name: redis
-    #ports:
-    #   - 6379:6379
     volumes:
       - redis-data:/data
   clinwiki:
@@ -67,12 +65,11 @@ services:
       - .:/clinwiki
       - ./compose/entrypoint.sh:/usr/bin/entrypoint.sh
       - node_modules:/clinwiki/front/node_modules
+    env_file:
+      - .env
     environment:
-      - DATABASE_URL=$DATABASE_URL
-      - AACT_DATABASE_URL=$AACT_DATABASE_URL
       - REDIS_URL=redis://redis:6379/0
       - SEARCHBOX_URL=http://elastic:$ELASTIC_PASSWORD@elastic:9200/
-      - CW_MODE=${CW_MODE}
     depends_on:
       - db
       - elastic
@@ -85,12 +82,11 @@ services:
     container_name: sidekiq
     volumes:
       - .:/clinwiki
+    env_file:
+      - .env
     environment:
-      - DATABASE_URL=$DATABASE_URL
-      - AACT_DATABASE_URL=$AACT_DATABASE_URL
       - REDIS_URL=redis://redis:6379/0
       - SEARCHBOX_URL=http://elastic:$ELASTIC_PASSWORD@elastic:9200/
-      - CW_MODE=WORKER
     depends_on:
       - db
       - elastic


### PR DESCRIPTION
- Remove staging database password from Docker Compose file and update `.example.env`
- Fix container volume path for Postgres so the data persists after `docker-compose down` 

Right now, the database container loses all its data when we destroy the container even though we have assigned a volume for it. Turns out, there is a specific directory where Postgresql requires you to store persistent data.

See Postgres docs and the `Where to Store Data` section of the Docker image [documentation](https://hub.docker.com/_/postgres) for more details.

It won't make deploying the environment variable changes easier this time but in the future, we should be able apply environment or Docker Compose configuration changes without destroying the staging or development data. This time, we will still have to do a database dump and restore.

Also, @rodctech this might be of interest to you. Sorry we had to blow up your local setup to figure it out. I have tested this out on my machine to confirm that the volume's data does persist after this change.