### PR TITLE
Buckets filter

### DIFF
--- a/front/src/containers/AggDropDown/Filter.tsx
+++ b/front/src/containers/AggDropDown/Filter.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useState } from 'react';
 import { Checkbox, FormControl } from 'react-bootstrap';
 import { AggBucket } from '../SearchPage/Types';
 import SortKind from './SortKind';
@@ -34,22 +34,23 @@ interface FilterProps {
   showLabel: boolean;
 }
 
-class Filter extends React.Component<FilterProps> {
-  render() {
-    const {
-      filter,
-      desc,
-      sortKind,
-      selectAll,
-      checkSelect,
-      checkboxValue,
-      removeSelectAll,
-      showLabel,
-      setShowLabel,
-      handleFilterChange,
-      toggleAlphaSort,
-      toggleNumericSort,
-    } = this.props;
+function Filter (props: FilterProps) {
+  const {
+    desc,
+    sortKind,
+    selectAll,
+    checkSelect,
+    checkboxValue,
+    removeSelectAll,
+    showLabel,
+    setShowLabel,
+    handleFilterChange,
+    toggleAlphaSort,
+    toggleNumericSort,
+  } = props;
+
+  const [filter, setFilter] = useState('')
+
     return (
       <div
         style={{
@@ -92,12 +93,14 @@ class Filter extends React.Component<FilterProps> {
           type="text"
           placeholder="filter..."
           value={filter}
-          onChange={handleFilterChange}
+          onChange={(e)=> {
+            setFilter(e.target.value)
+            handleFilterChange(e.target.value)
+          }}
           style={{ flex: 4, marginTop: '4px' }}
         />
       </div>
     );
   }
-}
 
 export default Filter;

--- a/front/src/containers/Islands/IslandAggChild.tsx
+++ b/front/src/containers/Islands/IslandAggChild.tsx
@@ -4,7 +4,7 @@ import useUrlParams from 'utils/UrlParamsProvider';
 import SortKind from 'containers/AggDropDown/SortKind';
 import CustomDropDown from 'containers/AggDropDown/CustomDrop';
 import { useDispatch, useSelector } from 'react-redux';
-import { toggleAgg, updateSearchParamsAction } from 'services/search/actions'
+import { toggleAgg, updateSearchParamsAction, updateBucketsFilter } from 'services/search/actions'
 import { RootState } from 'reducers';
 import { fetchSearchPageAggBuckets, fetchSearchPageCrowdAggBuckets } from 'services/search/actions';
 import { SearchQuery, SearchParams } from '../SearchPage/shared';
@@ -91,7 +91,6 @@ function IslandAggChild(props: Props) {
   const [desc, setDesc] = useState(true);
   const [sortKind, setSortKind] = useState(SortKind.Alpha);
   const [buckets, setBuckets] = useState([]);
-  const [aggFilter, setFilter] = useState('');
   const [hasMore, setHasMore] = useState(true);
   const [isOpen, setIsOpen] = useState(false);
   const [showLabel, setShowLabel] = useState(false);
@@ -103,6 +102,7 @@ function IslandAggChild(props: Props) {
   const data = useSelector((state: RootState) => state.search.searchResults);
   // const aggsList = useSelector((state : RootState ) => state.search.aggs);
   const aggBuckets = useSelector((state: RootState) => state.search.aggBuckets);
+  const aggBucketsFilter = useSelector((state: RootState) => state.search.aggBucketFilter);
   const isFetchingAggBuckets = useSelector((state: RootState) => state.search.isFetchingAggBuckets);
   const crowdAggBuckets = useSelector((state: RootState) => state.search.crowdAggBuckets);
   const isFetchingCrowdAggBuckets = useSelector((state: RootState) => state.search.isFetchingCrowdAggBuckets);
@@ -331,7 +331,6 @@ function IslandAggChild(props: Props) {
   const handleLoadMore = () => {
     let aggSort = handleSort(desc, sortKind);
 
-
     const variables = {
       ...searchParams,
       url: paramsUrl.sv,
@@ -340,7 +339,7 @@ function IslandAggChild(props: Props) {
       agg: [currentAgg.name],
       pageSize: PAGE_SIZE,
       page: getFullPagesCount(buckets) + 1,
-      aggOptionsFilter: aggFilter,
+      aggOptionsFilter: props.aggId && aggBucketsFilter && aggBucketsFilter[props.aggId] && aggBucketsFilter[props.aggId],
       aggOptionsSort: aggSort,
       q: searchParams.q,
       bucketsWanted: [currentAgg.visibleOptions]
@@ -410,9 +409,8 @@ function IslandAggChild(props: Props) {
     setHasMore(true);
     handleLoadMore();
   }
-  const handleFilterChange = (e: React.FormEvent<HTMLInputElement>) => {
-    const value = e.currentTarget.value;
-    setFilter(value);
+  const handleFilterChange = (value: string) => {
+    aggId && dispatch(updateBucketsFilter(aggId, value));
     setBuckets([]);
     setHasMore(true);
   };
@@ -530,7 +528,7 @@ function IslandAggChild(props: Props) {
         agg: [currentAgg.name],
         pageSize: PAGE_SIZE,
         page: getFullPagesCount(buckets) + 1,
-        aggOptionsFilter: aggFilter,
+        aggOptionsFilter: props.aggId && aggBucketsFilter && aggBucketsFilter[props.aggId] && aggBucketsFilter[props.aggId],
         aggOptionsSort: aggSort,
         q: searchParams.q,
         bucketsWanted: [currentAgg.visibleOptions]

--- a/front/src/services/search/actions.ts
+++ b/front/src/services/search/actions.ts
@@ -384,3 +384,12 @@ export const toggleExpander = (
     id,
     collapsed,
 });
+export const updateBucketsFilter = (
+    id: string,
+    bucketsFilter: string,
+): types.SearchActionTypes => (
+    {
+    type: types.BUCKET_FILTER,
+    id,
+    bucketsFilter,
+});

--- a/front/src/services/search/reducer.ts
+++ b/front/src/services/search/reducer.ts
@@ -28,6 +28,7 @@ const initialState: types.SearchState = {
     searchExport: undefined,
     isExportingToCsv: false,
     expanders: undefined,
+    aggBucketFilter: undefined
 };
 
 const searchReducer = (
@@ -388,6 +389,13 @@ const searchReducer = (
                 ...state,
                 isExportingToCsv: false,
             };
+        case types.BUCKET_FILTER:
+            let obj = {};
+            obj[action.id] = action.bucketsFilter;
+            return{
+                ...state,
+                aggBucketFilter: obj
+            }
         case types.TOGGLE_AGG:
             let newIslandConfig =
                 state.islandConfig || ({} as IslandConfigQuery);
@@ -423,6 +431,7 @@ const searchReducer = (
                 };
             }
         default:
+            console.log("defaulting")
             return { ...state };
     }
 };

--- a/front/src/services/search/sagas.ts
+++ b/front/src/services/search/sagas.ts
@@ -433,7 +433,7 @@ function* bucketFilter(action) {
 
 
         // Better error handling could be done here 
-          let response =currentAgg.aggKind== "crowdAggs" ? yield getSearchPageOpenCrowdAggBuckets({searchParams: variables, crowdAggIdArray: [{id:action.id, name: currentAgg.name}]}): yield getSearchPageOpenAggBuckets({searchParams: variables})
+          let response =currentAgg.aggKind== "crowdAggs" ? yield getSearchPageOpenCrowdAggBuckets({searchParams: variables, crowdAggIdArray: [{id:action.id, name: currentAgg.name}]}): yield getSearchPageOpenAggBuckets({searchParams: variables, aggIdArray: [{id:action.id, name: currentAgg.name}]})
 
     } catch (err) {
         console.log(err);

--- a/front/src/services/search/types.ts
+++ b/front/src/services/search/types.ts
@@ -87,6 +87,8 @@ export const EXPORT_T0_CSV_SEND = 'EXPORT_TO_CSV_SEND';
 export const EXPORT_T0_CSV_SUCCESS = 'EXPORT_TO_CSV_SUCCESS';
 export const EXPORT_T0_CSV_ERROR = 'EXPORT_TO_CSV_ERROR';
 
+export const BUCKET_FILTER = 'BUCKET_FILTER';
+
 export const TOGGLE_AGG = 'TOGGLE_AGG';
 export const TOGGLE_EXPANDER = 'TOGGLE_EXPANDER';
 
@@ -116,6 +118,7 @@ export interface SearchState {
     searchExport: any;
     isExportingToCsv: boolean;
     expanders: any;
+    aggBucketFilter: any;
 }
 export interface SearchDataError {
     message: string;
@@ -376,6 +379,11 @@ export interface toggleExpander {
     id: any;
     collapsed: boolean;
 }
+export interface updateBucketsFilter {
+    type: typeof BUCKET_FILTER;
+    id: string;
+    bucketsFilter: string;
+}
 export type SearchActionTypes =
     | FetchSearchPageAggsSendAction
     | FetchSearchPageAggsSuccessAction
@@ -436,4 +444,5 @@ export type SearchActionTypes =
     | ExportToCsvSuccessAction
     | ExportToCsvErrorAction
     | toggleAgg
-    | toggleExpander;
+    | toggleExpander
+    | updateBucketsFilter;


### PR DESCRIPTION
Restores aggBuckets Filter functionality 

Required changes in the translator as well as in our front-end code. 

Local state was holding our filter values prior and was being very problematic. Moved it to redux to solve most of our issues. (Should note I think our other state values can also benefit from a similar refactor  i.e. sort )


*** Current Caveat is No Karnofsky Facet can be defaulted to Open 