### PR TITLE
fix context limited in studyinfinitescroll island

### DIFF
--- a/front/src/containers/Islands/StudyInfiniteScroll.tsx
+++ b/front/src/containers/Islands/StudyInfiniteScroll.tsx
@@ -64,12 +64,10 @@ export default function StudyInfiniteScroll() {
     }
   }
 
-  const renderStudyTemplate = (nctId, overallStatus, briefTitle, studyType, phase, enrollmentType, enrollment, startDate, completionDate, lastUpdatePostedDate) => {
-    let studyContext = {
-      nctId, overallStatus, briefTitle, studyType, phase, enrollmentType, enrollment, startDate, completionDate, lastUpdatePostedDate
-    }
+  const renderStudyTemplate = (study) => {
+
     const compiled = compileTemplate(cardsTemplate)
-    const raw = applyTemplate(compiled, studyContext)
+    const raw = applyTemplate(compiled, study)
     const parser = new HtmlToReact.Parser();
     const reactElementHelperText = parser.parse(raw)
     return reactElementHelperText
@@ -140,7 +138,7 @@ export default function StudyInfiniteScroll() {
       >
         <div>{studyData.map((study, index) => {
           return (<div key={index}>
-            {renderStudyTemplate(study.nctId, study.overallStatus, study.briefTitle, study.studyType, study.phase, study.enrollmentType, study.enrollment, study.startDate, study.completionDate, study.lastUpdatePostedDate)
+            {renderStudyTemplate(study)
             }
           </div>
           )


### PR DESCRIPTION
Only select fields where being passed down through context into mm studyinfiniteascroll component. 

As a fix, passed in whole study object. This will need some refactoring in the future to generalize this island and make it accessible to all page types 
