### PR TITLE
Global style change for pre in mail-merge, makes it inherit font-family

### DIFF
--- a/front/src/global-styles.ts
+++ b/front/src/global-styles.ts
@@ -191,8 +191,10 @@ div.DraftEditor-editorContainer{
   background-color: white;
   border: 0px;
   padding: 0px;
+  font-family:inherit;
 }
 .mail-merge pre code {
   font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 13px;
+}
 `);


### PR DESCRIPTION
Css changes for font-family of pre tag. Did not see any wrapping issues