### PR TITLE
route path updates for the wiki history

### DIFF
--- a/front/src/containers/Islands/EditsHistoryIsland/EditsHistory.tsx
+++ b/front/src/containers/Islands/EditsHistoryIsland/EditsHistory.tsx
@@ -35,7 +35,7 @@ const EditsHistory = (props: EditsHistoryProps) => {
       <div>
         <EditsHistoryButtons />
         <Route
-          path={`${match.path}/wiki/history`}
+          path={`${match.path}/history`}
           render={() => <Edits edits={edits ? edits : []} />}
         />
       </div>

--- a/front/src/containers/Islands/EditsHistoryIsland/EditsHistoryButtons.tsx
+++ b/front/src/containers/Islands/EditsHistoryIsland/EditsHistoryButtons.tsx
@@ -52,18 +52,18 @@ const HistoryToggleButton = () => {
   const studyPath = trimPath(match.url);
 
   const goToEditHistoryUrl = () => {
-    history.push(`${studyPath}/wiki/history${queryStringAll(params)}`);
+    history.push(`${studyPath}/history${queryStringAll(params)}`);
   };
 
   const goToViewUrl = () => {
-    history.push(`${studyPath}/wiki${queryStringAll(params)}`);
+    history.push(`${studyPath}${queryStringAll(params)}`);
   };
 
   return (
     <>
       <Route
         exact
-        path={`${studyPath}/wiki`}
+        path={`${studyPath}`}
         render={() => (
           <ThemedButton type="button" onClick={goToEditHistoryUrl}>
             History <FontAwesome name="history" />
@@ -72,10 +72,10 @@ const HistoryToggleButton = () => {
       />
       <Route
         exact
-        path={`${studyPath}/wiki/history`}
+        path={`${studyPath}/history`}
         render={() => (
           <ThemedButton type="button" onClick={goToViewUrl}>
-            View <FontAwesome name="photo" />
+            Close <FontAwesome name="times" />
           </ThemedButton>
         )}
       />
@@ -95,7 +95,7 @@ const EditsHistoryButtons = () => {
       }}>
       <HistoryToggleButton />
       <Route
-        path={`${match.path}/wiki/history`}
+        path={`${match.path}/history`}
         component={ExpandHistoryButtons}
       />
     </div>

--- a/front/src/containers/Islands/EditsHistoryIsland/index.tsx
+++ b/front/src/containers/Islands/EditsHistoryIsland/index.tsx
@@ -19,8 +19,8 @@ const EditsHistoryIsland = (props: EditsIslandProps) => {
     },
   });
 
-  if (loading) return <BeatLoader />;
-  if (error || !data || !data.study || !data.study.wikiPage) {
+  if (loading || !data || !data.study || !data.study.wikiPage) return <BeatLoader />;
+  if (error) {
     return (
       <Error message="Looks like something went wrong. Please refresh the page." />
     );


### PR DESCRIPTION
Fix for our WikiHistory Island not displaying:

Was a two part issue routing and error handling

*Note I also changed the button that closes the history altogether to say close. Previously said "View" to return back to the regular wiki page, however no longer the case.

![history_pt1](https://user-images.githubusercontent.com/17464571/94043837-08ed2300-fd93-11ea-81b9-e1ce7160bf41.png)
![history_pt2](https://user-images.githubusercontent.com/17464571/94043839-0985b980-fd93-11ea-85e7-a6c43f1551d0.png)


Bonus: 

Config Picture 
![history_bonus](https://user-images.githubusercontent.com/17464571/94044401-b3654600-fd93-11ea-9e43-6f015eae8074.png)

