### PR TITLE
Cw 60 wikipage rework

### DIFF
--- a/front/src/components/WikiPageEditor/WikiPageEditor.tsx
+++ b/front/src/components/WikiPageEditor/WikiPageEditor.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from 'react';
+import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
+import useUrlParams, { queryStringAll } from 'utils/UrlParamsProvider';
+import { WikiPageQuery } from 'types/WikiPageQuery';
+import RichTextEditor, { EditorValue } from 'react-rte';
+import { Panel, FormControl } from 'react-bootstrap';
+import { useUnload } from "../../hooks/useUnload";
+import { BeatLoader } from 'react-spinners';
+
+interface Props {
+  data: WikiPageQuery;
+  updateText: (string) => void;
+}
+
+
+export default function WikiPageEditor(props: Props) {
+  useUnload(e => {
+    e.preventDefault();
+    e.returnValue = '';
+  });
+  let history = useHistory();
+  let match = useRouteMatch();
+  const params = useUrlParams();
+
+  const [plainEditorText, setplainEditorText] = useState('');
+  const [richEditorText, setRichEditorText] = useState('');
+
+  const [editorState, setEditorState] = useState('rich');
+
+  const handleRichEditorChange = (richEditorText: EditorValue) => {
+    props.updateText(richEditorText)
+    setRichEditorText(richEditorText);
+  };
+
+  const handlePlainEditorChange = (e: any) => {
+    setplainEditorText(e.currentTarget.value);
+  };
+
+  let location = useLocation();
+
+  const getEditorText = () => {
+    if (editorState === 'rich') {
+      return (
+        richEditorText &&
+        //@ts-ignore
+        richEditorText.toString('markdown')
+      );
+    }
+    return plainEditorText;
+  };
+  const handlePreview = () => {
+    if (editorState === 'plain') {
+      const text = getEditorText() || '';
+      setEditorState('rich');
+      setRichEditorText(RichTextEditor.createValueFromString(text, 'markdown'));
+    }
+
+    history.push(`${match.url}${queryStringAll(params)}`);
+  };
+
+  const { data, } = props;
+  console.log("DATA", data)
+  if (!data || !data.study || !data.study.wikiPage) return null;
+  const text = getEditorText() || '';
+  console.log("TEXT", text)
+  if (text !== data.study.wikiPage.content && !text) {
+    handlePreview()
+
+    if (editorState === 'rich') {
+      const richEditorText = RichTextEditor.createValueFromString(
+        data.study.wikiPage.content || '',
+        'markdown'
+      );
+      console.log("RICH", richEditorText)
+      setRichEditorText(richEditorText);
+    } else {
+      console.log("PLAIN", text)
+      setplainEditorText(text);
+    }
+  }
+
+  const readOnly = !location.pathname.includes('/wiki/edit');
+  if (!data) return <BeatLoader />;
+
+  if (editorState === 'rich') {
+    console.log("RICH", richEditorText)
+    return (
+      <Panel>
+        <Panel.Body>
+          <RichTextEditor
+            readOnly={readOnly}
+            onChange={handleRichEditorChange}
+            value={richEditorText || RichTextEditor.createEmptyValue()}
+          />
+        </Panel.Body>
+      </Panel>
+    );
+  }
+  console.log("PLAIN")
+  return (
+
+    <Panel>
+      <Panel.Body>
+        <FormControl
+          style={{ minHeight: '200px' }}
+          componentClass="textarea"
+          defaultValue={plainEditorText || ''}
+          onChange={handlePlainEditorChange}
+        />
+      </Panel.Body>
+    </Panel>
+  );
+}

--- a/front/src/containers/Islands/WikiPageIsland.tsx
+++ b/front/src/containers/Islands/WikiPageIsland.tsx
@@ -16,6 +16,7 @@ import { trimPath } from 'utils/helpers';
 import ThemedButton from 'components/StyledComponents/index';
 import * as FontAwesome from 'react-fontawesome';
 import { CurrentUserQuery_me } from 'types/CurrentUserQuery';
