### PR TITLE
CW-124 truncate showing ellipses when necessary

### DIFF
--- a/front/src/components/MailMerge/MailMergeHelpers.ts
+++ b/front/src/components/MailMerge/MailMergeHelpers.ts
@@ -47,6 +47,7 @@ export function registerHandlebarsHelpers() {
     return newVal
 });
   Handlebars.registerHelper('$TRUNCATE', (value: string, characters: number) => {
+    if(value.length<characters) return value
     let ellipses = '...'
     let newVal = value.slice(0,characters) 
     let cutValues = value.slice(characters, value.length)


### PR DESCRIPTION


Previously truncate appended the ellipses at the end of the value even if it was within the character limit. Therefore when hovering over the ellipses nothing was displayed. Conditional check if it's within character bounds will just return value. 


First Screenshot illustrates the old behavior. 

![CW-124](https://user-images.githubusercontent.com/17464571/97468446-4b19ff00-1913-11eb-8824-3835bf60a878.png)



This GIF tries to illustrate the new and originally desired behavior. 
![2020-10-28-11-39-31](https://user-images.githubusercontent.com/17464571/97468542-6a189100-1913-11eb-8d8f-a86be61e72b2.gif)