### PR TITLE
RTM: CW-79-Improves display of crowd tags 

### DIFF
--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -141,7 +141,7 @@ const QUERY = gql`
   }
 `;
 const QUERY_NO_RESULTS = gql`
-  query SearchPageSearchQueryNoResults(
+  query SearchPageSearchQuery(
     $q: SearchQueryInput!
     $page: Int
     $pageSize: Int

--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -141,7 +141,7 @@ const QUERY = gql`
   }
 `;
 const QUERY_NO_RESULTS = gql`
-  query SearchPageSearchQuery(
+  query SearchPageSearchQueryNoResults(
     $q: SearchQueryInput!
     $page: Int
     $pageSize: Int

--- a/front/src/global-styles.ts
+++ b/front/src/global-styles.ts
@@ -42,6 +42,19 @@ label {
   color: ${props => props.theme.crumbs.crumbFont} !important;
   line-height: 1.85em;
 }
+.crumb-wrapper{
+  display: flex;
+  flex-wrap:wrap;
+}
+.list-group-item {
+  position: relative;
+  display: block;
+  padding: 10px 15px;
+  margin-bottom: -1px;
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
 div.crumbs-bar span.label {
   background: #55B88D !important;
   color: #fff !important;


### PR DESCRIPTION
Additional global style defined to help improve the look of the crwod tags. 

![faux-crumbs](https://user-images.githubusercontent.com/17464571/94832358-6efd2a00-03d3-11eb-8c6d-fda49bfa0e09.png)
![faux-crumbs-wrapped](https://user-images.githubusercontent.com/17464571/94832367-702e5700-03d3-11eb-9968-5a0a9b47cb31.png)
![faux-crumbs-config](https://user-images.githubusercontent.com/17464571/94832372-715f8400-03d3-11eb-91d9-3d2f89321efd.png)





*Additionally snuck into this:  changed name of the added query in PR #809 previously left the same but when restarting enviornment causes error because that query already exists.