### PR TITLE
CW-119 Find and Replace next iteration 

### DIFF
--- a/front/src/components/MailMerge/MailMergeHelpers.ts
+++ b/front/src/components/MailMerge/MailMergeHelpers.ts
@@ -58,12 +58,16 @@ export function registerHandlebarsHelpers() {
     console.log("NEW:", newVal)
     return newVal
 });
-  Handlebars.registerHelper('$FindAndReplace', ( valueToFind: string, value:string, valueToReplace: string ) => {
-
-    if(valueToReplace.toLowerCase() == valueToFind.toLowerCase()){
-      return new Handlebars.SafeString(value);
+  Handlebars.registerHelper('$FindAndReplace', ( arrayOfValuesToFind: string, arrayOfValues:string, valueToReplace: string ) => {
+    let valuesToFind: string[] = arrayOfValuesToFind.toLowerCase().replace(/\s/g, "").split('|');
+    let values: string[] = arrayOfValues.replace(/\s/g, "").split('|');
+    
+    let indexFound= valuesToFind.indexOf(valueToReplace.toLocaleLowerCase())
+    if ( indexFound== -1){
+      return new Handlebars.SafeString(valueToReplace)
+    }else{
+      return new Handlebars.SafeString(values[indexFound])
     }
-  return valueToReplace
   });
 
 }

--- a/front/src/components/MailMerge/MailMergeHelpers.ts
+++ b/front/src/components/MailMerge/MailMergeHelpers.ts
@@ -60,9 +60,8 @@ export function registerHandlebarsHelpers() {
 });
   Handlebars.registerHelper('$FindAndReplace', ( arrayOfValuesToFind: string, arrayOfValues:string, valueToReplace: string ) => {
     let valuesToFind: string[] = arrayOfValuesToFind.toLowerCase().replace(/\s/g, "").split('|');
-    let values: string[] = arrayOfValues.replace(/\s/g, "").split('|');
-    
-    let indexFound= valuesToFind.indexOf(valueToReplace.toLocaleLowerCase())
+    let values: string[] = arrayOfValues.split('|');
+    let indexFound= valuesToFind.indexOf(valueToReplace.toLocaleLowerCase().replace(/\s/g, ""))
     if ( indexFound== -1){
       return new Handlebars.SafeString(valueToReplace)
     }else{


### PR DESCRIPTION
Can now feed a series of pipe separated strings to include in your find and replace. In the example I have recruiting, available, suspended, and terminated as the values I am looking for with their respective replacements (also pipe separated). 

![CW-119](https://user-images.githubusercontent.com/17464571/97479334-1c565580-1920-11eb-91fa-960be0ab08e4.png)


Attached is the results

![2020-10-28-13-30-16](https://user-images.githubusercontent.com/17464571/97480750-dbf7d700-1921-11eb-914e-93cc3f75dee8.gif)
