### PR TITLE
fixing default presearch content and panel styles

### DIFF
--- a/front/src/components/StyledComponents/index.ts
+++ b/front/src/components/StyledComponents/index.ts
@@ -114,6 +114,8 @@ const PresearchCard = styled.div`
   min-width: 320px;
   max-width: 320px;
   background: white;
+  //working on preserach fix
+  min-height: 320px;
 `;
 
 export const ThemedPresearchCard = withTheme(PresearchCard);
@@ -121,8 +123,8 @@ export const ThemedPresearchCard = withTheme(PresearchCard);
 const PresearchHeader = styled.div`
   background-color: ${props => props.theme.presearch.presearchHeaders};
   padding: 5px;
-  // border-top-left-radius: 12px;
-  // border-top-right-radius: 12px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
   height: 50px;
   display: flex;
   flex-direction: row;
@@ -311,7 +313,8 @@ export const TextFieldToggle = styled.div`
 
 export const PresearchFilter = styled.div`
   margin-left: 5px;
-  max-height: 30px;
+  //presearch-style fix
+  // max-height: 30px;
 `;
 
 export const PresearchPanel = styled.div`
@@ -319,7 +322,7 @@ export const PresearchPanel = styled.div`
   max-height: 200px;
  /*  min-height: 200px; */
   margin-left: 5px;
-  margin-top: 30px;
+  // margin-top: 30px;
   position: relative;
     .dropDownFacet{
       position: relative;

--- a/front/src/containers/AggDropDown/AggDropDown.tsx
+++ b/front/src/containers/AggDropDown/AggDropDown.tsx
@@ -642,7 +642,7 @@ class AggDropDown extends React.Component<AggDropDownProps, AggDropDownState> {
       field?.display === FieldDisplay.DROP_DOWN
     ){
       return (
-      <PresearchContent>
+      <>
         <PresearchPanel>
           <Filter
             buckets={buckets}
@@ -673,12 +673,12 @@ class AggDropDown extends React.Component<AggDropDownProps, AggDropDownState> {
             field={field}
           />
         </PresearchPanel>
-      </PresearchContent>
+      </>
     );
     }
 
     return (
-      <PresearchContent>
+      <>
         <PresearchFilter>
           <Filter
             buckets={buckets}
@@ -707,7 +707,7 @@ class AggDropDown extends React.Component<AggDropDownProps, AggDropDownState> {
             field={field}
           />
         </PresearchPanel>
-      </PresearchContent>
+      </>
     );
   };
 


### PR DESCRIPTION
Fixed redudant presearch container styles that were affecting the dropdown container and also creating really messed up margins on other presearch panels.

Fixed curved presearch headers.