### PR TITLE
CW-55-handles q coming from home.clinwiki

### DIFF
--- a/front/src/containers/SearchPage/SearchPage.tsx
+++ b/front/src/containers/SearchPage/SearchPage.tsx
@@ -363,7 +363,10 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     view: SiteViewFragment
   ): SearchParams => {
     const defaultParams = this.getDefaultParams(view, this.props.email);
-
+    if (this.state.params && this.state.params.q) {
+      let queryParams = { ...defaultParams, q: this.state.params.q }
+      return queryParams
+    }
     if (!params) return defaultParams;
 
     const q = params.q
@@ -618,19 +621,14 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
         key: 'AND',
         children: [{ children: [], key: searchTerm.getAll('q').toString() }],
       };
-      this.setState(
-        {
-          params: {
-            q: q,
-            aggFilters: [],
-            crowdAggFilters: [],
-            sorts: [],
-            page: 0,
-            pageSize: defaultPageSize,
-          },
-        },
-        () => this.updateSearchParams(this.state.params)
-      );
+      this.updateSearchParams({
+        q: q,
+        aggFilters: [],
+        crowdAggFilters: [],
+        sorts: [],
+        page: 0,
+        pageSize: defaultPageSize,
+      })
     }
     if (this.props.intervention) {
       //@ts-ignore


### PR DESCRIPTION
Just took some state update consolidation as well as making sure we update our default_params with our q querystring value
![2020-09-25_12-31-23](https://user-images.githubusercontent.com/17464571/94298218-5ac8b100-ff2b-11ea-8a10-58c55e903a21.gif)
