### PR TITLE
Presearch bugs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
   "ruby.specCommand": "bundle exec rspec",
   "prettier.configPath": "./front/.prettierrc",
   "prettier.packageManager": "yarn",
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  }
 }

--- a/front/src/containers/AggDropDown/AggDropDown.tsx
+++ b/front/src/containers/AggDropDown/AggDropDown.tsx
@@ -28,27 +28,11 @@ import { FieldDisplay } from 'types/globalTypes';
 import './AggDropDownStyle.css';
 import { PresentSiteFragment, PresentSiteFragment_siteView } from 'types/PresentSiteFragment';
 import SortKind from './SortKind';
-import BucketsPanel from './BucketsPanel';
-import Filter from './Filter';
 import SearchPageCrowdAggBucketsQuery from 'queries/SearchPageCrowdAggBucketsQuery';
 import SearchPageAggBucketsQuery from 'queries/SearchPageAggBucketsQuery';
-import RangeSelector from './RangeSelector';
-import TwoLevelPieChart from './TwoLevelPieChart';
-import BarChartComponent from './BarChart'
-import AllowMissingCheckbox from './AllowMissingCheckbox';
 import { ApolloClient }  from '@apollo/client';
 import { capitalize } from 'utils/helpers';
-import {
-  ThemedPresearchCard,
-  ThemedPresearchHeader,
-  PresearchTitle,
-  PresearchFilter,
-  PresearchPanel,
-  PresearchContent,
-} from 'components/StyledComponents';
 import {withPresentSite2} from "../PresentSiteProvider/PresentSiteProvider";
-import BucketsDropDown from './BucketsDropDown';
-import LocationAgg from './LocationAgg';
 import CustomDropDown from './CustomDrop';
 import AggFilterInputUpdater from 'containers/SearchPage/components/AggFilterInputUpdater';
 import { withAggContext } from 'containers/SearchPage/components/AggFilterUpdateContext';

--- a/front/src/containers/AggDropDown/AggKeyValuePairsDropDown.tsx
+++ b/front/src/containers/AggDropDown/AggKeyValuePairsDropDown.tsx
@@ -30,24 +30,9 @@ import './AggDropDownStyle.css';
 import { PresentSiteFragment, PresentSiteFragment_siteView } from 'types/PresentSiteFragment';
 import SortKind from './SortKind';
 import BucketsKeyValuePanel from './BucketsKeyValuePanel';
-import Filter from './Filter';
 import SearchPageCrowdAggBucketsQuery from 'queries/SearchPageCrowdAggBucketsQuery';
 import SearchPageAggBucketsQuery from 'queries/SearchPageAggBucketsQuery';
-import RangeSelector from './RangeSelector';
-import TwoLevelPieChart from './TwoLevelPieChart';
-import BarChartComponent from './BarChart'
-import AllowMissingCheckbox from './AllowMissingCheckbox';
-import { capitalize } from 'utils/helpers';
-import {
-  ThemedPresearchCard,
-  ThemedPresearchHeader,
-  PresearchTitle,
-  PresearchFilter,
-  PresearchPanel,
-  PresearchContent,
-} from 'components/StyledComponents';
 import {withPresentSite2} from "../PresentSiteProvider/PresentSiteProvider";
-import BucketsDropDown from './BucketsDropDown';
 
 const PAGE_SIZE = 25;
 

--- a/front/src/containers/AggDropDown/AllowMissingDropDownItem.tsx
+++ b/front/src/containers/AggDropDown/AllowMissingDropDownItem.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react';
 import { withAggContext } from 'containers/SearchPage/components/AggFilterUpdateContext';
 import AggFilterInputUpdater from 'containers/SearchPage/components/AggFilterInputUpdater';
-import { Checkbox } from 'react-bootstrap';
 import { AggBucket } from '../SearchPage/Types';
 import bucketKeyIsMissing from 'utils/aggs/bucketKeyIsMissing';
 
-interface AllowMissingCheckboxProps {
+interface AllowMissingDropDownItemProps {
   buckets: AggBucket[] | null;
   updater: AggFilterInputUpdater;
 }
 
-function AllowMissingCheckbox(props: AllowMissingCheckboxProps) {
+function AllowMissingDropDownItem(props: AllowMissingDropDownItemProps) {
   const { buckets, updater } = props;
   let totalMissing: number = 0;
   (buckets || []).forEach(bucket => {
@@ -19,12 +18,10 @@ function AllowMissingCheckbox(props: AllowMissingCheckboxProps) {
     }
   });
   return (
-    <Checkbox
-      checked={updater.allowsMissing()}
-      onChange={() =>
-        updater.toggleAllowMissing()
-      }>{`Allow Missing (${totalMissing})`}</Checkbox>
+    <div 
+      className="item-content"
+      >{`Allow Missing (${totalMissing})`}</div>
   );
 }
 
-export default withAggContext(AllowMissingCheckbox);
+export default withAggContext(AllowMissingDropDownItem);

--- a/front/src/containers/AggDropDown/CustomDrop.tsx
+++ b/front/src/containers/AggDropDown/CustomDrop.tsx
@@ -361,7 +361,9 @@ class CustomDropDown extends React.Component<CustomDropDownProps, CustomDropDown
 
       this.setState({ selectedItems: selectedKeysPlaceHolders })
     }
-
+    if (prevProps.isOpen !== this.props.isOpen){
+      this.setState({showItems : this.props.isOpen})
+    }
     if(this.props.field.display == "GREATER_THAN_DROP_DOWN"  && prevState.selectedItems == this.state.selectedItems){
       this.setState({ selectedItems: [{start: this.props.updater.input?.gte, end : this.props.updater.input?.lte}] })
     }

--- a/front/src/containers/AggDropDown/CustomDrop.tsx
+++ b/front/src/containers/AggDropDown/CustomDrop.tsx
@@ -334,7 +334,7 @@ class CustomDropDown extends React.Component<CustomDropDownProps, CustomDropDown
   };
   componentDidMount = () => {
     if (this.props.field.defaultToOpen === true) {
-      this.setState({ showItems: true, showAdditionalCrumbs: true });
+      this.setState({ showItems: true });
       this.props.handleLoadMore()
 
     }

--- a/front/src/containers/AggDropDown/CustomDrop.tsx
+++ b/front/src/containers/AggDropDown/CustomDrop.tsx
@@ -194,7 +194,9 @@ const SelectBoxBox = styled.div`
 .select-box--crumbs{
   display:flex;
   flex-wrap: wrap;
-
+  .crumb-icon{
+    padding-left:3px;
+  }
   .crumb-icon:hover {
     cursor: pointer;
     -webkit-text-stroke: 0.5px #333;

--- a/front/src/containers/AggDropDown/CustomDrop.tsx
+++ b/front/src/containers/AggDropDown/CustomDrop.tsx
@@ -39,6 +39,7 @@ import { isLeafType } from 'graphql';
 import BucketsDropDown from './BucketsDropDown';
 import { withAggContext } from 'containers/SearchPage/components/AggFilterUpdateContext';
 import AggFilterInputUpdater from 'containers/SearchPage/components/AggFilterInputUpdater';
+import AllowMissingDropDownItem from './AllowMissingDropDownItem';
 
 interface CustomDropDownProps {
   field: SiteViewFragment_search_aggs_fields | any;
@@ -73,7 +74,7 @@ interface CustomDropDownState {
   selectedItem: any[],
   type: string,
   defaultOpen: boolean,
-  selectedItems: any[]
+  selectedItems: any[],
   hasMore: boolean,
   loading: boolean,
   filter: string,
@@ -189,6 +190,9 @@ const SelectBoxBox = styled.div`
   background-color: ${props => props.theme.button};
  }
 
