### PR TITLE
CW-68-Reviews Flow

### DIFF
--- a/front/src/containers/ReviewForm/ReviewForm.tsx
+++ b/front/src/containers/ReviewForm/ReviewForm.tsx
@@ -185,7 +185,7 @@ class ReviewForm extends React.Component<ReviewFormProps, ReviewFormState> {
         nctId: this.props.nctId,
       },
     });
-    this.setState(defaultState);
+    this.setState(defaultState, ()=>this.props.handleClose());
   };
 
   renderMeta = () => {


### PR DESCRIPTION
After a user submits a review brings them back to the previous screen displaying the reviews. Achieves this by pushing user away from the `/new` route that gets appended to the url when we click `Write a Review`.

![2020-10-28-10-53-13](https://user-images.githubusercontent.com/17464571/97462323-9381ee80-190c-11eb-9ebf-68ee73002581.gif)

Small edit but large improvement in user experience in my opinion. 