### PR TITLE
Mmtest refatctor

### DIFF
--- a/front/src/components/MailMerge/MMTestComponentWrapper.tsx
+++ b/front/src/components/MailMerge/MMTestComponentWrapper.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect } from 'react';
+import {  useRouteMatch } from 'react-router-dom';
+import { BeatLoader } from 'react-spinners';
+import useUrlParams from 'utils/UrlParamsProvider';
+import { find, propEq } from 'ramda';
+import { fetchPageViewsHasura, fetchPageViewHasura } from 'services/study/actions';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from 'reducers';
+import MMTestComponent from './MMTestComponent';
+import { fetchSearchParams } from 'services/search/actions';
+interface Props {
+  url?: string;
+  arg?: string;
+}
+
+
+export default function GenericPageWrapper(props: Props) {
+  const match = useRouteMatch();
+  const defaultPage = () => {
+    if (props.url) {
+      return props.url
+    }
+    if (params.pv && pageViewsData) {
+      const defaultPageView = find(propEq('url', params.pv))(pageViewsData?.data?.page_views)
+      if (defaultPageView) {
+        return defaultPageView.url
+      }
+    }
+    if (pageViewsData) {
+      const defaultPageView = find(propEq('default', true))(pageViewsData?.data?.page_views)
+      return defaultPageView.url
+    }
+  }
+  // When we add more page types we need to refactor this a little bit and pull out the query/nctid
+  const dispatch = useDispatch();
+  const params = useUrlParams();
+  const site = useSelector((state: RootState) => state.site.hasuraPresentSiteProvider.sites[0]);
+  const pageViewsData = useSelector((state: RootState) => state.study.pageViewsHasura);
+  const pageViewData = useSelector((state: RootState) => state.study.pageViewHasura);
+  const currentPage = pageViewData ? pageViewData?.data?.page_views[0] : null;
+  const data = useSelector((state: RootState) => state.search.searchResults);
+
+console.log(params)
+
+  const url =
+    window.location.search;
+  const urlName = new URLSearchParams(url)
+    .getAll('sv')
+    .toString();
+  const urlFinal = urlName ? urlName : "default";
+
+  useEffect(() => {
+    dispatch(fetchPageViewsHasura(site?.id));
+  }, [dispatch, site.id]);
+
+  useEffect(() => {
+    dispatch(fetchPageViewHasura(site?.id, params.pv || defaultPage() || urlFinal));
+  }, [dispatch, params.pv]);
+  useEffect(() => {
+    dispatch(fetchSearchParams(params.hash));
+  }, [dispatch, params.hash]);
+
+  if (!currentPage) {
+    return <BeatLoader />
+  }
+  if (!data) {
+    return <BeatLoader />
+  }
+
+
+  return (
+    <MMTestComponent/>
+  );
+}

--- a/front/src/components/MailMerge/MMTestComponentWrapper.tsx
+++ b/front/src/components/MailMerge/MMTestComponentWrapper.tsx
@@ -8,6 +8,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from 'reducers';
 import MMTestComponent from './MMTestComponent';
 import { fetchSearchParams } from 'services/search/actions';
+import Unauthorized from 'components/ProtectedRoute/Unauthorized';
+import { isAdmin } from 'utils/auth';
 interface Props {
   url?: string;
   arg?: string;
@@ -39,7 +41,8 @@ export default function GenericPageWrapper(props: Props) {
   const pageViewData = useSelector((state: RootState) => state.study.pageViewHasura);
   const currentPage = pageViewData ? pageViewData?.data?.page_views[0] : null;
   const data = useSelector((state: RootState) => state.search.searchResults);
-
+  const user = useSelector((state: RootState) => state.user.current);
+  
 console.log(params)
 
   const url =
@@ -59,7 +62,10 @@ console.log(params)
   useEffect(() => {
     dispatch(fetchSearchParams(params.hash));
   }, [dispatch, params.hash]);
-
+  
+  if (!isAdmin(user)) {
+    return <Unauthorized />
+  }
   if (!currentPage) {
     return <BeatLoader />
   }

--- a/front/src/containers/App/App.tsx
+++ b/front/src/containers/App/App.tsx
@@ -23,7 +23,7 @@ import EditWorkflowsPage from 'containers/EditWorkflowsPage';
 import EditAggIslandsPage from 'containers/EditAggIslandsPage';
 import BulkEditPage from 'containers/BulkEditPage';
 import withTheme from 'containers/ThemeProvider';
-import MMTest from 'components/MailMerge/MMTestComponent'
+import MMTest from 'components/MailMerge/MMTestComponentWrapper'
 import HasuraMMTest from 'components/MailMerge/HasuraMMTestComponent'
 import GenericPageWrapper from 'containers/GenericPage/GenericPageWrapper';
 import HasuraGenericPage from 'containers/HasuraGenericPage/HasuraGenericPage.';
@@ -86,7 +86,8 @@ class App extends React.PureComponent<AppProps> {
                 <Route path="/sign_up" component={SignUpPage} />
                 <Route path="/not-configured" component={NotConfiguredPage} />
                 <Route path="/update_password" component={UpdatePassword} />
-                <Route path="/mmtest" component={MMTest} />
+                <Route exact path="/mmtest" component={MMTest} />
+                <Route exact path="/mmtest/:nctId" component={MMTest} />
                 <Route path="/hasurammtest" component={HasuraMMTest} />
                 <ProtectedRoute path="/reindex" component={Reindex} />
                 <Route component={NotFoundPage} />


### PR DESCRIPTION
Restores MMtest functionality. 

Refactored it to fit more of the new Generic Page Needs. 

No need to input NCT or hash anymore, or starter template. Have it reading from pv

Example: 
Lets say  I want to test new feature on presearch pv currently at http://experimental.clinwiki.org/search?hash=gELcp_Fb&pv=presearch 

Just change route from search  to mmtest and should pre-load the template. 
http://experimental.clinwiki.org/mmtest?hash=gELcp_Fb&pv=presearch 

works with studies as well 

http://experimental.clinwiki.org/study/NCT03196414?hash=gELcp_Fb&pv=study 

http://experimental.clinwiki.org/mmtest/NCT03196414?hash=gELcp_Fb&pv=study

![image](https://user-images.githubusercontent.com/17464571/133462666-14fbb685-ceb7-491f-8b20-102ca44328f5.png)

![image](https://user-images.githubusercontent.com/17464571/133462717-6e2fea6b-ee23-47b1-aec5-201f75957692.png)


This final screenshot shows the different parts of the page that are collapsible

![image](https://user-images.githubusercontent.com/17464571/133462200-bbaba284-4fd7-4f8e-880f-2f40a0c1ba71.png)
