### PR TITLE
add browse interv, cond, contact

### DIFF
--- a/api/src/pipeline/jobs/indexDoc.job.js
+++ b/api/src/pipeline/jobs/indexDoc.job.js
@@ -61,7 +61,15 @@ query MyQuery(
         crowd_key
         crowd_value
       }
-  
+      ctgov_prod_studies_browse_conditions {
+        mesh_term
+      }
+      ctgov_prod_studies_browse_interventions {
+        mesh_term
+      }
+      ctgov_prod_studies_central_contacts {
+        name
+      }
     }
   }
   

--- a/api/src/util/graphqlToIndexMapping.js
+++ b/api/src/util/graphqlToIndexMapping.js
@@ -111,7 +111,30 @@ export const graphqlToIndexMapping =  {
         "fieldNameIndex": "",
         "dataTypeToIndex": "Crowd"
     },
-
+    "ctgov_prod_studies_browse_conditions": {
+        "fieldNameIndex": "",
+        "dataTypeToIndex": "sub_query"
+    },
+    "ctgov_prod_studies_browse_conditions.mesh_term": {
+        "fieldNameIndex": "browse_conditions_mesh_term",
+        "dataTypeToIndex": "keyword"
+    },
+    "ctgov_prod_studies_browse_interventions": {
+        "fieldNameIndex": "",
+        "dataTypeToIndex": "sub_query"
+    },
+    "ctgov_prod_studies_browse_interventions.mesh_term": {
+        "fieldNameIndex": "browse_interventions_mesh_term",
+        "dataTypeToIndex": "keyword"
+    },
+    "ctgov_prod_studies_central_contacts": {
+        "fieldNameIndex": "",
+        "dataTypeToIndex": "sub_query"
+    },
+    "ctgov_prod_studies_central_contacts.name": {
+        "fieldNameIndex": "central_contacts_name",
+        "dataTypeToIndex": "keyword"
+    },
     //DIS
     "condition_id": {
         "fieldNameIndex": "condition_id",


### PR DESCRIPTION
added generic index for studies for browse_condtions, browse_interventions and central_contacts to the graphql query and mapping