### PR TITLE
reworked result sort to allow configuration through island_config table

### DIFF
--- a/front/src/containers/Islands/CommonIslands.tsx
+++ b/front/src/containers/Islands/CommonIslands.tsx
@@ -84,7 +84,7 @@ export const searchIslands: Record<string, IslandConstructor> = {
     <DownloadCSVIsland />
   ),
   resultsort: (attributes: Record<string, string>, context?: any) => (
-    <ResultSort sortables={attributes['sortBy']} />
+    <ResultSort islandId={attributes['id']} />
   ),
   randnumberloader: (attributes: Record<string, string>, context?: any) => (
     <RandNumberLoader />

--- a/front/src/containers/Islands/ResultSort.tsx
+++ b/front/src/containers/Islands/ResultSort.tsx
@@ -1,54 +1,26 @@
-import React, { useEffect, useRef } from 'react';
-import { useRouteMatch } from 'react-router-dom';
+import React, { useRef } from 'react';
 import useUrlParams from 'utils/UrlParamsProvider';
-import { useDispatch, useSelector } from 'react-redux';
-import { fetchSearchParams, updateSearchParamsAction } from 'services/search/actions'
+import {  updateSearchParamsAction } from 'services/search/actions'
+import { AggFilterInput } from 'types/globalTypes';
+import { BeatLoader } from 'react-spinners';
+import { MenuItem, DropdownButton } from 'react-bootstrap';
 import { RootState } from 'reducers';
 import { SearchQuery, SearchParams } from '../SearchPage/shared';
-import {  SortInput } from 'types/globalTypes';
-import aggToField from 'utils/aggs/aggToField';
-import { MenuItem, DropdownButton } from 'react-bootstrap';
+import { SortInput } from 'types/globalTypes';
+import { defaultPageSize } from '../SearchPage/Types';
+import { useDispatch, useSelector } from 'react-redux';
 import { useTheme } from 'containers/ThemeProvider/ThemeProvider';
-import { snakeCase } from 'utils/helpers';
 
-import {
-  AggBucket,
-  AggCallback,
-  AggregateAggCallback,
-  AggKind,
-  maskAgg,
-  defaultPageSize
-} from '../SearchPage/Types';
 
-import {  map, dissoc, over, lensProp } from 'ramda';
-import { BeatLoader } from 'react-spinners';
-import { AggFilterInput } from 'types/globalTypes';
-import {
-  SearchPageParamsQuery_searchParams,
-} from '../../services/search/model/SearchPageParamsQuery';
-import { SiteViewFragment } from 'services/site/model/SiteViewFragment';
-import { preselectedFilters } from 'utils/siteViewHelpers';
-import * as FontAwesome from 'react-fontawesome';
-
-const DEFAULT_PARAMS: SearchParams = {
-  q: { children: [], key: 'AND' },
-  aggFilters: [],
-  crowdAggFilters: [],
-  sorts: [],
-  page: 0,
-  pageSize: defaultPageSize,
-};
 interface Props {
-  sortables?: any;
+  islandId?: any;
 
 }
 
 function ResultSort(props: Props) {
   const theme = useTheme();
   const dispatch = useDispatch();
-  const params = useUrlParams();
-  const hash = params.hash
-  const PAGE_SIZE = 25;
+  const { islandId } = props
 
   const emptySet = new Set();
   const searchParamsCurrent = useRef({
@@ -60,137 +32,73 @@ function ResultSort(props: Props) {
     pageSize: defaultPageSize
 
   })
+  const islandConfig = useSelector((state: RootState) => state.search.islandConfig);
 
-  
+  let getCurrentIsland = () => {
+
+    let jsonConfig = islandConfig
+    return islandId && jsonConfig && jsonConfig[islandId]
+  }
 
 
-
+  const DEFAULT_CONFIG = {
+    "sortables":[
+       {
+          "fieldName":"nct_id",
+          "displayName":"NCT ID ▲",
+          "desc":false
+       },
+       {
+          "fieldName":"nct_id",
+          "displayName":"NCT ID ▼",
+          "desc":true
+       }
+    ]
+ }
   const data = useSelector((state: RootState) => state.search.searchResults);
   const searchParams = data?.data?.searchParams;
-  const match = useRouteMatch();
-  useEffect(() => {
-    match.path == "/search2/" && dispatch(fetchSearchParams(hash));
-  }, [dispatch]);
 
-
-  
-  const searchParamsFromQuery = (
-    params: SearchPageParamsQuery_searchParams | null | undefined,
-    view: SiteViewFragment
-  ): SearchParams => {
-    const defaultParams = {
-      ...DEFAULT_PARAMS,
-      ...preselectedFilters(view),
-    };
-    if (!params) return defaultParams;
-
-    const q = params.q
-      ? (JSON.parse(params.q) as SearchQuery)
-      : defaultParams.q;
-
-    const aggFilters = map(
-      dissoc('__typename'),
-      params.aggFilters || []
-    ) as AggFilterInput[];
-    const crowdAggFilters = map(
-      dissoc('__typename'),
-      params.crowdAggFilters || []
-    ) as AggFilterInput[];
-    const sorts = map(dissoc('__typename'), params.sorts || []) as SortInput[];
-    return {
-      aggFilters,
-      crowdAggFilters,
-      sorts,
-      q,
-      //page and pageSize no longer exists since it was removed from the shortlink hash
-      //defaulting to page 0 and defaultPageSize(100) to recieve the first 100 results for
-      page: 0,
-      pageSize: defaultPageSize,
-    };
-  };
 
   const dataParams = searchParams.searchParams
 
-  searchParamsCurrent.current= dataParams;
-  if(!data || !searchParams){
-    return <BeatLoader/>
+  searchParamsCurrent.current = dataParams;
+  if (!data || !searchParams) {
+    return <BeatLoader />
   }
-  const changeSorted = (sorts: [SortInput], params: SearchParams) => {
-    const idSortedLens = lensProp('id');
-    const snakeSorts = map(over(idSortedLens, snakeCase), sorts);
-    const afterParams = { ...params, sorts: snakeSorts, page: 0 }
-    return afterParams;
-  };
   const sortHelper = (sorts) => {
-    const newParams = () => changeSorted(sorts, searchParamsCurrent.current)
-    dispatch(updateSearchParamsAction(newParams()));
+    dispatch(updateSearchParamsAction({ ...searchParamsCurrent.current, sorts, page: 0 }));
   };
-  const sortField = () => {
-    if (searchParamsCurrent.current.sorts.length > 0) {
-      return aggToField(
-        searchParamsCurrent.current.sorts[0].id,
-        searchParamsCurrent.current.sorts[0].id
-      );
-    }
-    return ' ';
-  };
-  const reverseSort = () => {
-    let desc = searchParamsCurrent.current.sorts[0].desc;
-    let newSort: [SortInput] = [
-      { id: searchParamsCurrent.current.sorts[0].id, desc: !desc },
-    ];
-    const newParams = () => changeSorted(newSort, searchParamsCurrent.current)
-    dispatch(updateSearchParamsAction(newParams()));
-  };
-  const renderSortIcons = () => {
-    let isDesc = searchParamsCurrent.current.sorts[0].desc;
-    return (
-      <div
-        onClick={() => reverseSort()}
-        style={{ display: 'flex', cursor: 'pointer' }}>
-        {isDesc ? (
-          <FontAwesome
-            name={'sort-amount-desc'}
-            style={{ color: theme && theme.button, fontSize: '26px' }}
-          />
-        ) : (
-            <FontAwesome
-              name={'sort-amount-asc'}
-              style={{ color: theme && theme.button, fontSize: '26px' }}
-            />
-          )}
-      </div>
-    );
-  };
-
-  // hardcoding to nct_id for now. Use to live in SV level. Need to pass this in as argument possibly?
-  let sortables : string[]=  props.sortables ? props.sortables: ["nct_id", "status", "briefTitle", "start_date", "completion_date", "fm_PaCTD Rating", "fm_Trial Relevance Rating"]
+  let currentIsland = getCurrentIsland();
+  console.log(currentIsland)
+  
+  let itemsArray = currentIsland ? currentIsland?.sortables : DEFAULT_CONFIG.sortables
   return (
     <>
       <div style={{ display: 'flex', flexDirection: 'row', marginLeft: 'auto' }}>
         <div style={{ display: 'flex' }}>
           <DropdownButton
             bsStyle="default"
-            title={`Sort by: ${sortField()}`}
+            title={`Sort`}
             key="default"
             id="dropdown-basic-default"
             style={{
               width: '200px',
               background: theme && theme.button,
             }}>
-            {sortables.map((field, index) => {
-              let sorts = [{ id: field, desc: false }];
+            {itemsArray.map((field, index) => {
+              let sorts = [{ id: field.fieldName, desc: field.desc }];
               return (
                 <MenuItem
                   key={field + index}
                   name={field}
                   onClick={() => sortHelper(sorts)}>
-                  {aggToField(field, field)}
+
+                    {field.displayName}
+
                 </MenuItem>
               );
             })}
           </DropdownButton>
-          {sortField() !== ' ' ? renderSortIcons() : null}
         </div>
       </div>
     </>


### PR DESCRIPTION
Refactor of the result sort island to handle configuration through island. 

Each sort item is denoted by a object in a `sortables` array.

Object should contain the following fields :
 `fieldName` : string; field name as indexed
 `displayName` : string; what will be rendered on client 
`desc`: boolean; sort order des

### Sample Config 
```
{
   "sortables":[
      {
         "fieldName":"fm_Karnofsky Allowed Minimum",
         "displayName":"Karnofsky Allowed Min ▲",
         "desc":false
      },
      {
         "fieldName":"fm_Karnofsky Allowed Minimum",
         "displayName":"Karnofsky Allowed Min ▼",
         "desc":true
      },
      {
         "fieldName":"nct_id",
         "displayName":"NCT ID Asc.",
         "desc":false
      },
      {
         "fieldName":"nct_id",
         "displayName":"NCT ID Desc. ",
         "desc":true
      }
   ]
}


```
### Use
Much like our agg island it takes in the id of the island_config as a prop 
i.e. if we asume above config is linked to island_config id 840. 

We would insert into template  something like: 
```
<resultsort id='840'>
```

### Result 
![image (8)](https://user-images.githubusercontent.com/17464571/131170559-8ab685ab-2e1c-476f-aaf6-5b1876062fc4.png)
