### PR TITLE
Persist unchanged data during reload using previousData

### DIFF
--- a/front/src/containers/GenericPage/GenericPage.tsx
+++ b/front/src/containers/GenericPage/GenericPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState,useRef } from 'react';
 import { usePageView, usePageViews } from 'queries/PageViewQueries';
 import MailMergeView, {
   microMailMerge,
@@ -14,6 +14,7 @@ import { find, propEq } from 'ramda';
 import {usePresentSite} from "../PresentSiteProvider/PresentSiteProvider";
 import { useFragment } from 'components/MailMerge/MailMergeFragment';
 import StudyViewLogMutaion from 'queries/StudyViewLogMutation';
+import Error from 'components/Error';
 
 
 interface Props {
@@ -45,7 +46,7 @@ export default function GenericPage(props: Props) {
   const { data: pageViewData } = usePageView(defaultPage());
   const currentPage = pageViewData?.site?.pageView;
   const [ fragmentName, fragment ] = useFragment('Study', currentPage?.template || '');
-  const { data: studyData, loading, refetch } = useQuery(
+  const result = useQuery(
     getStudyQuery(fragmentName, fragment),
     {
       skip: fragment == '' || !props.arg,
@@ -60,10 +61,15 @@ export default function GenericPage(props: Props) {
     updateStudiViewLogCount();
 
   },[])
+  let studyData = result.data
+  if (studyData == undefined && result.previousData !== undefined) { studyData = result.previousData }
+  if (result.error) return <Error message={result.error.message} />;
+  if ((result.loading && studyData == undefined)) return <BeatLoader />;
+
   if (!props.arg) {
     return <h1>Missing NCTID in URL</h1>;
   }
-  if (loading || !pageViewData) {
+  if (!pageViewData) {
     return <BeatLoader />;
   }
 

--- a/front/src/containers/Islands/WorkflowIsland.tsx
+++ b/front/src/containers/Islands/WorkflowIsland.tsx
@@ -61,10 +61,8 @@ export default function WorkflowIsland(props: Props) {
   });
   const {data:user, refetch }= useQuery<CurrentUserQuery>(UserQuery)
   const [upsertMutation] = useMutation(UPSERT_LABEL_MUTATION, {
-    refetchQueries: [{ query: QUERY, variables: { nctId } }],
   });
   const [deleteMutation] = useMutation(DELETE_LABEL_MUTATION, {
-    refetchQueries: [{ query: QUERY, variables: { nctId } }],
   });
 
   const [flashAnimation, setFlashAnimation] = useState(false);
@@ -92,7 +90,6 @@ export default function WorkflowIsland(props: Props) {
   const handleResetAnimation=()=>{
     setTimeout(  resetHelper, 6500);
   }
-
   return (
   <>
     {flashAnimation == true? 

--- a/front/src/containers/WorkflowPage/SuggestedLabels.tsx
+++ b/front/src/containers/WorkflowPage/SuggestedLabels.tsx
@@ -80,7 +80,7 @@ class SuggestedLabels extends React.PureComponent<
   handleSelect = (key: string, value: string) => (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
-    this.props.showAnimation()
+    // this.props.showAnimation()
     this.props.onSelect(key, value, e.currentTarget.checked);
   };
 


### PR DESCRIPTION
Previously when interacting with the workflow on a pageview your entire page would reload. 
As of now, there is no reload on unchanged islands (i.e. facility or wikipage).  We only see a reload of the workflow island istelf.