### PR TITLE
removed prestart script and apollo codeen script and apollo config

### DIFF
--- a/front/apollo.config.js
+++ b/front/apollo.config.js
@@ -1,11 +1,11 @@
-module.exports = {
-  client: {
-    includes: ['src/**/*.tsx', 'src/**/*.ts'],
-    tagName: 'gql',
-    service: {
-      name: 'clinwiki',
-      url: 'http://localhost:3000/graphql',
-      skipSSLValidation: true,
-    },
-  },
-};
+// module.exports = {
+//   client: {
+//     includes: ['src/**/*.tsx', 'src/**/*.ts'],
+//     tagName: 'gql',
+//     service: {
+//       name: 'clinwiki',
+//       url: 'http://localhost:3000/graphql',
+//       skipSSLValidation: true,
+//     },
+//   },
+// };

--- a/front/package.json
+++ b/front/package.json
@@ -7,13 +7,11 @@
   },
   "license": "MIT",
   "scripts": {
-    "prestart": "yarn apollo:codegen",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "build:clean": "rimraf ./build/",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "apollo:codegen": "rm -rf src/types && apollo codegen:generate --config=apollo.config.js --target=typescript --outputFlat src/types",
     "prettier": "prettier --config .prettierrc --write \"**/*.ts?(x)\"",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public"

--- a/front/src/components/AuthHeader/AuthHeader.tsx
+++ b/front/src/components/AuthHeader/AuthHeader.tsx
@@ -107,7 +107,7 @@ const AuthHeader = (props) => {
                 target="_blank"
                 eventKey={2}
                 href="https://www.clinwiki.org/make-a-donation/">
-                Donate to ClinWikis
+                Donate to ClinWiki
                     </NavItem>
             }
             <NavItem eventKey={1} href="https://www.clinwiki.org/" target="_blank">

--- a/front/src/components/AuthHeader/AuthHeader.tsx
+++ b/front/src/components/AuthHeader/AuthHeader.tsx
@@ -107,7 +107,7 @@ const AuthHeader = (props) => {
                 target="_blank"
                 eventKey={2}
                 href="https://www.clinwiki.org/make-a-donation/">
-                Donate to ClinWiki
+                Donate to ClinWikis
                     </NavItem>
             }
             <NavItem eventKey={1} href="https://www.clinwiki.org/" target="_blank">


### PR DESCRIPTION
 file. Downside is that front-end now builds on 3000 which means we had to add 3000 to google cloud uri list which created some issues with other sites still using http that Google is now enforcing https on. So we are now forced to add https to experimental and admin in order to get working oauth back. Definitely not the end of the world, but fairly unfortunate. 