### PR TITLE
CW-76 Bug- Average rating displaying undefined instead of stars 

### DIFF
--- a/front/src/containers/AggDropDown/Bucket.tsx
+++ b/front/src/containers/AggDropDown/Bucket.tsx
@@ -11,6 +11,7 @@ class Bucket extends React.Component<BucketProps> {
   render() {
     let text = '';
     const { value, display, docCount } = this.props;
+    let intValue = Math.floor(Number(value))
     switch (display) {
       case FieldDisplay.STAR:
         text = {
@@ -20,7 +21,7 @@ class Bucket extends React.Component<BucketProps> {
           3: '★★★☆☆',
           4: '★★★★☆',
           5: '★★★★★',
-        }[value];
+        }[intValue];
         break;
       case FieldDisplay.DATE:
         text = new Date(parseInt(value.toString(), 10))


### PR DESCRIPTION
Switch statement expected a int value from 0-5 and was getting decimal values,  0.0 for example.

Not sure at what point the average rating changed from a int to a decimal or if we where handling the parsing somewhere that might have been accidently removed.  In any case added the handling of that into the buckets where it was broken and seems to be back in working order.

![CW-76](https://user-images.githubusercontent.com/17464571/96030270-6c61f200-0e21-11eb-9397-665905865322.png)
