### PR TITLE
CW-100 refactor search page

### DIFF
--- a/front/src/containers/SearchPage/SearchPage.tsx
+++ b/front/src/containers/SearchPage/SearchPage.tsx
@@ -467,19 +467,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     this.setState({ openedAgg: { name, kind } });
   };
 
-  // handleAggsUpdate = (
-  //   searchAggs: AggBucketMap,
-  //   searchCrowdAggs: AggBucketMap
-  // ) => {
-  //   if (
-  //     !equals(searchAggs, this.state.searchAggs) ||
-  //     !equals(searchCrowdAggs, this.state.searchCrowdAggs)
-  //   ) {
-  //     this.setState({ searchAggs, searchCrowdAggs }, () =>
-  //       this.updateSearchParams(this.state.params)
-  //     );
-  //   }
-  // };
 
   renderAggs = siteView => {
     const opened = this.state.openedAgg && this.state.openedAgg.name;
@@ -487,8 +474,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     const { aggFilters = [], crowdAggFilters = [] } = this.state.params || {};
     return (
       <Aggs
-        // aggs={this.state.searchAggs}
-        // crowdAggs={this.state.searchCrowdAggs}
         filters={this.transformFilters(aggFilters)}
         crowdFilters={this.transformFilters(crowdAggFilters)}
         addFilter={pipe(addFilter, this.handleUpdateParams)}
@@ -538,9 +523,7 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
               onBulkUpdate={this.handleBulkUpdateClick}
               onUpdateParams={this.handleUpdateParams}
               onRowClick={this.handleRowClick}
-              // onAggsUpdate={this.handleAggsUpdate}
               searchHash={hash || ''}
-              // crowdAggs={this.state.searchCrowdAggs}
               searchParams={this.state.params}
               presentSiteView={presentSiteView}
               getTotalResults={this.getTotalResults}
@@ -744,8 +727,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
             </ThemedButton>
         )}
         <Aggs
-          // aggs={this.state.searchAggs}
-          // crowdAggs={this.state.searchCrowdAggs}
           filters={this.transformFilters(aggFilters)}
           crowdFilters={this.transformFilters(crowdAggFilters)}
           addFilter={pipe(addFilter, this.handleUpdateParams)}

--- a/front/src/containers/SearchPage/SearchPage.tsx
+++ b/front/src/containers/SearchPage/SearchPage.tsx
@@ -319,8 +319,6 @@ interface SearchPageState {
     name: string;
     kind: AggKind;
   } | null;
-  searchAggs: AggBucketMap;
-  searchCrowdAggs: AggBucketMap;
   removeSelectAll: boolean;
   totalRecords: number;
   collapseFacetBar: boolean;
@@ -339,8 +337,6 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
   state: SearchPageState = {
     params: null,
     openedAgg: null,
-    searchAggs: {},
-    searchCrowdAggs: {},
     removeSelectAll: false,
     totalRecords: 0,
     collapseFacetBar:false
@@ -471,19 +467,19 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     this.setState({ openedAgg: { name, kind } });
   };
 
-  handleAggsUpdate = (
-    searchAggs: AggBucketMap,
-    searchCrowdAggs: AggBucketMap
-  ) => {
-    if (
-      !equals(searchAggs, this.state.searchAggs) ||
-      !equals(searchCrowdAggs, this.state.searchCrowdAggs)
-    ) {
-      this.setState({ searchAggs, searchCrowdAggs }, () =>
-        this.updateSearchParams(this.state.params)
-      );
-    }
-  };
+  // handleAggsUpdate = (
+  //   searchAggs: AggBucketMap,
+  //   searchCrowdAggs: AggBucketMap
+  // ) => {
+  //   if (
+  //     !equals(searchAggs, this.state.searchAggs) ||
+  //     !equals(searchCrowdAggs, this.state.searchCrowdAggs)
+  //   ) {
+  //     this.setState({ searchAggs, searchCrowdAggs }, () =>
+  //       this.updateSearchParams(this.state.params)
+  //     );
+  //   }
+  // };
 
   renderAggs = siteView => {
     const opened = this.state.openedAgg && this.state.openedAgg.name;
@@ -491,8 +487,8 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
     const { aggFilters = [], crowdAggFilters = [] } = this.state.params || {};
     return (
       <Aggs
-        aggs={this.state.searchAggs}
-        crowdAggs={this.state.searchCrowdAggs}
+        // aggs={this.state.searchAggs}
+        // crowdAggs={this.state.searchCrowdAggs}
         filters={this.transformFilters(aggFilters)}
         crowdFilters={this.transformFilters(crowdAggFilters)}
         addFilter={pipe(addFilter, this.handleUpdateParams)}
@@ -542,9 +538,9 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
               onBulkUpdate={this.handleBulkUpdateClick}
               onUpdateParams={this.handleUpdateParams}
               onRowClick={this.handleRowClick}
-              onAggsUpdate={this.handleAggsUpdate}
+              // onAggsUpdate={this.handleAggsUpdate}
               searchHash={hash || ''}
-              crowdAggs={this.state.searchCrowdAggs}
+              // crowdAggs={this.state.searchCrowdAggs}
               searchParams={this.state.params}
               presentSiteView={presentSiteView}
               getTotalResults={this.getTotalResults}
@@ -748,8 +744,8 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
             </ThemedButton>
         )}
         <Aggs