+ .select-box--buckets-presearch .allow-missing{
+  background-color: #ececec;
+ }
 
 .select-box--buckets-presearch{
   max-height:200px;
@@ -536,6 +540,7 @@ class CustomDropDown extends React.Component<CustomDropDownProps, CustomDropDown
   renderPanel = () => {
     const { hasMore, buckets, handleLoadMore, field } = this.props
     const { showItems, loading } = this.state
+    const showAllowMissing = field.showAllowMissing;
     if (!this.props.isOpen) return
     if (
       field?.display === FieldDisplay.DATE_RANGE ||
@@ -600,6 +605,16 @@ class CustomDropDown extends React.Component<CustomDropDownProps, CustomDropDown
     else if (this.props.field.display == "CHECKBOX" || this.props.field.display == "STRING") {
 
       return (
+      <>
+          {showAllowMissing && (
+            <div className="select-item allow-missing" onClick={() => this.props.updater.toggleAllowMissing()} >
+              <div className="item-content">
+                {this.props.updater.allowsMissing() ? <FontAwesome name='far fa-check-square check' className={`square-checkmark${this.props.isPresearch ? "" : "-facet"}`} /> : <div className={`check-outer${this.props.isPresearch ? "" : "-facet"}`}></div>}
+
+                <AllowMissingDropDownItem buckets={buckets} />
+              </div>
+            </div>
+          )}
         <InfiniteScroll
           pageStart={0}
           loadMore={this.props.handleLoadMore}
@@ -635,11 +650,18 @@ class CustomDropDown extends React.Component<CustomDropDownProps, CustomDropDown
               </div>
             ))}
         </InfiniteScroll>
+      </>
       )
     }
     else {
 
       return (
+        <>
+          {showAllowMissing && !this.props.updater.allowsMissing() && (
+            <div className="select-item allow-missing" onClick={() => this.props.updater.toggleAllowMissing()}>
+              <AllowMissingDropDownItem buckets={buckets} className="item-content" />
+            </div>
+          )}
         <InfiniteScroll
           pageStart={0}
           loadMore={this.props.handleLoadMore}
@@ -679,6 +701,7 @@ class CustomDropDown extends React.Component<CustomDropDownProps, CustomDropDown
               )
             })}
         </InfiniteScroll>
+        </>
       )
     }
   }
@@ -691,6 +714,8 @@ class CustomDropDown extends React.Component<CustomDropDownProps, CustomDropDown
     const ThemedTitle = this.props.isPresearch ? PresearchTitle : ThemedFacetTitle
     let configuredLabel = this.props.field?.displayName || '';
     const title = aggToField(this.props.field.name, configuredLabel);
+    const showAllowMissing = this.props.field.showAllowMissing;
+
     if (this.props.buckets == undefined && this.props.isOpen) {
       return <BeatLoader />
     }
@@ -710,6 +735,16 @@ class CustomDropDown extends React.Component<CustomDropDownProps, CustomDropDown
             {this.props.isPresearch ? (
               <div className='select-box--crumbs'>
                 {this.state.selectedItems.length > 0 ? this.renderSelectedItems() : this.renderSubLabel()}
+                {showAllowMissing && this.props.updater.allowsMissing() && (
+                  <div className='select-box--crumb-container'>
+                    {'Allow Missing'}
+                    <FontAwesome
+                      className="remove crumb-icon"
+                      name="remove"
+                      onClick={() => this.props.updater.toggleAllowMissing()}
+                    />
+                  </div>
+                )}
               </div>
             ) : null}
 

--- a/front/src/containers/AggDropDown/CustomDrop.tsx
+++ b/front/src/containers/AggDropDown/CustomDrop.tsx
@@ -16,7 +16,6 @@ import {
 } from 'components/StyledComponents';
 import Filter from './Filter';
 import SortKind from './SortKind';
-// import './AggDropDownStyle.css';
 import {
   AggBucket,
 } from '../SearchPage/Types';
@@ -25,21 +24,12 @@ import { capitalize } from 'utils/helpers';
 import {
   propEq,
   findIndex,
-  find
 } from 'ramda';
 import withTheme from 'containers/ThemeProvider';
-import bucketKeyIsMissing from 'utils/aggs/bucketKeyIsMissing';
-import LocationAgg from './LocationAgg';
-import RangeSelector from './RangeSelector';
-import TwoLevelPieChart from './TwoLevelPieChart';
-import BarChartComponent from './BarChart'
-import ValueCrumb from '../../components/MultiCrumb/ValueCrumb';
-import { isLeafType } from 'graphql';
-// import ValuesCrumb from '../../components/MultiCrumb/ValueCrumbs';
-import BucketsDropDown from './BucketsDropDown';
 import { withAggContext } from 'containers/SearchPage/components/AggFilterUpdateContext';
 import AggFilterInputUpdater from 'containers/SearchPage/components/AggFilterInputUpdater';
