### PR TITLE
CW-62 Temp fix for sort order button

### DIFF
--- a/front/src/containers/SearchPage/SearchPage.tsx
+++ b/front/src/containers/SearchPage/SearchPage.tsx
@@ -439,6 +439,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
 
   handleUpdateParams = (updater: (params: SearchParams) => SearchParams) => {
     const params = updater(this.state.params!);
+    //console.log("Search Page handle update params", params)
     this.previousSearchData = [];
     if (!equals(params.q, this.state.params && this.state.params.q)) {
       // For now search doesn't work well with args list
@@ -529,6 +530,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     const { presentSiteView } = this.props;
     return (
       <ParamsQueryComponent
+        fetchPolicy={"network-only"}
         key={`${hash}+${JSON.stringify(this.state?.params)}`}
         query={SearchPageParamsQuery}
         variables={{ hash }}
@@ -680,13 +682,14 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     }
     //Originally thought this should be an updateSearchParams call but seems to error out
     //Commented out the application seems to still function as inteded. All the aggs update appropriately with no hash, with a hash. So far has passed all my current tests.
-    // Will leave it in and commented out for now as a reminder to come back and look into it.  
-    // this.setState({
-    //   params: {
-    //     ...params,
-    //   },
-    // });
+    // Will leave it in and commented out for now as a reminder to come back and look into it.
+     this.setState({
+      params: {
+        ...params,
+       },
+     });
   }
+
   findFilter = (variable: string) => {
     let aggFilter = this.state.params?.aggFilters;
     let response = find(propEq('field', variable), aggFilter || []) as {


### PR DESCRIPTION
As a temporary fix sets fetch policy to network only for query SearchPageParamsQuery, it skips the use of cache and will force network request to get the data. (does not help performance) 
Sort order button toggle is working continuously.