### PR TITLE
add values to index and gql

### DIFF
--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -809,6 +809,7 @@ type ElasticStudy implements Timestamps {
   baselinePopulation: String
   briefSummary: String
   briefTitle: String!
+  ctgovProdStudiesInterventionsName: [String]
   completionDate: DateTime
   conditions: String
   createdAt: DateTime!
@@ -823,6 +824,7 @@ type ElasticStudy implements Timestamps {
   expandedAccessTypeTreatment: String
   facilityStates: [String!]!
   hasExpandedAccess: String
+  indexedAt: DateTime!
   interventions: [String!]!
   interventionsMeshTerms: [String!]!
   ipdAccessCriteria: String

--- a/api/src/pipeline/jobs/indexDoc.job.js
+++ b/api/src/pipeline/jobs/indexDoc.job.js
@@ -172,6 +172,9 @@ query MyQuery(
         organization
         responsible_party_type
       }
+      ctgov_prod_studies_interventions {
+        name
+      }
     }
   }
   


### PR DESCRIPTION
Our Index Jobs run off the SAMPLE_QUERY_CLINWIKI. 

- To make sure the fields make it to our index we simply make sure they are in said query (indexed_at gets added by the backend once the index job is processing, hence why it isn't in the query)

- To add them/access them in our pv/results we have to make sure it is in our  schema.graphql file in our ElasticStudyObject. For whatever reason (ruby => node) it has to be camelCased. Some place in our code it converts it back to snake_case, looked for it briefly but was not obvious at first glance so keep an eye out for the PR to remove that in future. 

Sample use in template and how it renders :
![image](https://user-images.githubusercontent.com/17464571/148981091-fbe3ff57-4415-4355-817c-c386a136fb99.png)

