### PR TITLE
Fix for crowd aggs disappearing

### DIFF
--- a/front/src/containers/SearchPage/components/Aggs.tsx
+++ b/front/src/containers/SearchPage/components/Aggs.tsx
@@ -55,7 +55,9 @@ const QUERY = gql`
       }
     ) {
       aggs {
-        name
+        buckets{
+          key
+        }
       }
     }
     search(


### PR DESCRIPTION
Incorrectly was querying for crowdAgg "name" field which always just returned "front-matterkeys"
should really have been querying for the bucket keys which is what we use to build the crowd aggs 