### PR TITLE
Cw 107 default bug

### DIFF
--- a/front/src/components/AuthHeader/AuthHeader.tsx
+++ b/front/src/components/AuthHeader/AuthHeader.tsx
@@ -77,12 +77,13 @@ const StyledWrapper = styled.div`
     color: #333;
   }
 
-  a#logo {
+  div#logo {
     background: url(${logo}) center left no-repeat;
     background-size: 100px 30px;
     padding-left: 30px;
     color: ${props => props.theme.authHeader.logoFont};
     min-width: 110px;
+    cursor: pointer;
   }
   span#small {
     font-size: 14px;
@@ -93,6 +94,13 @@ const StyledWrapper = styled.div`
 const ThemedStyledWrapper = withTheme(StyledWrapper);
 
 export class AuthHeader extends React.PureComponent<AuthHeaderProps> {
+
+  pushToDefault = () => {
+    // this is a temp fix to handle default hash not getting updated on logo click
+      this.props.history.push('/search?sv=default')
+      window.location.reload()
+  }
+
   render() {
     return (
       <QueryComponent
@@ -114,9 +122,9 @@ export class AuthHeader extends React.PureComponent<AuthHeaderProps> {
                 style={{ paddingLeft: '15px', paddingRight: '15px' }}>
                 <Navbar.Header>
                   <Navbar.Brand>
-                    <Link id="logo" to="/search?sv=default">
+                    <div id="logo" onClick={this.pushToDefault}>
                       <span></span>
-                    </Link>
+                    </div>
                   </Navbar.Brand>
                   <Navbar.Toggle />
                 </Navbar.Header>

--- a/front/src/containers/SearchPage/SearchPage.tsx
+++ b/front/src/containers/SearchPage/SearchPage.tsx
@@ -484,6 +484,10 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
   renderSearch = () => {
     const hash = this.getHashFromLocation();
     const { presentSiteView } = this.props;
+    const FILTERED_PARAMS = {
+      ...DEFAULT_PARAMS,
+      ...preselectedFilters(presentSiteView),
+    };
     return (
       <ParamsQueryComponent
         fetchPolicy={"network-only"}
@@ -495,6 +499,14 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
         }}>
         {({ data, loading, error }) => {
           if (error || loading) return null;
+          if(!hash && !loading){
+
+            console.log("DEFAULT", FILTERED_PARAMS)
+            this.updateSearchParams(DEFAULT_PARAMS)          
+
+            //Breaks when passing FILTERED_PARAMS
+            // this.updateSearchParams(FILTERED_PARAMS)          
+    }
 
           const params: SearchParams = this.searchParamsFromQuery(
             data!.searchParams,
@@ -526,6 +538,11 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
 
   componentDidMount() {
     let searchTerm = new URLSearchParams(this.props.location?.search || '');
+    const FILTERED_PARAMS = {
+      ...DEFAULT_PARAMS,
+      ...preselectedFilters(this.props.presentSiteView),
+    };
+                                                                                
     if (window.innerWidth < 768) {
       this.setState({ collapseFacetBar: true })
     }
@@ -547,6 +564,14 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
         },
         () => this.updateSearchParams(this.state.params)
       );
+
+    }if(!searchTerm.has('hash')){
+      console.log(2)
+      
+      //Breaks when passing FILTERED_PARAMS
+      // this.updateSearchParams(FILTERED_PARAMS)
+      this.updateSearchParams(DEFAULT_PARAMS)
+
     }
     if (this.props.intervention) {
       //@ts-ignore

--- a/front/src/containers/SearchPage/SearchPage.tsx
+++ b/front/src/containers/SearchPage/SearchPage.tsx
@@ -499,14 +499,12 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
         }}>
         {({ data, loading, error }) => {
           if (error || loading) return null;
-          if(!hash && !loading){
+          // if(!hash && !loading){
 
-            console.log("DEFAULT", FILTERED_PARAMS)
-            this.updateSearchParams(DEFAULT_PARAMS)          
-
-            //Breaks when passing FILTERED_PARAMS
-            // this.updateSearchParams(FILTERED_PARAMS)          
-    }
+          //   this.updateSearchParams(DEFAULT_PARAMS)          
+          //   //Breaks when passing FILTERED_PARAMS
+          //   // this.updateSearchParams(FILTERED_PARAMS)          
+          // }
 
           const params: SearchParams = this.searchParamsFromQuery(
             data!.searchParams,
@@ -565,12 +563,9 @@ class SearchPage extends React.Component<SearchPageProps, SearchPageState> {
         () => this.updateSearchParams(this.state.params)
       );
 
-    }if(!searchTerm.has('hash')){
-      console.log(2)
-      
-      //Breaks when passing FILTERED_PARAMS
-      // this.updateSearchParams(FILTERED_PARAMS)
-      this.updateSearchParams(DEFAULT_PARAMS)
+    }   
+    if(!searchTerm.has('hash') ){
+      this.updateSearchParams(FILTERED_PARAMS)
 
     }
     if (this.props.intervention) {


### PR DESCRIPTION
1. Urls with no hash get hash based on site params in componentDidMount

2. When clicking on the logo we were getting caught in loop due to a hash update/params update state war. The fix is probably a continuing refactor of some of the searchpage flow of operations. for quick fix we are reloading the entire page when a user clicks on the logo which then just reverts to step 1. Not great but should work for the time being. 