-          aggs={this.state.searchAggs}
-          crowdAggs={this.state.searchCrowdAggs}
+          // aggs={this.state.searchAggs}
+          // crowdAggs={this.state.searchCrowdAggs}
           filters={this.transformFilters(aggFilters)}
           crowdFilters={this.transformFilters(crowdAggFilters)}
           addFilter={pipe(addFilter, this.handleUpdateParams)}

--- a/front/src/containers/SearchPage/Types.ts
+++ b/front/src/containers/SearchPage/Types.ts
@@ -1,5 +1,6 @@
 import { filter } from 'ramda';
 import { SortInput, AggFilterInput } from 'types/globalTypes';
+import { SearchQueryInput } from 'types/globalTypes'
 
 export type Params = {};
 
@@ -45,6 +46,15 @@ export interface SortItem {
 
 export interface SearchParams {
   readonly q: string[];
+  readonly page: number;
+  readonly pageSize: number;
+  readonly aggFilters: AggFilterInput[];
+  readonly crowdAggFilters: AggFilterInput[];
+  readonly sorts: SortInput[];
+}
+
+export interface SearchParamsAsInput {
+  readonly q: SearchQueryInput;
   readonly page: number;
   readonly pageSize: number;
   readonly aggFilters: AggFilterInput[];

--- a/front/src/containers/SearchPage/components/Aggs.tsx
+++ b/front/src/containers/SearchPage/components/Aggs.tsx
@@ -15,7 +15,7 @@ import {
   AggBucketMap,
   AggCallback,
   AggregateAggCallback,
-  SearchParams,
+  SearchParamsAsInput,
   AggKind,
   AggFilterMap,
 } from '../Types';
@@ -112,7 +112,7 @@ interface AggsProps {
   addFilters: AggregateAggCallback;
   removeFilter: AggCallback;
   removeFilters: AggregateAggCallback;
-  searchParams: SearchParams;
+  searchParams: SearchParamsAsInput;
   opened: string | null;
   openedKind: AggKind | null;
   onOpen: (agg: string, kind: AggKind) => void;
@@ -196,7 +196,6 @@ class Aggs extends React.PureComponent<AggsProps> {
       return (
         <QueryComponent
           query={QUERY}
-          //@ts-ignore
           variables={searchParams}
         >
           {({ data, loading, error }) => {

--- a/front/src/types/SearchPageAggsQuery.ts
+++ b/front/src/types/SearchPageAggsQuery.ts
@@ -1,0 +1,65 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { SearchQueryInput, SortInput, AggFilterInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL query operation: SearchPageAggsQuery
+// ====================================================
+
+export interface SearchPageAggsQuery_crowdAggs_aggs_buckets {
+  __typename: "AggBucket";
+  key: string;
+  keyAsString: string | null;
+  docCount: number;
+}
+
+export interface SearchPageAggsQuery_crowdAggs_aggs {
+  __typename: "Agg";
+  buckets: SearchPageAggsQuery_crowdAggs_aggs_buckets[];
+}
+
+export interface SearchPageAggsQuery_crowdAggs {
+  __typename: "SearchResultSet";
+  aggs: SearchPageAggsQuery_crowdAggs_aggs[] | null;
+}
+
+export interface SearchPageAggsQuery_search_aggs_buckets {
+  __typename: "AggBucket";
+  key: string;
+  docCount: number;
+}
+
+export interface SearchPageAggsQuery_search_aggs {
+  __typename: "Agg";
+  name: string;
+  buckets: SearchPageAggsQuery_search_aggs_buckets[];
+}
+
+export interface SearchPageAggsQuery_search {
+  __typename: "SearchResultSet";
+  /**
+   * Total results
+   */
+  recordsTotal: number | null;
+  aggs: SearchPageAggsQuery_search_aggs[] | null;
+}
+
+export interface SearchPageAggsQuery {
+  crowdAggs: SearchPageAggsQuery_crowdAggs;
+  /**
+   * Searches params by searchHash on server and `params` argument into it
+   */
+  search: SearchPageAggsQuery_search | null;
+}
+
+export interface SearchPageAggsQueryVariables {
+  q: SearchQueryInput;
+  page?: number | null;
+  pageSize?: number | null;
+  sorts?: SortInput[] | null;
+  aggFilters?: AggFilterInput[] | null;
+  crowdAggFilters?: AggFilterInput[] | null;
+}

--- a/front/src/types/SearchPageSearchQuery.ts
+++ b/front/src/types/SearchPageSearchQuery.ts
@@ -9,26 +9,6 @@ import { SearchQueryInput, SortInput, AggFilterInput } from "./globalTypes";
 // GraphQL query operation: SearchPageSearchQuery
 // ====================================================
 
-export interface SearchPageSearchQuery_crowdAggs_aggs_buckets {
-  __typename: "AggBucket";
-  key: string;
-}
-
-export interface SearchPageSearchQuery_crowdAggs_aggs {
-  __typename: "Agg";
-  buckets: SearchPageSearchQuery_crowdAggs_aggs_buckets[];
-}
-
-export interface SearchPageSearchQuery_crowdAggs {
-  __typename: "SearchResultSet";
-  aggs: SearchPageSearchQuery_crowdAggs_aggs[] | null;
-}
-
-export interface SearchPageSearchQuery_search_aggs {
-  __typename: "Agg";
-  name: string;
-}
-
 export interface SearchPageSearchQuery_search_studies {
   __typename: "ElasticStudy";
   averageRating: number;
@@ -86,7 +66,6 @@ export interface SearchPageSearchQuery_search {
    * Total results
    */
   recordsTotal: number | null;
-  aggs: SearchPageSearchQuery_search_aggs[] | null;
   /**
    * A set of matching studies
    */
@@ -94,7 +73,6 @@ export interface SearchPageSearchQuery_search {
 }
 
 export interface SearchPageSearchQuery {
-  crowdAggs: SearchPageSearchQuery_crowdAggs;
   /**
    * Searches params by searchHash on server and `params` argument into it
    */

--- a/front/src/types/SearchPageSearchQueryNoResults.ts
+++ b/front/src/types/SearchPageSearchQueryNoResults.ts
@@ -1,0 +1,34 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { SearchQueryInput, SortInput, AggFilterInput } from "./globalTypes";
+
+// ====================================================
+// GraphQL query operation: SearchPageSearchQueryNoResults
+// ====================================================
+
+export interface SearchPageSearchQueryNoResults_search {
+  __typename: "SearchResultSet";
+  /**
+   * Total results
+   */
+  recordsTotal: number | null;
+}
+
+export interface SearchPageSearchQueryNoResults {
+  /**
+   * Searches params by searchHash on server and `params` argument into it
+   */
+  search: SearchPageSearchQueryNoResults_search | null;
+}
+
+export interface SearchPageSearchQueryNoResultsVariables {
+  q: SearchQueryInput;
+  page?: number | null;
+  pageSize?: number | null;
+  sorts?: SortInput[] | null;
+  aggFilters?: AggFilterInput[] | null;
+  crowdAggFilters?: AggFilterInput[] | null;
+}


### PR DESCRIPTION
First step in our refactor.

Removes CrowdAggs and Aggs from our State in SearchPage 

Instead each component queries only the data it needs. 

After implementing cut reloads by about 30%