### PR TITLE
CW-129 fix for config preselected and visible options

### DIFF
--- a/front/src/components/SiteForm/AggField.tsx
+++ b/front/src/components/SiteForm/AggField.tsx
@@ -300,6 +300,7 @@ class AggField extends React.Component<AggFieldProps, AggFieldState> {
                 updater: preselectedUpdater,
               }}>
               <AggDropDown
+                fromAggField={true}
                 agg={this.props.field.name}
                 aggKind={this.props.kind}
                 searchParams={searchParams}
@@ -341,6 +342,7 @@ class AggField extends React.Component<AggFieldProps, AggFieldState> {
                 updater: visibleOptionsUpdater,
               }}>
               <AggDropDown
+                fromAggField={true}
                 agg={this.props.field.name}
                 aggKind={this.props.kind}
                 searchParams={{

--- a/front/src/containers/AggDropDown/AggDropDown.tsx
+++ b/front/src/containers/AggDropDown/AggDropDown.tsx
@@ -137,6 +137,7 @@ interface AggDropDownProps {
   client: ApolloClient<any>;
   site: PresentSiteFragment;
   presentSiteView: PresentSiteFragment_siteView;
+  fromAggField: boolean;
 }
 
 class AggDropDown extends React.Component<AggDropDownProps, AggDropDownState> {
@@ -422,9 +423,10 @@ class AggDropDown extends React.Component<AggDropDownProps, AggDropDownState> {
       );
     }
     else if (
-      field?.display === FieldDisplay.DROP_DOWN ||
+      (field?.display === FieldDisplay.DROP_DOWN ||
       field?.display === FieldDisplay.LESS_THAN_DROP_DOWN ||
-      field?.display === FieldDisplay.GREATER_THAN_DROP_DOWN
+      field?.display === FieldDisplay.GREATER_THAN_DROP_DOWN)
+      && !this.props.fromAggField
     ){
       return (
       <Panel.Collapse className="bm-panel-collapse">

--- a/front/src/containers/AggDropDown/AggDropDown.tsx
+++ b/front/src/containers/AggDropDown/AggDropDown.tsx
@@ -137,7 +137,7 @@ interface AggDropDownProps {
   client: ApolloClient<any>;
   site: PresentSiteFragment;
   presentSiteView: PresentSiteFragment_siteView;
-  fromAggField: boolean;
+  fromAggField?: boolean;
 }
 
 class AggDropDown extends React.Component<AggDropDownProps, AggDropDownState> {


### PR DESCRIPTION
Makes preselected values & visible options on siteview config aggs show as checkboxes