### PR TITLE
tooltip css

### DIFF
--- a/front/src/global-styles.ts
+++ b/front/src/global-styles.ts
@@ -329,6 +329,36 @@ div.DraftEditor-editorContainer{
  }
 }
 
+  ///TOOL TIPS
+
+  .tooltip {
+    position: relative;
+    display: inline-block;
+  }
+  
+  .tooltip .tooltiptext {
+    visibility: hidden;
+    width: 120px;
+    background: rgba(0,0,0,.7);
+    color: #fff;
+    text-align: center;
+    border-radius: 6px;
+    padding: 5px 0;
+  
+    /* Position the tooltip */
+    position: absolute;
+    z-index: 1;
+    opacity: 0;
+    transition: .5s;
+  }
+  
+  .tooltip:hover .tooltiptext {
+    visibility: visible;
+    opacity: 1;
+    top: -20px;
+  }
+
+//// GRID WORK
 
 .grid-container{
   // display: flex;


### PR DESCRIPTION
Can add in theme color assuming you plan on using same syntax as they did in the w3 article.  Just wanted to make sure this is what you were looking for. 

`
  ///TOOL TIPS

  .tooltip {
    position: relative;
    display: inline-block;
  }
  
  .tooltip .tooltiptext {
    visibility: hidden;
    width: 120px;
    background: rgba(0,0,0,.7);
    color: #fff;
    text-align: center;
    border-radius: 6px;
    padding: 5px 0;
  
    /* Position the tooltip */
    position: absolute;
    z-index: 1;
    opacity: 0;
    transition: .5s;
  }
  
  .tooltip:hover .tooltiptext {
    visibility: visible;
    opacity: 1;
    top: -20px;
  }`