### PR TITLE
Cw-198 remove buckets from AggsQuery

### DIFF
--- a/front/src/containers/SearchPage/components/Aggs.tsx
+++ b/front/src/containers/SearchPage/components/Aggs.tsx
@@ -54,11 +54,7 @@ const QUERY = gql`
       }
     ) {
       aggs {
-        buckets {
-          key
-          keyAsString
-          docCount
-        }
+        name
       }
     }
     search(
@@ -74,10 +70,6 @@ const QUERY = gql`
       recordsTotal
       aggs {
         name
-        buckets {
-          key
-          docCount
-        }
       }
     }
   }


### PR DESCRIPTION
Buckets was redundant as it gets queried again when agg opens 