### PR TITLE
CW-93 Wiki edits warn user of unsaved before leaving page.

### DIFF
--- a/front/src/components/WikiPageEditor/WikiPageEditor.tsx
+++ b/front/src/components/WikiPageEditor/WikiPageEditor.tsx
@@ -59,10 +59,10 @@ export default function WikiPageEditor(props: Props) {
   };
 
   const { data, } = props;
-  console.log("DATA", data)
+  //console.log("DATA", data)
   if (!data || !data.study || !data.study.wikiPage) return null;
   const text = getEditorText() || '';
-  console.log("TEXT", text)
+  //console.log("TEXT", text)
   if (text !== data.study.wikiPage.content && !text) {
     handlePreview()
 
@@ -71,10 +71,10 @@ export default function WikiPageEditor(props: Props) {
         data.study.wikiPage.content || '',
         'markdown'
       );
-      console.log("RICH", richEditorText)
+      //console.log("RICH", richEditorText)
       setRichEditorText(richEditorText);
     } else {
-      console.log("PLAIN", text)
+      //console.log("PLAIN", text)
       setplainEditorText(text);
     }
   }
@@ -83,7 +83,7 @@ export default function WikiPageEditor(props: Props) {
   if (!data) return <BeatLoader />;
 
   if (editorState === 'rich') {
-    console.log("RICH", richEditorText)
+   // console.log("RICH", richEditorText)
     return (
       <Panel>
         <Panel.Body>

--- a/front/src/components/WikiPageEditor/WikiPageEditor.tsx
+++ b/front/src/components/WikiPageEditor/WikiPageEditor.tsx
@@ -59,10 +59,8 @@ export default function WikiPageEditor(props: Props) {
   };
 
   const { data, } = props;
-  //console.log("DATA", data)
   if (!data || !data.study || !data.study.wikiPage) return null;
   const text = getEditorText() || '';
-  //console.log("TEXT", text)
   if (text !== data.study.wikiPage.content && !text) {
     handlePreview()
 
@@ -71,10 +69,8 @@ export default function WikiPageEditor(props: Props) {
         data.study.wikiPage.content || '',
         'markdown'
       );
-      //console.log("RICH", richEditorText)
       setRichEditorText(richEditorText);
     } else {
-      //console.log("PLAIN", text)
       setplainEditorText(text);
     }
   }
@@ -83,7 +79,6 @@ export default function WikiPageEditor(props: Props) {
   if (!data) return <BeatLoader />;
 
   if (editorState === 'rich') {
-   // console.log("RICH", richEditorText)
     return (
       <Panel>
         <Panel.Body>

--- a/front/src/containers/Islands/WikiPageIsland.tsx
+++ b/front/src/containers/Islands/WikiPageIsland.tsx
@@ -9,7 +9,7 @@ import QUERY from 'queries/WikiPageQuery';
 import { useQuery, useMutation } from 'react-apollo';
 import CurrentUser, { useCurrentUser, QUERY as UserQuery } from 'containers/CurrentUser/CurrentUser';
 import useUrlParams, { queryStringAll } from 'utils/UrlParamsProvider';
-import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
+import { useHistory, useLocation, useRouteMatch, Prompt } from 'react-router-dom';
 import { BeatLoader } from 'react-spinners';
 import { Switch, Route } from 'react-router';
 import { trimPath } from 'utils/helpers';
@@ -124,13 +124,21 @@ export default function WikiPageIsland(props: Props) {
     const editorTextData =
       data.study && data.study.wikiPage && data.study.wikiPage.content;
 
+    let editMessage = `Changes not saved. Are you sure you want to leave while editing?` ;
+
     return (
+    <div>
+      <Prompt
+      when={!readOnly}
+      message={location => editMessage}
+      />
       <ThemedButton
-        onClick={() => handleEditSubmit(updateContentMutation)}
+        onClick={() => {editMessage = "Save changes?";  handleEditSubmit(updateContentMutation);}}
         disabled={editorTextState === editorTextData}
         style={{ marginLeft: '10px' }}>
         Save <FontAwesome name="pencil" />
       </ThemedButton>
+    </div>
     );
   };
 


### PR DESCRIPTION
-Prompts user before navigation ( back in browser, back to search results, admin console, next, first, etc.) to verify before leaving page while editing the Wiki section is active.
-On save button prompt to verify save of current changes.