-import AllowMissingDropDownItem from './AllowMissingDropDownItem';
+import CustomDropCrumbs from './CustomDropCrumbs';
+import CustomDropPanel from './CustomDropPanel';
 
 interface CustomDropDownProps {
   field: SiteViewFragment_search_aggs_fields | any;
@@ -326,7 +316,6 @@ class CustomDropDown extends React.Component<CustomDropDownProps, CustomDropDown
 
       if (index !== -1) {
         selectedItemsArray.splice(index, 1)
-        console.log(selectedItemsArray)
         this.setState({
           selectedItem: [],
           selectedItems: selectedItemsArray
@@ -341,116 +330,6 @@ class CustomDropDown extends React.Component<CustomDropDownProps, CustomDropDown
     }
 
   };
-  renderRangeLabel = () => {
-    let range = this.state.selectedItems[0]
-    if (!this.state.selectedItems) return
-    //@ts-ignore
-    if (!range.start) return `≤ ${range.end}`
-    //@ts-ignore
-    if (!range.end) return `≥ ${range.start}`
-    //@ts-ignore
-    return `${range.start} - ${range.end}`
-
-  }
-  renderLocationLabel = () => {
-    let location = this.state.selectedItems[0]
-    //@ts-ignore
-    if (!location.zipcode && !location.radius) return
-    //@ts-ignore
-    if (!location.zipcode) return `Within ${location.radius} of current location`
-    //@ts-ignore
-    if (!location.lat && !location.long) return `Within ${location.radius} of ${location.zipcode}`
-
-  }
-
-  renderSelectedItems = () => {
-    const { field } = this.props
-    if (this.state.selectedItems.length > 0) {
-      let displayedCrumbs: any[] = this.state.selectedItems.slice(0, field.maxCrumbs)
-      let otherValues = { key: `... ${this.state.selectedItems.length - displayedCrumbs.length} others` }
-      displayedCrumbs.push(otherValues)
-      if (field.maxCrumbs == 0 || field.maxCrumbs == null) return
-      return displayedCrumbs.map((item: AggBucket, index) => {
-        if (
-          field?.display === FieldDisplay.DATE_RANGE ||
-          field?.display === FieldDisplay.NUMBER_RANGE ||
-          field?.display === FieldDisplay.LESS_THAN_RANGE ||
-          field?.display === FieldDisplay.GREATER_THAN_RANGE ||
-          field?.display === FieldDisplay.GREATER_THAN_DROP_DOWN
-        ) {
-          return (
-            <div className='select-box--crumb-container' key={item.key + "crumb-container"}>
-              {this.renderRangeLabel()}
-              <FontAwesome
-                className="remove crumb-icon"
-                name="remove"
-                onClick={() => console.log("need a remove function")}
-              />
-              {/* <ValueCrumb label={item.key}  onClick={() => this.props.onCheckBoxToggle(item.key, this.state.selectedItems)} /> */}
-            </div>
-          )
-
-        } else if (field.display == FieldDisplay.LOCATION) {
-          return (
-            <div key="location-crumb" className='select-box--crumb-container' >
-              {this.renderLocationLabel()}
-              <FontAwesome
-                className="remove crumb-icon"
-                name="remove"
-                onClick={() => console.log("need a remove function")}
-              />
-              {/* <ValueCrumb label={item.key}  onClick={() => this.props.onCheckBoxToggle(item.key, this.state.selectedItems)} /> */}
-            </div>
-          )
-        } else if (field?.display === FieldDisplay.BAR_CHART || field?.display === FieldDisplay.PIE_CHART) {
-        }
-
-        //@ts-ignore
-        if (this.isSelected(item.key)) {
-          //@ts-ignore
-          return <div className='select-box--crumb-container' key={item.key + 'isSelected'}>
-            {item.key}          <FontAwesome
-              className="remove crumb-icon"
-              name="remove"
-              onClick={() => this.selectItem(item)}
-            />
-            {/* <ValueCrumb label={item.key}  onClick={() => this.props.onCheckBoxToggle(item.key, this.state.selectedItems)} /> */}
-          </div>
-        }
-        if (this.state.selectedItems.length > field.maxCrumbs) {
-          let chevronDirection = this.state.showAdditionalCrumbs ? 'left' : 'right';
-          if (this.state.showAdditionalCrumbs) {
-            let otherCrumbs: any[] = this.state.selectedItems.slice(field.maxCrumbs, this.state.selectedItems.length)
-            return otherCrumbs.map(item => {
-              return (<div className='select-box--crumb-container' key={item.key}>
-                {item.key}          <FontAwesome
-                  className={`remove crumb-icon`}
-                  name={`remove`}
-                  onClick={() => this.selectItem(item)}
-                />
-              </div>)
-            })
-          }
-          return (
-            <div className='select-box--crumb-container'>
-              {item.key}          <FontAwesome
-                className={`chevron-${chevronDirection} crumb-icon`}
-                name={`chevron-${chevronDirection}`}
-                onClick={() => this.setState({ showAdditionalCrumbs: !this.state.showAdditionalCrumbs })}
-              />
-            </div>
-          )
-        }
-      });
-    } else {
-      console.log(3)
-    }
-  };
-  renderSubLabel = () => {
-    return (
-      <div className={"select-box--sublabel"}>{this.props.field.aggSublabel}</div>)
-
-  }
   componentDidMount = () => {
     if (this.props.field.defaultToOpen === true) {
       this.setState({ showItems: true, showAdditionalCrumbs: true });
@@ -462,51 +341,34 @@ class CustomDropDown extends React.Component<CustomDropDownProps, CustomDropDown
       this.props.selectedKeys.forEach(o => (
         selectedKeysPlaceHolders.push({ key: o, docCount: null })
       ))
-      this.setState({ selectedItems: selectedKeysPlaceHolders })
+      this.setState({ selectedItems: selectedKeysPlaceHolders });
+    }
+    if(this.props.field.display == "GREATER_THAN_DROP_DOWN"){
+      this.setState({ selectedItems: [{start: this.props.updater.input?.gte, end : this.props.updater.input?.lte}] });
+    }
+    if(this.props.field.display == "LOCATION"){
+      this.setState({ selectedItems: [{zipcode: this.props.updater.input?.zipcode, radius : this.props.updater.input?.radius, lat : this.props.updater.input?.lat, long : this.props.updater.input?.long}] });
     }
   };
-  componentDidUpdate(prevProps){
-    if(this.props.selectedKeys !== prevProps.selectedKeys){
+  componentDidUpdate(prevProps,prevState){
+    if(this.props.selectedKeys !== prevProps.selectedKeys&& this.props.selectedKeys[0] ){
       let selectedKeysPlaceHolders: any[] = [];
       this.props.selectedKeys.forEach(o => (
         selectedKeysPlaceHolders.push({ key: o, docCount: null })
       ))
+
       this.setState({ selectedItems: selectedKeysPlaceHolders })
     }
-  }
-  renderPreValue = (item) => {
-    if (this.props.field.display == "CHECKBOX" ||this.props.field.display == "STRING" ) {
-      return this.isSelected(item) ? <FontAwesome name='far fa-check-square check' className={`square-checkmark${this.props.isPresearch ? "" : "-facet"}`}/> : <div className={`check-outer${this.props.isPresearch ? "" : "-facet"}`}></div>
+
+    if(this.props.field.display == "GREATER_THAN_DROP_DOWN"  && prevState.selectedItems == this.state.selectedItems){
+      this.setState({ selectedItems: [{start: this.props.updater.input?.gte, end : this.props.updater.input?.lte}] })
     }
-    return null
-  };
-  renderValue = (item,bucketKeyValuePair) =>{
-    let text = '';
-    const { docCount } = item;
-    const value = item.key;
-    const display = this.props.field.display
-    let intValue = Math.floor(Number(value))
-    switch (display) {
-      case FieldDisplay.STAR:
-        text = {
-          0: '☆☆☆☆☆',
-          1: '★☆☆☆☆',
-          2: '★★☆☆☆',
-          3: '★★★☆☆',
-          4: '★★★★☆',
-          5: '★★★★★',
-        }[intValue];
-        break;
-      case FieldDisplay.DATE:
-        text = new Date(parseInt(value.toString(), 10))
-          .getFullYear()
-          .toString();
-        break;
-      default:
-        text = bucketKeyValuePair ?  `${bucketKeyValuePair.key} - ${bucketKeyValuePair.label}` : value.toString();
+    if(this.props.field.display == "LOCATION"  && prevState.selectedItems == this.state.selectedItems){ 
+      this.setState({ selectedItems: [{zipcode: this.props.updater.input?.zipcode, radius : this.props.updater.input?.radius, lat : this.props.updater.input?.lat, long : this.props.updater.input?.long}] });
     }
-    return `${text} (${docCount})`;
   }
+
+
   handleRange = (rangeArray) => {
     this.setState({ selectedItems: rangeArray })
   }
@@ -537,175 +399,8 @@ class CustomDropDown extends React.Component<CustomDropDownProps, CustomDropDown
     return
   }
 
-  renderPanel = () => {
-    const { hasMore, buckets, handleLoadMore, field } = this.props
-    const { showItems, loading } = this.state
-    const showAllowMissing = field.showAllowMissing;
-    if (!this.props.isOpen) return
-    if (
-      field?.display === FieldDisplay.DATE_RANGE ||
-      field?.display === FieldDisplay.NUMBER_RANGE ||
-      field?.display === FieldDisplay.LESS_THAN_RANGE ||
-      field?.display === FieldDisplay.GREATER_THAN_RANGE
-    ) {
-
-      return (
-        <RangeSelector
-          isOpen={this.props.isOpen}
-          hasMore={hasMore}
-          loading={loading}
-          buckets={buckets}
-          handleLoadMore={this.props.handleLoadMore}
-          aggType={field?.display}
-          field={field}
-          handleRange={this.handleRange}
-        />
-      )
-    } else if (field?.display === FieldDisplay.PIE_CHART) {
-      return (
-        <TwoLevelPieChart
-          isPresearch={this.props.isPresearch}
-          buckets={buckets}
-          hasMore={hasMore}
-          handleLoadMore={this.props.handleLoadMore}
-          field={field}
-          onClickHandler={this.selectItem}
-        />
-      )
-    } else if (field?.display === FieldDisplay.BAR_CHART) {
-      return (
-        <BarChartComponent
-          isPresearch={this.props.isPresearch}
-          onClickHandler={this.selectItem}
-          // visibleOptions={visibleOptions}
-          buckets={buckets}
-          // isSelected={this.isSelected}
-          hasMore={hasMore}
-          handleLoadMore={this.props.handleLoadMore}
-          field={field}
-        />
-      )
-    }
-    else if (field.display == FieldDisplay.LOCATION) {
-      return (
-        <LocationAgg
-          agg={field.name}
-          removeFilters={this.props.onCheckBoxToggle}
-          buckets={buckets}
-          isSelected={this.isSelected}
-          hasMore={hasMore}
-          field={field}
-          handleLocation={this.handleLocation}
-        />
-      )
-    }
-    else if (field.display == "CRUMBS_ONLY") {
-      return null
-    }
-    else if (this.props.field.display == "CHECKBOX" || this.props.field.display == "STRING") {
-
-      return (
-      <>
-          {showAllowMissing && (
-            <div className="select-item allow-missing" onClick={() => this.props.updater.toggleAllowMissing()} >
-              <div className="item-content">
-                {this.props.updater.allowsMissing() ? <FontAwesome name='far fa-check-square check' className={`square-checkmark${this.props.isPresearch ? "" : "-facet"}`} /> : <div className={`check-outer${this.props.isPresearch ? "" : "-facet"}`}></div>}
-
-                <AllowMissingDropDownItem buckets={buckets} />
-              </div>
-            </div>
-          )}
-        <InfiniteScroll
-          pageStart={0}
-          loadMore={this.props.handleLoadMore}
-          hasMore={this.props.hasMore}
-          useWindow={false}
-          loader={
-            <div key={0} style={{ display: 'flex', justifyContent: 'center' }}>
-              <BeatLoader key="loader" color={this.props.isPresearch ? '#000' : '#fff'} />
-            </div>
-          }>
-          {this.props.buckets
-            .filter(
-              bucket =>
-                !bucketKeyIsMissing(bucket) &&
-                (this.props.field.visibleOptions.length
-                  ? this.props.field.visibleOptions.includes(bucket.key)
-                  : true)
-            )
-            .map((item) => (
-              <div
-                key={item.key + 'buckets'}
-                onClick={() => this.selectItem(item)}
-                className={
-                  this.state.selectedItem === item
-                    ? "selected select-item"
-                    : "select-item"
-                }
-              >
-                <div className="item-content">
-                  {this.renderPreValue(item.key)}
-                  <span>{item.key} ({item.docCount})</span>
-                </div>
-              </div>
-            ))}
-        </InfiniteScroll>
-      </>
-      )
-    }
-    else {
-
-      return (
-        <>
-          {showAllowMissing && !this.props.updater.allowsMissing() && (
-            <div className="select-item allow-missing" onClick={() => this.props.updater.toggleAllowMissing()}>
-              <AllowMissingDropDownItem buckets={buckets} className="item-content" />
-            </div>
-          )}
-        <InfiniteScroll
-          pageStart={0}
-          loadMore={this.props.handleLoadMore}
-          hasMore={this.props.hasMore}
-          useWindow={false}
-          loader={
-            <div key={0} style={{ display: 'flex', justifyContent: 'center' }}>
-              <BeatLoader key="loader" color={this.props.isPresearch ? '#000' : '#fff'} />
-            </div>
-          }>
-          {this.props.buckets
-            .filter(
-              bucket =>
-                !bucketKeyIsMissing(bucket) &&
-                (this.props.field.visibleOptions.length
-                  ? this.props.field.visibleOptions.includes(bucket.key)
-                  : true)
-            )
-            .map((item) => {
-              const bucketKeyValuePair = field.bucketKeyValuePairs ? find(propEq('key', item.key))(field.bucketKeyValuePairs) : false;
-              return (
-                this.isSelected(item.key) ? null :
-                  <div
-                    key={item.key + 'buckets'}
-                    onClick={() => this.selectItem(item)}
-                    className={
-                      this.state.selectedItem === item
-                        ? "selected select-item"
-                        : "select-item"
-                    }
-                  >
-                    <div className="item-content">
-                      {/* {this.renderPreValue(item.key)} */}
-                      <span>{this.renderValue(item, bucketKeyValuePair)}</span>
-                    </div>
-                  </div>
-              )
-            })}
-        </InfiniteScroll>
-        </>
-      )
-    }
-  }
-  isSelected = (key: string): boolean =>
+  
+    isSelected = (key: string): boolean =>
     this.props.selectedKeys && this.props.selectedKeys.has(key);
   render() {
     const ThemedContainer = this.props.isPresearch ? ThemedPresearchCard : ThemedFacetAgg
@@ -734,7 +429,11 @@ class CustomDropDown extends React.Component<CustomDropDownProps, CustomDropDown
             </ThemedTitle>
             {this.props.isPresearch ? (
               <div className='select-box--crumbs'>
-                {this.state.selectedItems.length > 0 ? this.renderSelectedItems() : this.renderSubLabel()}
+                 <CustomDropCrumbs 
+                 field = { this.props.field } 
+                 selectedItems = {this.state.selectedItems}
+                 isSelected={this.isSelected}
+                 selectItem={this.selectItem} />
                 {showAllowMissing && this.props.updater.allowsMissing() && (
                   <div className='select-box--crumb-container'>
                     {'Allow Missing'}
@@ -760,7 +459,22 @@ class CustomDropDown extends React.Component<CustomDropDownProps, CustomDropDown
 
             className={this.props.isPresearch ? "select-box--buckets-presearch" : "select-box--buckets-facet"}
           >
-            {this.renderPanel()}
+            <CustomDropPanel 
+            buckets={this.props.buckets} 
+            field={this.props.field}
+            handleLoadMore={this.props.handleLoadMore}
+            hasMore={this.props.hasMore}
+            isOpen={this.props.isOpen}
+            handleRange={this.handleRange}
+            loading={this.state.loading}
+            selectItem={this.selectItem}
+            isSelected={this.isSelected}
+            handleLocation={this.handleLocation}
+            onCheckBoxToggle={this.props.onCheckBoxToggle}
+            selectedItem={this.state.selectedItem}
+            isPresearch={this.props.isPresearch}
+
+            />
           </div>
         </ThemedContainer>
       </ThemedSelectBox>

--- a/front/src/containers/AggDropDown/CustomDrop.tsx
+++ b/front/src/containers/AggDropDown/CustomDrop.tsx
@@ -476,6 +476,33 @@ class CustomDropDown extends React.Component<CustomDropDownProps, CustomDropDown
     }
     return null
   };
+  renderValue = (item,bucketKeyValuePair) =>{
+    let text = '';
+    const { docCount } = item;
+    const value = item.key;
+    const display = this.props.field.display
+    let intValue = Math.floor(Number(value))
+    switch (display) {
+      case FieldDisplay.STAR:
+        text = {
+          0: '☆☆☆☆☆',
+          1: '★☆☆☆☆',
+          2: '★★☆☆☆',
+          3: '★★★☆☆',
+          4: '★★★★☆',
+          5: '★★★★★',
+        }[intValue];
+        break;
+      case FieldDisplay.DATE:
+        text = new Date(parseInt(value.toString(), 10))
+          .getFullYear()
+          .toString();
+        break;
+      default:
+        text = bucketKeyValuePair ?  `${bucketKeyValuePair.key} - ${bucketKeyValuePair.label}` : value.toString();
+    }
+    return `${text} (${docCount})`;
+  }
   handleRange = (rangeArray) => {
     this.setState({ selectedItems: rangeArray })
   }
@@ -646,7 +673,7 @@ class CustomDropDown extends React.Component<CustomDropDownProps, CustomDropDown
                   >
                     <div className="item-content">
                       {/* {this.renderPreValue(item.key)} */}
-                      <span>{bucketKeyValuePair ? `${bucketKeyValuePair.key} - ${bucketKeyValuePair.label}` : item.key} ({item.docCount})</span>
+                      <span>{this.renderValue(item, bucketKeyValuePair)}</span>
                     </div>
                   </div>
               )

--- a/front/src/containers/AggDropDown/CustomDropCrumbs.tsx
+++ b/front/src/containers/AggDropDown/CustomDropCrumbs.tsx
@@ -1,0 +1,158 @@
+import * as React from 'react';
+import { FieldDisplay } from 'types/globalTypes';
+import { SiteViewFragment_search_aggs_fields } from 'types/SiteViewFragment';
+import * as FontAwesome from 'react-fontawesome';
+import { AggBucket } from '../SearchPage/Types';
+import { withAggContext } from 'containers/SearchPage/components/AggFilterUpdateContext';
+import AggFilterInputUpdater from 'containers/SearchPage/components/AggFilterInputUpdater';
+
+interface CustomDropCrumbsProps {
+  field: SiteViewFragment_search_aggs_fields | any;
+  isSelected: any;
+  updater: AggFilterInputUpdater;
+  selectedItems: any[];
+  selectItem: any;
+
+}
+interface CustomDropCrumbsState {
+  showAdditionalCrumbs: boolean;
+}
+
+
+class CustomDropCrumbs extends React.Component<CustomDropCrumbsProps, CustomDropCrumbsState> {
+  state = {
+    showAdditionalCrumbs: false
+  };
+  rangeText = () => {
+    let range = this.props.selectedItems[0]
+    if (!this.props.selectedItems) return
+    console.log(1)
+    //@ts-ignore
+    if (!range.start) return `≤ ${range.end}`
+    console.log(2, range)
+    //@ts-ignore
+    if (!range.end) return `≥ ${range.start}`
+    console.log(3)
+    //@ts-ignore
+    return `${range.start} - ${range.end}`
+  }
+  renderLocationLabel = () => {
+    let location = this.props.selectedItems[0]
+    //@ts-ignore
+    if (!location.zipcode && !location.radius) return
+    //@ts-ignore
+    if (!location.zipcode) return `Within ${location.radius} of current location`
+    //@ts-ignore
+    if (!location.lat && !location.long) return `Within ${location.radius} of ${location.zipcode}`
+
+  }
+
+  render() {
+    const { field } = this.props
+
+    if (this.props.selectedItems.length > 0) {
+
+      let displayedCrumbs: any[] = this.props.selectedItems.slice(0, field.maxCrumbs)
+      let otherValues = { key: `... ${this.props.selectedItems.length - displayedCrumbs.length} others` }
+      displayedCrumbs.push(otherValues)
+      if (field.maxCrumbs == 0 || field.maxCrumbs == null || !field) return
+      //the fields in the if block below technically will only ever have one crumb 
+      //so we pop the last index which holds our "... and others" to prevent a duplicate crumb
+      if (
+        field?.display === FieldDisplay.DATE_RANGE ||
+        field?.display === FieldDisplay.NUMBER_RANGE ||
+        field?.display === FieldDisplay.LESS_THAN_RANGE ||
+        field?.display === FieldDisplay.GREATER_THAN_RANGE ||
+        field?.display === FieldDisplay.GREATER_THAN_DROP_DOWN ||
+        field?.display === FieldDisplay.LOCATION
+      ) {
+        displayedCrumbs.pop()
+      }
+
+      return displayedCrumbs.map((item: AggBucket, index) => {
+        if (
+          field?.display === FieldDisplay.DATE_RANGE ||
+          field?.display === FieldDisplay.NUMBER_RANGE ||
+          field?.display === FieldDisplay.LESS_THAN_RANGE ||
+          field?.display === FieldDisplay.GREATER_THAN_RANGE ||
+          field?.display === FieldDisplay.GREATER_THAN_DROP_DOWN
+        ) {
+          if (this.props.selectedItems[0].key) return
+          if (!this.props.selectedItems[0].start && !this.props.selectedItems[0].end && !this.props.selectedItems[0].key) return
+
+          return (
+            <div className='select-box--crumb-container' key={item.key + "crumb-container"}>
+              {this.rangeText()}
+              <FontAwesome
+                className="remove crumb-icon"
+                name="remove"
+                onClick={() => this.props.updater.removeRange()}
+              />
+            </div>
+          )
+
+        } else if (field.display == FieldDisplay.LOCATION) {
+          console.log("IN LOCATION", field.display)
+          if (!this.props.selectedItems[0].radius) return
+
+          return (
+            <div key={"location-crumb"} className='select-box--crumb-container' >
+              {this.renderLocationLabel()}
+              <FontAwesome
+                className="remove crumb-icon"
+                name="remove"
+                onClick={() => this.props.updater.removeDistance()}
+              />
+            </div>
+          )
+        } else if (field?.display === FieldDisplay.BAR_CHART || field?.display === FieldDisplay.PIE_CHART) {
+        }
+
+        if (this.props.isSelected(item.key)) {
+          console.log(item.key)
+          return <div className='select-box--crumb-container' key={item.key + 'isSelected'}>
+            {item.key}
+            <FontAwesome
+              className="remove crumb-icon"
+              name="remove"
+              onClick={() => this.props.selectItem(item)}
+            />
+          </div>
+        }
+        if (this.props.selectedItems.length > field.maxCrumbs) {
+          let chevronDirection = this.state.showAdditionalCrumbs ? 'left' : 'right';
+          if (this.state.showAdditionalCrumbs) {
+            let otherCrumbs: any[] = this.props.selectedItems.slice(field.maxCrumbs, this.props.selectedItems.length)
+            return otherCrumbs.map(item => {
+              return (
+                <div className='select-box--crumb-container' key={item.key}>
+                  {item.key}
+                  <FontAwesome
+                    className={`remove crumb-icon`}
+                    name={`remove`}
+                    onClick={() => this.props.selectItem(item)}
+                  />
+                </div>)
+            })
+          }
+          return (
+            <div className='select-box--crumb-container'>
+              {item.key}
+              <FontAwesome
+                className={`chevron-${chevronDirection} crumb-icon`}
+                name={`chevron-${chevronDirection}`}
+                onClick={() => this.setState({ showAdditionalCrumbs: !this.state.showAdditionalCrumbs })}
+              />
+            </div>
+          )
+        }
+      });
+    } else {
+      console.log("else", this.props.field.displayName)
+      return (<div className={"select-box--sublabel"}>{this.props.field.aggSublabel}</div>)
+    }
+  }
+};
+
+
+export default withAggContext(CustomDropCrumbs);

--- a/front/src/containers/AggDropDown/CustomDropCrumbs.tsx
+++ b/front/src/containers/AggDropDown/CustomDropCrumbs.tsx
@@ -123,7 +123,17 @@ class CustomDropCrumbs extends React.Component<CustomDropCrumbsProps, CustomDrop
           let chevronDirection = this.state.showAdditionalCrumbs ? 'left' : 'right';
           if (this.state.showAdditionalCrumbs) {
             let otherCrumbs: any[] = this.props.selectedItems.slice(field.maxCrumbs, this.props.selectedItems.length)
+            otherCrumbs.push({key:"<" })
             return otherCrumbs.map(item => {
+          if(item.key=="<"){              
+              return (
+                <div className='select-box--crumb-container' key={item.key}>
+                  <FontAwesome
+                className={`chevron-${chevronDirection} crumb-icon`}
+                name={`chevron-${chevronDirection}`}
+                onClick={() => this.setState({ showAdditionalCrumbs: !this.state.showAdditionalCrumbs })}
+                  />
+                </div>)}
               return (
                 <div className='select-box--crumb-container' key={item.key}>
                   {item.key}

--- a/front/src/containers/AggDropDown/CustomDropPanel.tsx
+++ b/front/src/containers/AggDropDown/CustomDropPanel.tsx
@@ -1,0 +1,250 @@
+import * as React from 'react';
+import { FieldDisplay } from 'types/globalTypes';
+import styled from 'styled-components';
+import { SiteViewFragment_search_aggs_fields } from 'types/SiteViewFragment';
+import * as FontAwesome from 'react-fontawesome';
+import { BeatLoader } from 'react-spinners';
+import * as InfiniteScroll from 'react-infinite-scroller';
+import {
+  AggBucket,
+} from '../SearchPage/Types';
+import {
+  propEq,
+  findIndex,
+  find
+} from 'ramda';
+import bucketKeyIsMissing from 'utils/aggs/bucketKeyIsMissing';
+import LocationAgg from './LocationAgg';
+import RangeSelector from './RangeSelector';
+import TwoLevelPieChart from './TwoLevelPieChart';
+import BarChartComponent from './BarChart'
+import { withAggContext } from 'containers/SearchPage/components/AggFilterUpdateContext';
+import AggFilterInputUpdater from 'containers/SearchPage/components/AggFilterInputUpdater';
+import AllowMissingDropDownItem from './AllowMissingDropDownItem';
+interface CustomDropPanelProps {
+  field: SiteViewFragment_search_aggs_fields | any;
+  buckets: AggBucket[],
+  isPresearch: boolean,
+  handleLoadMore: () => any;
+  hasMore: boolean;
+  handleRange: any;
+  handleLocation: any;
+  selectItem: any;
+  isSelected: any;
+  onCheckBoxToggle: (string, []) => void;
+  isOpen: boolean;
+  updater: AggFilterInputUpdater;
+  loading: boolean;
+  selectedItem: any,
+
+
+}
+interface CustomDropPanelState {
+
+}
+
+
+
+class CustomDropPanel extends React.Component<CustomDropPanelProps, CustomDropPanelState> {
+
+  renderPreValue = (item) => {
+    if (this.props.field.display == "CHECKBOX" || this.props.field.display == "STRING") {
+      return this.props.isSelected(item) ? <FontAwesome name='far fa-check-square check' className={`square-checkmark${this.props.isPresearch ? "" : "-facet"}`} /> : <div className={`check-outer${this.props.isPresearch ? "" : "-facet"}`}></div>
+    }
+    return null
+  };
+  renderValue = (item, bucketKeyValuePair) => {
+    let text = '';
+    const { docCount } = item;
+    const value = item.key;
+    const display = this.props.field.display
+    let intValue = Math.floor(Number(value))
+    switch (display) {
+      case FieldDisplay.STAR:
+        text = {
+          0: '☆☆☆☆☆',
+          1: '★☆☆☆☆',
+          2: '★★☆☆☆',
+          3: '★★★☆☆',
+          4: '★★★★☆',
+          5: '★★★★★',
+        }[intValue];
+        break;
+      case FieldDisplay.DATE:
+        text = new Date(parseInt(value.toString(), 10))
+          .getFullYear()
+          .toString();
+        break;
+      default:
+        text = bucketKeyValuePair ? `${bucketKeyValuePair.key} - ${bucketKeyValuePair.label}` : value.toString();
+    }
+    return `${text} (${docCount})`;
+  }
+  render() {
+    const { hasMore, buckets, handleLoadMore, field, loading } = this.props
+    const showAllowMissing = field.showAllowMissing;
+    // if (!this.props.isOpen) return
+
+    if (
+      field?.display === FieldDisplay.DATE_RANGE ||
+      field?.display === FieldDisplay.NUMBER_RANGE ||
+      field?.display === FieldDisplay.LESS_THAN_RANGE ||
+      field?.display === FieldDisplay.GREATER_THAN_RANGE
+    ) {
+      return (
+        <RangeSelector
+          isOpen={this.props.isOpen}
+          hasMore={hasMore}
+          loading={loading}
+          buckets={buckets}
+          handleLoadMore={handleLoadMore}
+          aggType={field?.display}
+          field={field}
+          handleRange={this.props.handleRange}
+        />
+      )
+    } else if (field?.display === FieldDisplay.PIE_CHART) {
+      return (
+        <TwoLevelPieChart
+          isPresearch={this.props.isPresearch}
+          buckets={buckets}
+          hasMore={hasMore}
+          handleLoadMore={this.props.handleLoadMore}
+          field={field}
+          onClickHandler={this.props.selectItem}
+        />
+      )
+    } else if (field?.display === FieldDisplay.BAR_CHART) {
+      return (
+        <BarChartComponent
+          isPresearch={this.props.isPresearch}
+          onClickHandler={this.props.selectItem}
+          // visibleOptions={visibleOptions}
+          buckets={buckets}
+          // isSelected={this.isSelected}
+          hasMore={hasMore}
+          handleLoadMore={this.props.handleLoadMore}
+          field={field}
+        />
+      )
+    }
+    else if (field.display == FieldDisplay.LOCATION) {
+      return (
+        <LocationAgg
+          agg={field.name}
+          removeFilters={this.props.onCheckBoxToggle}
+          buckets={buckets}
+          isSelected={this.props.isSelected}
+          hasMore={hasMore}
+          field={field}
+          handleLocation={this.props.handleLocation}
+        />
+      )
+    }
+    else if (field.display == "CRUMBS_ONLY") {
+      return null
+    }
+    else if (this.props.field.display == "CHECKBOX" || this.props.field.display == "STRING") {
+      return (
+        <>
+          {showAllowMissing && (
+            <div className="select-item allow-missing" onClick={() => this.props.updater.toggleAllowMissing()} >
+              <div className="item-content">
+                {this.props.updater.allowsMissing() ? <FontAwesome name='far fa-check-square check' className={`square-checkmark${this.props.isPresearch ? "" : "-facet"}`} /> : <div className={`check-outer${this.props.isPresearch ? "" : "-facet"}`}></div>}
+
+                <AllowMissingDropDownItem buckets={buckets} />
+              </div>
+            </div>
+          )}
+          <InfiniteScroll
+            pageStart={0}
+            loadMore={this.props.handleLoadMore}
+            hasMore={this.props.hasMore}
+            useWindow={false}
+            loader={
+              <div key={0} style={{ display: 'flex', justifyContent: 'center' }}>
+                <BeatLoader key="loader" color={this.props.isPresearch ? '#000' : '#fff'} />
+              </div>
+            }>
+            {this.props.buckets
+              .filter(
+                bucket =>
+                  !bucketKeyIsMissing(bucket) &&
+                  (this.props.field.visibleOptions.length
+                    ? this.props.field.visibleOptions.includes(bucket.key)
+                    : true)
+              )
+              .map((item) => (
+                <div
+                  key={item.key + 'buckets'}
+                  onClick={() => this.props.selectItem(item)}
+                  className={
+                    this.props.selectedItem === item
+                      ? "selected select-item"
+                      : "select-item"
+                  }
+                >
+                  <div className="item-content">
+                    {this.renderPreValue(item.key)}
+                    <span>{item.key} ({item.docCount})</span>
+                  </div>
+                </div>
+              ))}
+          </InfiniteScroll>
+        </>
+      )
+    }
+    else {
+      return (
+        <>
+          {showAllowMissing && !this.props.updater.allowsMissing() && (
+            <div className="select-item allow-missing" onClick={() => this.props.updater.toggleAllowMissing()}>
+              <AllowMissingDropDownItem buckets={buckets} className="item-content" />
+            </div>
+          )}
+          <InfiniteScroll
+            pageStart={0}
+            loadMore={this.props.handleLoadMore}
+            hasMore={this.props.hasMore}
+            useWindow={false}
+            loader={
+              <div key={0} style={{ display: 'flex', justifyContent: 'center' }}>
+                <BeatLoader key="loader" color={this.props.isPresearch ? '#000' : '#fff'} />
+              </div>
+            }>
+            {this.props.buckets && this.props.buckets
+              .filter(
+                bucket =>
+                  !bucketKeyIsMissing(bucket) &&
+                  (this.props.field.visibleOptions.length
+                    ? this.props.field.visibleOptions.includes(bucket.key)
+                    : true)
+              )
+              .map((item) => {
+                const bucketKeyValuePair = field.bucketKeyValuePairs ? find(propEq('key', item.key))(field.bucketKeyValuePairs) : false;
+                return (
+                  this.props.isSelected(item.key) ? null :
+                    <div
+                      key={item.key + 'buckets'}
+                      onClick={() => this.props.selectItem(item)}
+                      className={
+                        this.props.selectedItem === item
+                          ? "selected select-item"
+                          : "select-item"
+                      }
+                    >
+                      <div className="item-content">
+                        {/* {this.renderPreValue(item.key)} */}
+                        <span>{this.renderValue(item, bucketKeyValuePair)}</span>
+                      </div>
+                    </div>
+                )
+              })}
+          </InfiniteScroll>
+        </>
+      )
+    }
+  }
+}
+
+export default withAggContext(CustomDropPanel);

--- a/front/src/containers/SearchPage/components/Aggs.tsx
+++ b/front/src/containers/SearchPage/components/Aggs.tsx
@@ -320,7 +320,6 @@ const Aggs = (props: AggsProps) => {
     }
 
       if (presearch && preSearchAggs) {
-        console.log('presearch options', props.presearchButtonOptions)
         const aggHFields = getAggs(props.presentSiteView, true).filter(k => findFields(k, props.presentSiteView, presearch)?.layout == "horizontal" || findFields(k, props.presentSiteView, presearch)?.layout == null)
         const aggVFields = getAggs(props.presentSiteView, true).filter(k => findFields(k, props.presentSiteView, presearch)?.layout == "vertical")
         {aggPresearchVertical = aggVFields.map(k => { return (


### PR DESCRIPTION
Fix for a few bugs with new presearch

CW-261: Average Rating and remaining Drop Down Field Types
CW-302: Allow Missing not showing up as an option
CW-282: Presearch Crumbs not working for location and range filters
CW-259: Facet bar only opens 1 agg at a time

Last but not least. Prior to this breadcrumbs would auto show all if panel was open. That behavior is no more. 

![PRScreenSchot](https://user-images.githubusercontent.com/17464571/105543410-5f298e80-5cbf-11eb-8811-d350a43e6eae.png)
![Screenshot 2021-01-22 144352](https://user-images.githubusercontent.com/17464571/105544340-7d43be80-5cc0-11eb-8383-44db8805214a.png)