+import WikiPageEditor from '../../components/WikiPageEditor/WikiPageEditor';
 
 interface Props {
   nctId: string;
@@ -41,7 +42,6 @@ export default function WikiPageIsland(props: Props) {
   const [editorState, setEditorState] = useState('rich');
   const [plainEditorText, setplainEditorText] = useState('');
   const [richEditorText, setRichEditorText] = useState('');
-
   const user = useCurrentUser()?.data?.me;
   const params = useUrlParams();
   // TODO: This query should be pushed up as a fragment to the Page
@@ -52,7 +52,7 @@ export default function WikiPageIsland(props: Props) {
     refetchQueries: [{ query: QUERY, variables: { nctId } }],
   });
 
-  const readOnly = !location.pathname.includes('/wiki/edit');
+   const readOnly = !location.pathname.includes('/wiki/edit');
   const editPath = `${trimPath(match.path)}/wiki/edit`;
 
   const getEditorText = () => {
@@ -84,33 +84,14 @@ export default function WikiPageIsland(props: Props) {
     setplainEditorText(e.currentTarget.value);
   };
 
-  const renderMarkdownButton = () => {
-    if (editorState === 'plain') {
-      return (
-        <ThemedButton type="button" onClick={() => handleMarkdownToggle()}>
-          Editor <FontAwesome name="newspaper-o" />
-        </ThemedButton>
-      );
-    }
-    return (
-      <ThemedButton type="button" onClick={() => handleMarkdownToggle()}>
-        Markdown <FontAwesome name="code" />
-      </ThemedButton>
-    );
-  };
-
-  const handleMarkdownToggle = () => {
-    const text = getEditorText() || '';
-    const editorStateTemp = editorState === 'rich' ? 'plain' : 'rich';
-    setEditorState(editorStateTemp);
-    setplainEditorText(text);
-    setRichEditorText(RichTextEditor.createValueFromString(text, 'markdown'));
-  };
 
   const handleEdit = () => {
     history.push(`${trimPath(match.url)}/wiki/edit${queryStringAll(params)}`);
   };
+  const handleUpdateText =(text)=>{
+    setRichEditorText(text)
 
+  }
   const handleEditSubmit = (
     updateWikiContent: (vars: {
       variables: WikiPageUpdateContentMutationVariables;
@@ -122,6 +103,7 @@ export default function WikiPageIsland(props: Props) {
         content: getEditorText() || '',
       },
     });
+    history.push(`${match.url}${queryStringAll(params)}`);
   };
 
   const renderSubmitButton = (
@@ -140,7 +122,7 @@ export default function WikiPageIsland(props: Props) {
         onClick={() => handleEditSubmit(updateContentMutation)}
         disabled={editorTextState === editorTextData}
         style={{ marginLeft: '10px' }}>
-        Submit <FontAwesome name="pencil" />
+        Save <FontAwesome name="pencil" />
       </ThemedButton>
     );
   };
@@ -172,13 +154,6 @@ export default function WikiPageIsland(props: Props) {
             path={editPath}
             render={() => (
               <>
-                {renderMarkdownButton()}{' '}
-                <ThemedButton
-                  type="button"
-                  onClick={() => handlePreview()}
-                  style={{ marginLeft: '10px' }}>
-                  Preview <FontAwesome name="photo" />
-                </ThemedButton>
                 {renderSubmitButton(data, isAuthenticated, readOnly)}
               </>
             )}
@@ -240,7 +215,8 @@ export default function WikiPageIsland(props: Props) {
     <div>
       <StyledPanel>
         <div>
-          <Route render={() => renderEditor(studyData)} />
+        <Route exact path = {editPath} render={props=><WikiPageEditor updateText={handleUpdateText} data={studyData}/>}/>
+        {readOnly? <Route render={ () => renderEditor(studyData)} />: null} 
           {renderToolbar(studyData, user, readOnly)}
         </div>
       </StyledPanel>

--- a/front/src/hooks/useUnload.ts
+++ b/front/src/hooks/useUnload.ts
@@ -1,0 +1,34 @@
+import { useRef, useEffect } from 'react';
+
+export function useUnload(fn) {
+    const cb = useRef(fn); // init with fn, so that type checkers won't assume that current might be undefined
+
+    useEffect(() => {
+      cb.current = fn;
+    }, [fn]);
+  
+    useEffect(() => {
+      const onUnload = cb.current;
+  
+      window.addEventListener("beforeunload", onUnload);
+  
+      return () => window.removeEventListener("beforeunload", onUnload);
+    }, []);
+  }
+// export function useUnload = (fn) => {
+//   const cb = useRef(fn); // init with fn, so that type checkers won't assume that current might be undefined
+
+//   useEffect(() => {
+//     cb.current = fn;
+//   }, [fn]);
+
+//   useEffect(() => {
+//     const onUnload = cb.current;
+
+//     window.addEventListener("beforeunload", onUnload);
+
+//     return () => window.removeEventListener("beforeunload", onUnload);
+//   }, []);
+// };
+
+export default useUnload;

--- a/front/src/hooks/useUnload.ts
+++ b/front/src/hooks/useUnload.ts
@@ -15,20 +15,5 @@ export function useUnload(fn) {
       return () => window.removeEventListener("beforeunload", onUnload);
     }, []);
   }
-// export function useUnload = (fn) => {
-//   const cb = useRef(fn); // init with fn, so that type checkers won't assume that current might be undefined
-
-//   useEffect(() => {
-//     cb.current = fn;
-//   }, [fn]);
-
-//   useEffect(() => {
-//     const onUnload = cb.current;
-
-//     window.addEventListener("beforeunload", onUnload);
-
-//     return () => window.removeEventListener("beforeunload", onUnload);
-//   }, []);
-// };
 
 export default useUnload;


### PR DESCRIPTION
- Remove `Preview` button
- Remove `Markdown` button
- When user clicks the `Edit` button, it should change to a disabled `Save` button
- When user makes an edit to the text, the `Save` button should be enabled
- When user clicks `Save`, the button should change back to `Edit`
- If user tries to close the tab or their browser without saving their changes, they should be warned and given the option to keep the tab open so they can save


![2020-09-30_12-22-47](https://user-images.githubusercontent.com/17464571/94719694-1a957400-0319-11eb-8f3b-c0d77a4ce526.gif)
