### PR TITLE
removed a config from config/puma for development

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -17,7 +17,7 @@
 workers Integer(ENV.fetch("WEB_CONCURRENCY", 2))
 threads_count = Integer(ENV.fetch("MAX_THREADS", 2))
 threads(threads_count, threads_count)
-worker_timeout (24*60*60) if ENV['RAILS_ENV']=='development'
+#worker_timeout (24*60*60) if ENV['RAILS_ENV']=='development'
 
 preload_app!
 


### PR DESCRIPTION
commented out worker_timeout (24*60*60) if ENV['RAILS_ENV']=='development' in config/puma