### PR TITLE
RTM: Update SearchView2.tsx

### DIFF
--- a/front/src/containers/SearchPage/SearchView2.tsx
+++ b/front/src/containers/SearchPage/SearchView2.tsx
@@ -141,7 +141,7 @@ const QUERY = gql`
   }
 `;
 const QUERY_NO_RESULTS = gql`
-  query SearchPageSearchQuery(
+  query SearchPageSearchQueryNoResults(
     $q: SearchQueryInput!
     $page: Int
     $pageSize: Int


### PR DESCRIPTION
changed name of the added query in PR #809, previously left the same but when restarting environment causes error because that query already has been defined. 